### PR TITLE
Include correct lib version

### DIFF
--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -1,6 +1,7 @@
 import ws from "ws";
 import type WebSocket from "ws";
 import type { Driver } from "zwave-js";
+import { libVersion } from "zwave-js";
 import { EventForwarder } from "./forward";
 import type * as OutgoingMessages from "./outgoing_message";
 import { IncomingMessage } from "./incoming_message";
@@ -90,7 +91,7 @@ class Client {
   sendVersion() {
     this.sendData({
       type: "version",
-      driverVersion: "TBD",
+      driverVersion: libVersion,
       serverVersion: version,
       homeId: this.driver.controller.homeId,
     });

--- a/src/test/integration.ts
+++ b/src/test/integration.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import ws from "ws";
+import { libVersion } from "zwave-js";
 import { ZwavejsServer } from "../lib/server";
 import { createMockDriver } from "../mock";
 
@@ -41,7 +42,7 @@ const runTest = async () => {
     await new Promise((resolve) => socket.once("open", resolve));
 
     assert.deepEqual(await nextMessage(), {
-      driverVersion: "TBD",
+      driverVersion: libVersion,
       homeId: 1,
       serverVersion: "1.0.0",
       type: "version",


### PR DESCRIPTION
Now that we're at v6 beta 0 of ZJS, we can export the version of the driver.