### PR TITLE
Bump zwave-js to 6.0 RC

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "minimist": "^1.2.5",
     "ws": "^7.4.2",
-    "zwave-js": "^6.0.0-beta.1"
+    "zwave-js": "^6.0.0-beta.2-pr-1398-514d350"
   },
   "devDependencies": {
     "@types/node": "^14.14.20",


### PR DESCRIPTION
Upstream has a release candidate that's ready for further testing