### PR TITLE
Fix value events

### DIFF
--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -6,7 +6,7 @@ import {
   ZWaveNodeEvents,
 } from "zwave-js";
 import { OutgoingEvent } from "./outgoing_message";
-import { dumpNode, dumpValue } from "./state";
+import { dumpNode } from "./state";
 
 export class EventForwarder {
   /**

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -121,26 +121,18 @@ export class EventForwarder {
     }
 
     {
-      const events: ZWaveNodeEvents[] = ["value updated", "value removed"];
+      const events: ZWaveNodeEvents[] = [
+        "value updated",
+        "value removed",
+        "value added",
+        "value notification",
+        "metadata updated",
+      ];
       for (const event of events) {
         node.on(event, (changedNode: ZWaveNode, args: any) => {
           // only forward value events for ready nodes
           if (!changedNode.ready) return;
-          // value updated/removed events are forwarded as-is
           notifyNode(changedNode, event, { args });
-        });
-      }
-    }
-
-    {
-      const events: ZWaveNodeEvents[] = ["value added", "value notification"];
-      for (const event of events) {
-        node.on(event, (changedNode: ZWaveNode, args: any) => {
-          // only forward value events for ready nodes
-          if (!changedNode.ready) return;
-          // value added/notification should contain metadata, use dumpValue
-          const valueState = dumpValue(changedNode, args);
-          notifyNode(changedNode, event, { args: valueState });
         });
       }
     }

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -39,27 +39,24 @@ function getNodeValues(node: ZWaveNode): ValueState[] {
 export const dumpValue = (
   node: ZWaveNode,
   valueArgs: TranslatedValueID
-): ValueState => {
-  const valueState: ValueState = {
-    endpoint: valueArgs.endpoint,
-    commandClass: valueArgs.commandClass,
-    commandClassName: valueArgs.commandClassName,
-    property: valueArgs.property,
-    propertyName: valueArgs.propertyName,
-    propertyKeyName: valueArgs.propertyKeyName,
-    // get CC Version for this endpoint, fallback to CC version of the node itself
-    ccVersion:
-      node
-        .getEndpoint(valueArgs.endpoint)
-        ?.getCCVersion(valueArgs.commandClass) ||
-      node.getEndpoint(0).getCCVersion(valueArgs.commandClass),
-    // append metadata
-    metadata: node.getValueMetadata(valueArgs),
-    // append actual value
-    value: node.getValue(valueArgs),
-  };
-  return valueState;
-};
+): ValueState => ({
+  endpoint: valueArgs.endpoint,
+  commandClass: valueArgs.commandClass,
+  commandClassName: valueArgs.commandClassName,
+  property: valueArgs.property,
+  propertyName: valueArgs.propertyName,
+  propertyKeyName: valueArgs.propertyKeyName,
+  // get CC Version for this endpoint, fallback to CC version of the node itself
+  ccVersion:
+    node
+      .getEndpoint(valueArgs.endpoint)
+      ?.getCCVersion(valueArgs.commandClass) ||
+    node.getEndpoint(0).getCCVersion(valueArgs.commandClass),
+  // append metadata
+  metadata: node.getValueMetadata(valueArgs),
+  // append actual value
+  value: node.getValue(valueArgs),
+});
 
 export const dumpNode = (node: ZWaveNode): NodeState => ({
   nodeId: node.nodeId,

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -55,11 +55,9 @@ export const dumpValue = (
       node.getEndpoint(0).getCCVersion(valueArgs.commandClass),
     // append metadata
     metadata: node.getValueMetadata(valueArgs),
+    // append actual value
+    value: node.getValue(valueArgs),
   };
-  // retrieve value if needed
-  if (!("value" in valueArgs)) {
-    valueState.value = node.getValue(valueArgs);
-  }
   return valueState;
 };
 


### PR DESCRIPTION
As discussed with @AlCalzone we missed the metadata updated event and so we do not need the workaround.
This change will:

- Forward all value events as-is
- Only in the dumpState/dumpNode function a full value object, including metadata and ccVersion will be sent
- metadata updated event will be forwarded, which can be used to update metadata of values
- This will/should fix the issue that the value's value is not present in Scene Activation events.