### PR TITLE
chore: release tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,24 @@
   "main": "build/index.js",
   "scripts": {
     "lint": "eslint --ext .ts .",
-    "lint:fix": "eslint --fix --ext .ts ."
+    "lint:fix": "eslint --fix --ext .ts .",
+    "release": "read -p 'GITHUB_TOKEN: ' GITHUB_TOKEN && export GITHUB_TOKEN=$GITHUB_TOKEN && release-it --disable-metrics"
+  },
+  "release-it": {
+    "github": {
+      "release": true
+    },
+    "git": {
+      "tagName": "v${version}"
+    },
+    "hooks": {
+      "before:init": [
+        "npm run lint"
+      ]
+    },
+    "npm": {
+      "publish": true
+    }
   },
   "author": "",
   "license": "ISC",
@@ -24,6 +41,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
+    "release-it": "^14.2.2",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zjs",
   "version": "1.0.0",
-  "description": "",
+  "description": "Full access to Zwave-JS APIs using a websocket server",
   "main": "build/index.js",
   "scripts": {
     "lint": "eslint --ext .ts .",


### PR DESCRIPTION
With this setup you just have to run `npm run release` and follow the steps on CLI to make a new release. It automatically bump the version in package.json, tags the commit, create a github release and a new npm release. 