### PR TITLE
Bump version to 1.0.0-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -452,11 +452,11 @@
       }
     },
     "@zwave-js/config": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-6.1.0.tgz",
-      "integrity": "sha512-eaB2/VydqyznQ3gI4jkwH1dULAasPc/oQu4jS00FP/SM9AnzTnDN/tT1VxIaD5ecTyxT5BG+G3RCQY3tSnR12g==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-6.1.1.tgz",
+      "integrity": "sha512-jhqosKbY2FpZDBAgTa6bMrqQCO7WfpLf68BhhN6pMry3E+dY/4y5rxOD6aqVedkPDaaoydeHs0lTJIAuHIjt8w==",
       "requires": {
-        "@zwave-js/core": "^6.1.0",
+        "@zwave-js/core": "^6.1.1",
         "@zwave-js/shared": "^6.0.0-beta.2",
         "alcalzone-shared": "^3.0.2",
         "ansi-colors": "^4.1.1",
@@ -467,9 +467,9 @@
       }
     },
     "@zwave-js/core": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-6.1.0.tgz",
-      "integrity": "sha512-oYoLQHWo74xE28qy6Oy9cTOd7asp00QhusdL5Tto0Bh9bTXtOpT6e7szv2bHwJ4+tCiTbTdzMnDn7rwhlOeXQA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-6.1.1.tgz",
+      "integrity": "sha512-sSVuuev6rzHB2BRaB02PTh6pqULeCbMCPZQRqMTBp9aeT4+Hc8Baj1bj9EjSVyXvpEJ19VXbiNgKt/O4TiHBrA==",
       "requires": {
         "@alcalzone/jsonl-db": "^1.2.3",
         "@zwave-js/shared": "^6.0.0-beta.2",
@@ -482,11 +482,11 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-6.1.0.tgz",
-      "integrity": "sha512-whE4awDvEXabl3G1P/TKEKBoFP8ubavR6YNk/J6YVPKWW/6xu0mfiNSM9WfR1PI3CMGmzGd5GmSLiuM1xwPR9A==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-6.1.1.tgz",
+      "integrity": "sha512-qw9ri/5HVY34SfgwZncJWHnqqE76K6IcmlbJlOH1uZXpNQOY54tEtPAU7991ibROyl9ivvWfmRRxsRpCIXVQIg==",
       "requires": {
-        "@zwave-js/core": "^6.1.0",
+        "@zwave-js/core": "^6.1.1",
         "alcalzone-shared": "^3.0.2",
         "serialport": "^9.0.1",
         "winston": "^3.3.3"
@@ -2972,16 +2972,16 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-6.1.0.tgz",
-      "integrity": "sha512-UlwAmPXFS8ZPHpLkpGvc69E6DiXNZeEgZg3evekJ6Nc1B7BHQVvlpJZia8kT+oe05XMFibVtf6y1X5rWI/CLOQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-6.1.1.tgz",
+      "integrity": "sha512-Dqz/GXZZmBRmF7wmN/tuFvbXLTLgCYgPpmSfdUFPidzCaNjXczj9kgHXhRaNErSQTvVybbj7p2+z9axkyB64/w==",
       "requires": {
         "@alcalzone/jsonl-db": "^1.2.3",
         "@sentry/integrations": "^5.24.2",
         "@sentry/node": "^5.24.2",
-        "@zwave-js/config": "^6.1.0",
-        "@zwave-js/core": "^6.1.0",
-        "@zwave-js/serial": "^6.1.0",
+        "@zwave-js/config": "^6.1.1",
+        "@zwave-js/core": "^6.1.1",
+        "@zwave-js/serial": "^6.1.1",
         "@zwave-js/shared": "^6.0.0-beta.2",
         "alcalzone-shared": "^3.0.2",
         "ansi-colors": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Full access to zwave-js driver throught Websockets",
   "main": "dist/lib/index.js",
   "bin": {
@@ -23,7 +23,7 @@
   "dependencies": {
     "minimist": "^1.2.5",
     "ws": "^7.4.2",
-    "zwave-js": "^6.1.0"
+    "zwave-js": "^6.1.1"
   },
   "devDependencies": {
     "@types/node": "^14.14.20",


### PR DESCRIPTION
also include latest zwave-js version 6.1.1