### PR TITLE
chore: separate instance handlers

### DIFF
--- a/lib/error.ts
+++ b/lib/error.ts
@@ -1,0 +1,33 @@
+export enum ErrorCode {
+  unknownError = "unknown_error",
+  unknownCommand = "unknown_command",
+  nodeNotFound = "node_not_found",
+}
+
+export class BaseError {
+  errorCode: ErrorCode;
+}
+
+export class UnknownError extends BaseError {
+  errorCode = ErrorCode.unknownError;
+
+  constructor(public error: Error) {
+    super();
+  }
+}
+
+export class UnknownCommandError extends BaseError {
+  errorCode = ErrorCode.unknownCommand;
+
+  constructor(public command: string) {
+    super();
+  }
+}
+
+export class NodeNotFoundError extends BaseError {
+  errorCode = ErrorCode.nodeNotFound;
+
+  constructor(public nodeId: number) {
+    super();
+  }
+}

--- a/lib/incoming_message.ts
+++ b/lib/incoming_message.ts
@@ -1,18 +1,11 @@
-import { ValueID } from "zwave-js";
+import { IncomingCommandBase } from "./incoming_message_base";
+import { IncomingMessageNode } from "./node/incoming_message";
 
-interface IncomingCommandStartListening {
+interface IncomingCommandStartListening extends IncomingCommandBase {
   messageId: string;
   command: "start_listening";
 }
 
-interface IncomingCommandNodeSetValue {
-  messageId: string;
-  command: "node.set_value";
-  nodeId: number;
-  valueId: ValueID;
-  value: unknown;
-}
-
 export type IncomingMessage =
   | IncomingCommandStartListening
-  | IncomingCommandNodeSetValue;
+  | IncomingMessageNode;

--- a/lib/incoming_message_base.ts
+++ b/lib/incoming_message_base.ts
@@ -1,0 +1,4 @@
+export interface IncomingCommandBase {
+  messageId: string;
+  command: string;
+}

--- a/lib/instance.ts
+++ b/lib/instance.ts
@@ -1,0 +1,5 @@
+export enum Instance {
+  controller = "controller",
+  driver = "driver",
+  node = "node",
+}

--- a/lib/node/command.ts
+++ b/lib/node/command.ts
@@ -1,0 +1,3 @@
+export enum NodeCommand {
+  setValue = "node.set_value",
+}

--- a/lib/node/incoming_message.ts
+++ b/lib/node/incoming_message.ts
@@ -1,0 +1,15 @@
+import { ValueID } from "zwave-js";
+import { IncomingCommandBase } from "../incoming_message_base";
+import { NodeCommand } from "./command";
+
+export interface IncomingCommandNodeBase extends IncomingCommandBase {
+  nodeId: number;
+}
+
+export interface IncomingCommandNodeSetValue extends IncomingCommandNodeBase {
+  command: NodeCommand.setValue;
+  valueId: ValueID;
+  value: unknown;
+}
+
+export type IncomingMessageNode = IncomingCommandNodeSetValue;

--- a/lib/node/message_handler.ts
+++ b/lib/node/message_handler.ts
@@ -1,0 +1,28 @@
+import { Driver } from "zwave-js";
+import { NodeNotFoundError, UnknownCommandError } from "../error";
+import { NodeCommand } from "./command";
+import { IncomingMessageNode } from "./incoming_message";
+import { NodeResultTypes } from "./outgoing_message";
+
+export class NodeMessageHandler {
+  static async handle(
+    message: IncomingMessageNode,
+    driver: Driver
+  ): Promise<NodeResultTypes[NodeCommand]> {
+    const { nodeId } = message;
+
+    const node = driver.controller.nodes.get(nodeId);
+    if (!node) {
+      throw new NodeNotFoundError(nodeId);
+    }
+
+    switch (message.command) {
+      case NodeCommand.setValue:
+        const { value, valueId } = message;
+        const success = await node.setValue(valueId, value);
+        return { success };
+      default:
+        throw new UnknownCommandError(message.command);
+    }
+  }
+}

--- a/lib/node/outgoing_message.ts
+++ b/lib/node/outgoing_message.ts
@@ -1,0 +1,5 @@
+import { NodeCommand } from "./command";
+
+export interface NodeResultTypes {
+  [NodeCommand.setValue]: { success: boolean };
+}

--- a/lib/outgoing_message.ts
+++ b/lib/outgoing_message.ts
@@ -1,4 +1,5 @@
 import type { ZwaveState } from "./state";
+import { NodeResultTypes } from "./node/outgoing_message";
 
 export interface OutgoingEvent {
   source: "driver" | "controller" | "node";
@@ -25,10 +26,9 @@ interface OutgoingResultMessageError {
   errorCode: string;
 }
 
-interface ResultTypes {
+type ResultTypes = {
   start_listening: { state: ZwaveState };
-  "node.set_value": { success: boolean };
-}
+} & NodeResultTypes;
 
 export interface OutgoingResultMessageSuccess {
   type: "result";


### PR DESCRIPTION
This separates the handing of messages based on instance type to avoid growing `server.ts` code.
I was not sure about the naming/files structure and will be happy to improve it depending on needs.

Hope this idea will be helpful ;)