### PR TITLE
Bump node-zwave-js and server version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -473,13 +473,13 @@
       }
     },
     "@zwave-js/config": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-6.1.3.tgz",
-      "integrity": "sha512-oWJKcCESS2oxzjIilVR880tGnFTuIiEcXIzZpVSbIBkWGfFzrDd6pl+1bgXoZyfz7N6Y3vcn9hlxhKpwj2QmBQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-6.2.0.tgz",
+      "integrity": "sha512-KUlOd4/nkqKpYLGj4j0sS2h0zj0WV5mnWgwFoXCAOgsac4Tv1KdqfDzuLz+WyO6L9eqD9oYcjTOfF10V+44jzQ==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "^6.1.1",
-        "@zwave-js/shared": "^6.0.0-beta.2",
+        "@zwave-js/core": "^6.2.0",
+        "@zwave-js/shared": "^6.2.0",
         "alcalzone-shared": "^3.0.2",
         "ansi-colors": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -489,13 +489,13 @@
       }
     },
     "@zwave-js/core": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-6.1.1.tgz",
-      "integrity": "sha512-sSVuuev6rzHB2BRaB02PTh6pqULeCbMCPZQRqMTBp9aeT4+Hc8Baj1bj9EjSVyXvpEJ19VXbiNgKt/O4TiHBrA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-6.2.0.tgz",
+      "integrity": "sha512-JdYLOeb+gYK2pd1JP2wZXLsrYWbixbExinDroexx9OMkmu0UxH17TQ/jwIFrG0aVH54s0AEk8sp0hqQZ+Dkg3g==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^1.2.3",
-        "@zwave-js/shared": "^6.0.0-beta.2",
+        "@zwave-js/shared": "^6.2.0",
         "alcalzone-shared": "^3.0.2",
         "ansi-colors": "^4.1.1",
         "moment": "^2.29.0",
@@ -505,21 +505,21 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-6.1.1.tgz",
-      "integrity": "sha512-qw9ri/5HVY34SfgwZncJWHnqqE76K6IcmlbJlOH1uZXpNQOY54tEtPAU7991ibROyl9ivvWfmRRxsRpCIXVQIg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-6.2.0.tgz",
+      "integrity": "sha512-PhHiTP1NvIiG7Uk+7a5ccttGiABJN6tWI7lViRV54PqIIuUKNb+ajlsmwlxcGFVW2VJZqCt2ZKwiCWq+krBe2A==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "^6.1.1",
+        "@zwave-js/core": "^6.2.0",
         "alcalzone-shared": "^3.0.2",
         "serialport": "^9.0.1",
         "winston": "^3.3.3"
       }
     },
     "@zwave-js/shared": {
-      "version": "6.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-6.0.0-beta.2.tgz",
-      "integrity": "sha512-Uxpy755f2wPIidr0xbBqf7yB3Yhm/jCNKRL1dIfjLMhLdV27loTOjMxKTXZ+YyvwHKr+bygwajyXOa3snLmwRg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-6.2.0.tgz",
+      "integrity": "sha512-xQeDt9GLAMTSvgFUMSOny/j1L1edd3A7Yr++G763fWabj4dX62ezO7ok5A5Ecld+AXAhjZY9s/nIhhm9yxsYiQ==",
       "dev": true,
       "requires": {
         "alcalzone-shared": "^3.0.2"
@@ -724,9 +724,9 @@
       }
     },
     "bl": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.4.tgz",
-      "integrity": "sha512-7tdr4EpSd7jJ6tuQ21vu2ke8w7pNEstzj1O8wwq6sNNzO3UDi5MA8Gny/gquCj7r2C6fHudg8tKRGyjRgmvNxQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dev": true,
       "requires": {
         "buffer": "^5.5.0",
@@ -1628,9 +1628,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.5.tgz",
-      "integrity": "sha512-kBBSQbz2K0Nyn+31j/w36fUfxkBW9/gfwRWdUY1ULReH3iokVJgddZAFcD1D0xlgTmFxJCbUkUclAlc6/IDJkw==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
     },
     "has-flag": {
@@ -3184,18 +3184,18 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-6.1.3.tgz",
-      "integrity": "sha512-QQ7RtR7lek9JMCnFDz8zqsM1uskdtSA1TL922r7tYb0l/VXO3Cqtehw/+r65lWKotbbHf31G5ThgKry5z+0zMw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-6.2.0.tgz",
+      "integrity": "sha512-e/AODawVy3jmQd9eOXRErRN+ISw/vkLjPDOQGf0KR3a9ocL87ixyBdXrwtmP69P/yehOOlya+Rq5pvfPuVlbqA==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^1.2.3",
         "@sentry/integrations": "^5.24.2",
         "@sentry/node": "^5.24.2",
-        "@zwave-js/config": "^6.1.3",
-        "@zwave-js/core": "^6.1.1",
-        "@zwave-js/serial": "^6.1.1",
-        "@zwave-js/shared": "^6.0.0-beta.2",
+        "@zwave-js/config": "^6.2.0",
+        "@zwave-js/core": "^6.2.0",
+        "@zwave-js/serial": "^6.2.0",
+        "@zwave-js/shared": "^6.2.0",
         "alcalzone-shared": "^3.0.2",
         "ansi-colors": "^4.1.1",
         "fs-extra": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Full access to zwave-js driver throught Websockets",
   "main": "dist/lib/index.js",
   "bin": {
@@ -25,7 +25,7 @@
     "ws": "^7.4.2"
   },
   "peerDependencies": {
-    "zwave-js": "^6.1"
+    "zwave-js": "^6.2.0"
   },
   "devDependencies": {
     "@types/node": "^14.14.20",
@@ -40,7 +40,7 @@
     "prettier": "^2.2.1",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3",
-    "zwave-js": "^6.1"
+    "zwave-js": "^6.2.0"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ws": "^7.4.2"
   },
   "peerDependencies": {
-    "zwave-js": "^6.2.0"
+    "zwave-js": "^6.2"
   },
   "devDependencies": {
     "@types/node": "^14.14.20",
@@ -40,7 +40,7 @@
     "prettier": "^2.2.1",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3",
-    "zwave-js": "^6.2.0"
+    "zwave-js": "^6.2"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Changelog: https://github.com/zwave-js/node-zwave-js/releases/tag/v6.2.0