### PR TITLE
Add a prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:fix": "eslint --fix --ext .ts . && prettier -w .",
     "test": "prettier --check src && tsc --noEmit && npm run lint && ts-node src/test/integration.ts",
     "build": "tsc -p .",
+    "prepare": "npm run build",
     "prepublishOnly": "rm -rf dist && npm run build"
   },
   "author": "",


### PR DESCRIPTION
This allows zwave-js-server to be installed from a github repository, making it easy to try specific versions without having a source repo on hand, e.g.:
```
npm install zwave-js/zwave-js-server#commit
```

The prepare step is necessary to install the dependencies to compile typescript to js. See [life cycle scripts](https://docs.npmjs.com/cli/v6/using-npm/scripts#life-cycle-scripts).