### PR TITLE
Only dump full node values if the node is ready

### DIFF
--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -108,15 +108,11 @@ export class EventForwarder {
         ...extra,
       });
 
-    {
-      const events: ZWaveNodeEvents[] = ["interview completed", "ready"];
-      for (const event of events) {
-        node.on(event, (changedNode: ZWaveNode) => {
-          const nodeState = dumpNode(changedNode);
-          notifyNode(changedNode, event, { nodeState });
-        });
-      }
-    }
+    node.on("ready", (changedNode: ZWaveNode) => {
+      // Dump full node state on ready event
+      const nodeState = dumpNode(changedNode);
+      notifyNode(changedNode, "notification", { nodeState });
+    });
 
     {
       const events: ZWaveNodeEvents[] = ["wake up", "sleep", "dead", "alive"];
@@ -128,7 +124,10 @@ export class EventForwarder {
     }
 
     {
-      const events: ZWaveNodeEvents[] = ["value removed", "interview failed"];
+      const events: ZWaveNodeEvents[] = [
+        "interview completed",
+        "interview failed",
+      ];
       for (const event of events) {
         node.on(event, (changedNode: ZWaveNode, args: any) => {
           notifyNode(changedNode, event, { args });
@@ -141,6 +140,7 @@ export class EventForwarder {
         "value updated",
         "value added",
         "value notification",
+        "value removed",
       ];
       for (const event of events) {
         node.on(event, (changedNode: ZWaveNode, args: any) => {

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -103,7 +103,7 @@ export class EventForwarder {
     node.on("ready", (changedNode: ZWaveNode) => {
       // Dump full node state on ready event
       const nodeState = dumpNode(changedNode);
-      notifyNode(changedNode, "notification", { nodeState });
+      notifyNode(changedNode, "ready", { nodeState });
     });
 
     {

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -147,7 +147,7 @@ export class EventForwarder {
           // only forward value events for ready nodes
           if (!changedNode.ready) return;
           const valueState = dumpValue(changedNode, args);
-          notifyNode(changedNode, event, { valueState });
+          notifyNode(changedNode, event, { args: valueState });
         });
       }
     }

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -4,17 +4,9 @@ import {
   NodeStatus,
   ZWaveNode,
   ZWaveNodeEvents,
-  ZWaveNodeValueNotificationArgs,
-  ValueMetadata,
 } from "zwave-js";
 import { OutgoingEvent } from "./outgoing_message";
 import { dumpNode, dumpValue } from "./state";
-
-interface ValueNotificationState
-  extends Partial<ZWaveNodeValueNotificationArgs> {
-  metadata: ValueMetadata;
-  ccVersion: number;
-}
 
 export class EventForwarder {
   /**

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -137,23 +137,20 @@ export class EventForwarder {
     }
 
     {
-      const events: ZWaveNodeEvents[] = ["value updated", "value added"];
+      const events: ZWaveNodeEvents[] = [
+        "value updated",
+        "value added",
+        "value notification",
+      ];
       for (const event of events) {
         node.on(event, (changedNode: ZWaveNode, args: any) => {
           // only forward value events for ready nodes
           if (!changedNode.ready) return;
-          notifyNode(changedNode, event, { args });
+          const valueState = dumpValue(changedNode, args);
+          notifyNode(changedNode, event, { valueState });
         });
       }
     }
-
-    node.on(
-      "value notification",
-      (changedNode: ZWaveNode, args: ZWaveNodeValueNotificationArgs) => {
-        const valueState = dumpValue(changedNode, args);
-        notifyNode(changedNode, "value notification", { valueState });
-      }
-    );
 
     node.on("notification", (changedNode, notificationLabel, parameters) =>
       notifyNode(changedNode, "notification", { notificationLabel, parameters })

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -27,19 +27,29 @@ interface NodeState extends Partial<ZWaveNode> {
 }
 
 function getNodeValues(node: ZWaveNode): ValueState[] {
-  const result = [];
-  for (const valueId of node.getDefinedValueIDs()) {
-    const valueState = valueId as ValueState;
-    valueState.metadata = node.getValueMetadata(valueId);
-    valueState.value = node.getValue(valueId);
-    // get CC Version for this endpoint, fallback to CC version of the node itself
-    valueState.ccVersion =
-      node.getEndpoint(valueId.endpoint).getCCVersion(valueId.commandClass) ||
-      node.getEndpoint(0).getCCVersion(valueId.commandClass);
-    result.push(valueState);
+  if (!node.ready) {
+    // guard: do not request all values (and their metadata) while the node is still being interviewed.
+    // once the node hits ready state, all values will be sent in the 'node ready' event.
+    return [];
   }
-  return result;
+  return Array.from(node.getDefinedValueIDs(), (valueId) =>
+    dumpValue(node, valueId)
+  );
 }
+
+export const dumpValue = (
+  node: ZWaveNode,
+  valueId: TranslatedValueID
+): ValueState => {
+  const valueState = valueId as ValueState;
+  valueState.metadata = node.getValueMetadata(valueId);
+  valueState.value = node.getValue(valueId);
+  // get CC Version for this endpoint, fallback to CC version of the node itself
+  valueState.ccVersion =
+    node.getEndpoint(valueId.endpoint)?.getCCVersion(valueId.commandClass) ||
+    node.getEndpoint(0).getCCVersion(valueId.commandClass);
+  return valueState;
+};
 
 export const dumpNode = (node: ZWaveNode): NodeState => ({
   nodeId: node.nodeId,


### PR DESCRIPTION
This is the real fix for issue discussed today where value events for a node are fired before the node is ready.

- The dumpState will only dump all values for a node if the node is ready. If the node is not ready, the values will be an empty array.
- Value events (value added, value changed) will not be forwarded if the node is not is a ready state.
- When the node hits ready, a full nodeState will be dumped into the event, including all value infos.