### PR TITLE
Remove allNodesReady

### DIFF
--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -21,13 +21,6 @@ export class EventForwarder {
   ) {}
 
   start() {
-    this.driver.once("all nodes ready", () =>
-      this.forwardEvent({
-        source: "driver",
-        event: "all nodes ready",
-      })
-    );
-
     this.driver.controller.nodes.forEach((node) => this.setupNode(node));
 
     // Bind to all controller events

--- a/src/lib/outgoing_message.ts
+++ b/src/lib/outgoing_message.ts
@@ -3,7 +3,7 @@ import { NodeResultTypes } from "./node/outgoing_message";
 import { ControllerResultTypes } from "./controller/outgoing_message";
 
 export interface OutgoingEvent {
-  source: "driver" | "controller" | "node";
+  source: "controller" | "node";
   event: string;
   [key: string]: unknown;
 }

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -8,7 +8,6 @@ import {
 } from "zwave-js";
 
 export interface ZwaveState {
-  driver: Partial<Driver>;
   controller: Partial<ZWaveController>;
   nodes: Partial<ZWaveNode>[];
 }
@@ -89,9 +88,6 @@ export const dumpEndpoint = (endpoint: Endpoint): EndpointState => ({
 export const dumpState = (driver: Driver): ZwaveState => {
   const controller = driver.controller;
   return {
-    driver: {
-      allNodesReady: driver.allNodesReady,
-    },
     controller: {
       libraryVersion: controller.libraryVersion,
       type: controller.type,

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -8,7 +8,6 @@ class MockController extends EventEmitter {
 
 class MockDriver extends EventEmitter {
   public controller = new MockController();
-  public allNodesReady = true;
 
   async start() {
     this.emit("driver ready");

--- a/src/test/integration.ts
+++ b/src/test/integration.ts
@@ -61,9 +61,6 @@ const runTest = async () => {
       messageId: "my-msg-id!",
       result: {
         state: {
-          driver: {
-            allNodesReady: true,
-          },
           controller: { homeId: 1 },
           nodes: [],
         },


### PR DESCRIPTION
Remove the "all nodes ready" boolean and event forwarding.

This property is not useful because it will never be `true` if there are dead nodes in the network. Clients shouldn't rely on this. It can also be derived by iterating the available nodes and so violates single source of truth.

CC @marcelveldt