### PR TITLE
Small fix for value (notification) events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -124,8 +124,8 @@ export class EventForwarder {
       const events: ZWaveNodeEvents[] = [
         "value updated",
         "value added",
-        "value removed",
         "value notification",
+        "value removed",
       ];
       for (const event of events) {
         node.on(event, (changedNode: ZWaveNode, args: any) => {

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -121,16 +121,24 @@ export class EventForwarder {
     }
 
     {
-      const events: ZWaveNodeEvents[] = [
-        "value updated",
-        "value added",
-        "value notification",
-        "value removed",
-      ];
+      const events: ZWaveNodeEvents[] = ["value updated", "value removed"];
       for (const event of events) {
         node.on(event, (changedNode: ZWaveNode, args: any) => {
           // only forward value events for ready nodes
           if (!changedNode.ready) return;
+          // vakue updated/removed events are forwarded as-is
+          notifyNode(changedNode, event, { args });
+        });
+      }
+    }
+
+    {
+      const events: ZWaveNodeEvents[] = ["value added", "value notification"];
+      for (const event of events) {
+        node.on(event, (changedNode: ZWaveNode, args: any) => {
+          // only forward value events for ready nodes
+          if (!changedNode.ready) return;
+          // value added/notification should contain metadata, use dumpValue
           const valueState = dumpValue(changedNode, args);
           notifyNode(changedNode, event, { args: valueState });
         });

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -4,10 +4,9 @@ import {
   NodeStatus,
   ZWaveNode,
   ZWaveNodeEvents,
-  ZWaveNodeValueNotificationArgs,
 } from "zwave-js";
 import { OutgoingEvent } from "./outgoing_message";
-import { dumpNode, dumpValue, dumpValueNotification } from "./state";
+import { dumpNode, dumpValue } from "./state";
 
 export class EventForwarder {
   /**
@@ -126,6 +125,7 @@ export class EventForwarder {
         "value updated",
         "value added",
         "value removed",
+        "value notification",
       ];
       for (const event of events) {
         node.on(event, (changedNode: ZWaveNode, args: any) => {
@@ -136,14 +136,6 @@ export class EventForwarder {
         });
       }
     }
-
-    node.on(
-      "value notification",
-      (changedNode: ZWaveNode, args: ZWaveNodeValueNotificationArgs) =>
-        notifyNode(changedNode, "value notification", {
-          args: dumpValueNotification(changedNode, args),
-        })
-    );
 
     node.on("notification", (changedNode, notificationLabel, parameters) =>
       notifyNode(changedNode, "notification", { notificationLabel, parameters })

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -126,7 +126,7 @@ export class EventForwarder {
         node.on(event, (changedNode: ZWaveNode, args: any) => {
           // only forward value events for ready nodes
           if (!changedNode.ready) return;
-          // vakue updated/removed events are forwarded as-is
+          // value updated/removed events are forwarded as-is
           notifyNode(changedNode, event, { args });
         });
       }

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -4,9 +4,10 @@ import {
   NodeStatus,
   ZWaveNode,
   ZWaveNodeEvents,
+  ZWaveNodeValueNotificationArgs,
 } from "zwave-js";
 import { OutgoingEvent } from "./outgoing_message";
-import { dumpNode, dumpValue } from "./state";
+import { dumpNode, dumpValue, dumpValueNotification } from "./state";
 
 export class EventForwarder {
   /**
@@ -124,7 +125,6 @@ export class EventForwarder {
       const events: ZWaveNodeEvents[] = [
         "value updated",
         "value added",
-        "value notification",
         "value removed",
       ];
       for (const event of events) {
@@ -136,6 +136,14 @@ export class EventForwarder {
         });
       }
     }
+
+    node.on(
+      "value notification",
+      (changedNode: ZWaveNode, args: ZWaveNodeValueNotificationArgs) =>
+        notifyNode(changedNode, "value notification", {
+          args: dumpValueNotification(changedNode, args),
+        })
+    );
 
     node.on("notification", (changedNode, notificationLabel, parameters) =>
       notifyNode(changedNode, "notification", { notificationLabel, parameters })

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -21,8 +21,6 @@ interface EndpointState extends Partial<Endpoint> {}
 interface ValueState extends TranslatedValueID {
   metadata: ValueMetadata;
   value?: any;
-  newValue?: any;
-  prevValue?: any;
   ccVersion: number;
 }
 

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -48,7 +48,7 @@ export const dumpValue = (
       .getEndpoint(valueArgs.endpoint)
       ?.getCCVersion(valueArgs.commandClass) ||
     node.getEndpoint(0).getCCVersion(valueArgs.commandClass);
-  if (!("value" in valueState)) {
+  if (!("value" in valueArgs)) {
     valueState.value = node.getValue(valueArgs);
   }
   return valueState;

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -16,7 +16,7 @@ interface EndpointState extends Partial<Endpoint> {}
 
 interface ValueState extends TranslatedValueID {
   metadata: ValueMetadata;
-  value?: any;
+  value: any;
   ccVersion: number;
 }
 

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -5,10 +5,6 @@ import {
   Endpoint,
   TranslatedValueID,
   ValueMetadata,
-  ZWaveNodeValueAddedArgs,
-  ZWaveNodeValueUpdatedArgs,
-  ZWaveNodeValueRemovedArgs,
-  ZWaveNodeValueNotificationArgs,
 } from "zwave-js";
 
 export interface ZwaveState {
@@ -42,38 +38,19 @@ function getNodeValues(node: ZWaveNode): ValueState[] {
 
 export const dumpValue = (
   node: ZWaveNode,
-  valueArgs:
-    | ZWaveNodeValueAddedArgs
-    | ZWaveNodeValueUpdatedArgs
-    | ZWaveNodeValueRemovedArgs
-    | ZWaveNodeValueNotificationArgs
-    | TranslatedValueID
+  valueArgs: TranslatedValueID
 ): ValueState => {
-  const valueState: ValueState = {
-    commandClassName: valueArgs.commandClassName,
-    commandClass: valueArgs.commandClass,
-    endpoint: valueArgs.endpoint,
-    property: valueArgs.property,
-    propertyName: valueArgs.propertyName,
-    propertyKeyName: valueArgs.propertyKeyName,
-    metadata: node.getValueMetadata(valueArgs),
-    // get CC Version for this endpoint, fallback to CC version of the node itself
-    ccVersion:
-      node
-        .getEndpoint(valueArgs.endpoint)
-        ?.getCCVersion(valueArgs.commandClass) ||
-      node.getEndpoint(0).getCCVersion(valueArgs.commandClass),
-  };
-
-  // make sure that value attribute always holds correct value
-  if ("newValue" in valueArgs) {
-    valueState.value = valueArgs.newValue;
-  } else if ("prevValue" in valueArgs) {
-    valueState.value = valueArgs.prevValue;
-  } else if (!("value" in valueArgs)) {
+  const valueState = valueArgs as ValueState;
+  valueState.metadata = node.getValueMetadata(valueArgs);
+  // get CC Version for this endpoint, fallback to CC version of the node itself
+  valueState.ccVersion =
+    node
+      .getEndpoint(valueArgs.endpoint)
+      ?.getCCVersion(valueArgs.commandClass) ||
+    node.getEndpoint(0).getCCVersion(valueArgs.commandClass);
+  if (!("value" in valueState)) {
     valueState.value = node.getValue(valueArgs);
   }
-
   return valueState;
 };
 

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -51,7 +51,9 @@ export const dumpValue = (
     | TranslatedValueID
 ): ValueState => {
   const valueState: ValueState = {
-    ...valueArgs,
+    commandClassName: valueArgs.commandClassName,
+    commandClass: valueArgs.commandClass,
+    property: valueArgs.property,
     metadata: node.getValueMetadata(valueArgs),
     // get CC Version for this endpoint, fallback to CC version of the node itself
     ccVersion:

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -4,6 +4,7 @@ import {
   ZWaveNode,
   Endpoint,
   TranslatedValueID,
+  ZWaveNodeValueNotificationArgs,
   ValueMetadata,
 } from "zwave-js";
 
@@ -47,6 +48,16 @@ export const dumpValue = (
   valueState.ccVersion =
     node.getEndpoint(valueId.endpoint)?.getCCVersion(valueId.commandClass) ||
     node.getEndpoint(0).getCCVersion(valueId.commandClass);
+  return valueState;
+};
+
+export const dumpValueNotification = (
+  node: ZWaveNode,
+  valueArgs: ZWaveNodeValueNotificationArgs
+): ValueState => {
+  const valueState = valueArgs as ValueState;
+  valueState.metadata = node.getValueMetadata(valueArgs);
+  valueState.ccVersion = 0; // no need for ccVersion in these stateless events (for now)
   return valueState;
 };
 

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -41,20 +41,24 @@ export const dumpValue = (
   node: ZWaveNode,
   valueArgs: TranslatedValueID
 ): ValueState => {
-  const valueState = valueArgs as ValueState;
-  valueState.metadata = node.getValueMetadata(valueArgs);
+  const valueState: ValueState = {
+    ...valueArgs,
+    metadata: node.getValueMetadata(valueArgs),
+    // get CC Version for this endpoint, fallback to CC version of the node itself
+    ccVersion:
+      node
+        .getEndpoint(valueArgs.endpoint)
+        ?.getCCVersion(valueArgs.commandClass) ||
+      node.getEndpoint(0).getCCVersion(valueArgs.commandClass),
+  };
+
   // make sure that value attribute always holds correct value
   if (typeof valueState.newValue !== "undefined") {
     valueState.value = valueState.newValue;
   } else if (typeof valueState.value === "undefined") {
     valueState.value = node.getValue(valueArgs);
   }
-  // get CC Version for this endpoint, fallback to CC version of the node itself
-  valueState.ccVersion =
-    node
-      .getEndpoint(valueArgs.endpoint)
-      ?.getCCVersion(valueArgs.commandClass) ||
-    node.getEndpoint(0).getCCVersion(valueArgs.commandClass);
+
   return valueState;
 };
 

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -16,7 +16,8 @@ interface EndpointState extends Partial<Endpoint> {}
 
 interface ValueState extends Partial<TranslatedValueID> {
   metadata: ValueMetadata;
-  value: any;
+  value?: any;
+  newValue?: any;
   ccVersion: number;
 }
 
@@ -36,15 +37,16 @@ function getNodeValues(node: ZWaveNode): ValueState[] {
   );
 }
 
-export const dumpValue = (node: ZWaveNode, valueArgs: any): ValueState => {
+export const dumpValue = (
+  node: ZWaveNode,
+  valueArgs: TranslatedValueID
+): ValueState => {
   const valueState = valueArgs as ValueState;
   valueState.metadata = node.getValueMetadata(valueArgs);
   // make sure that value attribute always holds correct value
-  if (typeof valueArgs.value !== "undefined") {
-    valueState.value = valueArgs.value;
-  } else if (typeof valueArgs.newValue !== "undefined") {
-    valueState.value = valueArgs.newValue;
-  } else {
+  if (typeof valueState.newValue !== "undefined") {
+    valueState.value = valueState.newValue;
+  } else if (typeof valueState.value === "undefined") {
     valueState.value = node.getValue(valueArgs);
   }
   // get CC Version for this endpoint, fallback to CC version of the node itself

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -5,6 +5,10 @@ import {
   Endpoint,
   TranslatedValueID,
   ValueMetadata,
+  ZWaveNodeValueAddedArgs,
+  ZWaveNodeValueUpdatedArgs,
+  ZWaveNodeValueRemovedArgs,
+  ZWaveNodeValueNotificationArgs,
 } from "zwave-js";
 
 export interface ZwaveState {
@@ -39,7 +43,12 @@ function getNodeValues(node: ZWaveNode): ValueState[] {
 
 export const dumpValue = (
   node: ZWaveNode,
-  valueArgs: TranslatedValueID
+  valueArgs:
+    | ZWaveNodeValueAddedArgs
+    | ZWaveNodeValueUpdatedArgs
+    | ZWaveNodeValueRemovedArgs
+    | ZWaveNodeValueNotificationArgs
+    | TranslatedValueID
 ): ValueState => {
   const valueState: ValueState = {
     ...valueArgs,
@@ -53,9 +62,9 @@ export const dumpValue = (
   };
 
   // make sure that value attribute always holds correct value
-  if (typeof valueState.newValue !== "undefined") {
-    valueState.value = valueState.newValue;
-  } else if (typeof valueState.value === "undefined") {
+  if ("newValue" in valueArgs) {
+    valueState.value = valueArgs.newValue;
+  } else if ("value" in valueArgs) {
     valueState.value = node.getValue(valueArgs);
   }
 

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -22,6 +22,7 @@ interface ValueState extends TranslatedValueID {
   metadata: ValueMetadata;
   value?: any;
   newValue?: any;
+  prevValue?: any;
   ccVersion: number;
 }
 
@@ -53,7 +54,10 @@ export const dumpValue = (
   const valueState: ValueState = {
     commandClassName: valueArgs.commandClassName,
     commandClass: valueArgs.commandClass,
+    endpoint: valueArgs.endpoint,
     property: valueArgs.property,
+    propertyName: valueArgs.propertyName,
+    propertyKeyName: valueArgs.propertyKeyName,
     metadata: node.getValueMetadata(valueArgs),
     // get CC Version for this endpoint, fallback to CC version of the node itself
     ccVersion:
@@ -66,7 +70,9 @@ export const dumpValue = (
   // make sure that value attribute always holds correct value
   if ("newValue" in valueArgs) {
     valueState.value = valueArgs.newValue;
-  } else if ("value" in valueArgs) {
+  } else if ("prevValue" in valueArgs) {
+    valueState.value = valueArgs.prevValue;
+  } else if (!("value" in valueArgs)) {
     valueState.value = node.getValue(valueArgs);
   }
 

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -39,8 +39,14 @@ function getNodeValues(node: ZWaveNode): ValueState[] {
 export const dumpValue = (node: ZWaveNode, valueArgs: any): ValueState => {
   const valueState = valueArgs as ValueState;
   valueState.metadata = node.getValueMetadata(valueArgs);
-  valueState.value =
-    valueArgs.value || valueArgs.newValue || node.getValue(valueArgs);
+  // make sure that value attribute always holds correct value
+  if (typeof valueArgs.value !== "undefined") {
+    valueState.value = valueArgs.value;
+  } else if (typeof valueArgs.newValue !== "undefined") {
+    valueState.value = valueArgs.newValue;
+  } else {
+    valueState.value = node.getValue(valueArgs);
+  }
   // get CC Version for this endpoint, fallback to CC version of the node itself
   valueState.ccVersion =
     node

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -4,7 +4,6 @@ import {
   ZWaveNode,
   Endpoint,
   TranslatedValueID,
-  ZWaveNodeValueNotificationArgs,
   ValueMetadata,
 } from "zwave-js";
 
@@ -37,27 +36,17 @@ function getNodeValues(node: ZWaveNode): ValueState[] {
   );
 }
 
-export const dumpValue = (
-  node: ZWaveNode,
-  valueId: TranslatedValueID
-): ValueState => {
-  const valueState = valueId as ValueState;
-  valueState.metadata = node.getValueMetadata(valueId);
-  valueState.value = node.getValue(valueId);
-  // get CC Version for this endpoint, fallback to CC version of the node itself
-  valueState.ccVersion =
-    node.getEndpoint(valueId.endpoint)?.getCCVersion(valueId.commandClass) ||
-    node.getEndpoint(0).getCCVersion(valueId.commandClass);
-  return valueState;
-};
-
-export const dumpValueNotification = (
-  node: ZWaveNode,
-  valueArgs: ZWaveNodeValueNotificationArgs
-): ValueState => {
+export const dumpValue = (node: ZWaveNode, valueArgs: any): ValueState => {
   const valueState = valueArgs as ValueState;
   valueState.metadata = node.getValueMetadata(valueArgs);
-  valueState.ccVersion = 0; // no need for ccVersion in these stateless events (for now)
+  valueState.value =
+    valueArgs.value || valueArgs.newValue || node.getValue(valueArgs);
+  // get CC Version for this endpoint, fallback to CC version of the node itself
+  valueState.ccVersion =
+    node
+      .getEndpoint(valueArgs.endpoint)
+      ?.getCCVersion(valueArgs.commandClass) ||
+    node.getEndpoint(0).getCCVersion(valueArgs.commandClass);
   return valueState;
 };
 

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -16,8 +16,8 @@ interface EndpointState extends Partial<Endpoint> {}
 
 interface ValueState extends TranslatedValueID {
   metadata: ValueMetadata;
-  value: any;
   ccVersion: number;
+  value?: any;
 }
 
 interface NodeState extends Partial<ZWaveNode> {
@@ -40,14 +40,23 @@ export const dumpValue = (
   node: ZWaveNode,
   valueArgs: TranslatedValueID
 ): ValueState => {
-  const valueState = valueArgs as ValueState;
-  valueState.metadata = node.getValueMetadata(valueArgs);
-  // get CC Version for this endpoint, fallback to CC version of the node itself
-  valueState.ccVersion =
-    node
-      .getEndpoint(valueArgs.endpoint)
-      ?.getCCVersion(valueArgs.commandClass) ||
-    node.getEndpoint(0).getCCVersion(valueArgs.commandClass);
+  const valueState: ValueState = {
+    endpoint: valueArgs.endpoint,
+    commandClass: valueArgs.commandClass,
+    commandClassName: valueArgs.commandClassName,
+    property: valueArgs.property,
+    propertyName: valueArgs.propertyName,
+    propertyKeyName: valueArgs.propertyKeyName,
+    // get CC Version for this endpoint, fallback to CC version of the node itself
+    ccVersion:
+      node
+        .getEndpoint(valueArgs.endpoint)
+        ?.getCCVersion(valueArgs.commandClass) ||
+      node.getEndpoint(0).getCCVersion(valueArgs.commandClass),
+    // append metadata
+    metadata: node.getValueMetadata(valueArgs),
+  };
+  // retrieve value if needed
   if (!("value" in valueArgs)) {
     valueState.value = node.getValue(valueArgs);
   }

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -14,7 +14,7 @@ export interface ZwaveState {
 
 interface EndpointState extends Partial<Endpoint> {}
 
-interface ValueState extends Partial<TranslatedValueID> {
+interface ValueState extends TranslatedValueID {
   metadata: ValueMetadata;
   value?: any;
   newValue?: any;


### PR DESCRIPTION
Value notification value is already provided in the event.
This change will make sure that the message signature is always consistent for all value events, where the value attribute always contains the most recent value.