### PR TITLE
fix: update package-lock to match alpha.1 bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Related to https://github.com/zwave-js/zwave-js-server/commit/f7221e21ad495ad86556bbae3ae38a16719f60d7