### PR TITLE
Include metadata and ccVersion in added and notification events

### DIFF
--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -136,7 +136,8 @@ export class EventForwarder {
       for (const event of events) {
         node.on(event, (changedNode: ZWaveNode, args: any) => {
           // include metadata in the response
-          args.metadata = node.getValueMetadata(args);
+          const metadata = node.getValueMetadata(args);
+          args.metadata = metadata;
           notifyNode(changedNode, event, { args });
         });
       }

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -135,9 +135,12 @@ export class EventForwarder {
       const events: ZWaveNodeEvents[] = ["value added", "value notification"];
       for (const event of events) {
         node.on(event, (changedNode: ZWaveNode, args: any) => {
-          // include metadata in the response
+          // include metadata and ccVersion in the response
           const metadata = node.getValueMetadata(args);
           args.metadata = metadata;
+          args.ccVersion =
+            node.getEndpoint(args.endpoint).getCCVersion(args.commandClass) ||
+            node.getEndpoint(0).getCCVersion(args.commandClass);
           notifyNode(changedNode, event, { args });
         });
       }

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -120,16 +120,25 @@ export class EventForwarder {
 
     {
       const events: ZWaveNodeEvents[] = [
-        "value added",
         "value updated",
         "value removed",
-        "value notification",
         "interview failed",
       ];
       for (const event of events) {
         node.on(event, (changedNode: ZWaveNode, args: any) =>
           notifyNode(changedNode, event, { args })
         );
+      }
+    }
+
+    {
+      const events: ZWaveNodeEvents[] = ["value added", "value notification"];
+      for (const event of events) {
+        node.on(event, (changedNode: ZWaveNode, args: any) => {
+          // include metadata in the response
+          args.metadata = node.getValueMetadata(args);
+          notifyNode(changedNode, event, { args });
+        });
       }
     }
 

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -18,6 +18,7 @@ interface EndpointState extends Partial<Endpoint> {}
 interface ValueState extends Partial<TranslatedValueID> {
   metadata: ValueMetadata;
   value: any;
+  ccVersion: number;
 }
 
 interface NodeState extends Partial<ZWaveNode> {
@@ -31,6 +32,10 @@ function getNodeValues(node: ZWaveNode): ValueState[] {
     const valueState = valueId as ValueState;
     valueState.metadata = node.getValueMetadata(valueId);
     valueState.value = node.getValue(valueId);
+    // get CC Version for this endpoint, fallback to CC version of the node itself
+    valueState.ccVersion =
+      node.getEndpoint(valueId.endpoint).getCCVersion(valueId.commandClass) ||
+      node.getEndpoint(0).getCCVersion(valueId.commandClass);
     result.push(valueState);
   }
   return result;


### PR DESCRIPTION
Discussed here:
https://github.com/home-assistant-libs/zwave-js-server-python/issues/50

Value's metadata is only sent in the full state (at initial connection) but never when new values are added (e.g. a node completes interview after the server init or a new node was added). That is problematic as we need the metadata in the python library (and HA integration).

We can alter the python lib to ask for the metadata through the getValueMetaData command call but this feels better so it is more in line with the initial state object and second reason is that we have to refactor the python lib as commands are async (and the event handlers are not now).

The state (and value added event) now also includes the ccVersion as this is important metadata to know, for example to solve the targetValue issue in HA light platform.
