### PR TITLE
Add commands to get and update log config

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,19 @@ interface {
 }
 ```
 
-Returns `LogConfig`
+Returns `Partial<LogConfig>`:
+
+```ts
+interface {
+  enabled: boolean;
+  level: number;
+  logToFile: boolean;
+  filename: string;
+  forceConsole: boolean;
+}
+``
 
 ## Authentication
 
 Z-Wave JS Server does not handle authentication and allows all connections to the websocket API. If you want to add authentication, add authentication middleware to your Express instance or run NGINX in front of Express instance.
+```

--- a/README.md
+++ b/README.md
@@ -103,12 +103,16 @@ interface {
 
 ## Client commands
 
+### Start Listening for events
+
 ```ts
 interface {
   messageId: string;
   command: "start_listening";
 }
 ```
+
+### Set value on a node
 
 ```ts
 interface {

--- a/README.md
+++ b/README.md
@@ -146,6 +146,17 @@ interface {
 }
 ```
 
+### Get the logging configuration
+
+```ts
+interface {
+  messageId: string;
+  command: "get_log_config";
+}
+```
+
+Returns `LogConfig`
+
 ## Authentication
 
 Z-Wave JS Server does not handle authentication and allows all connections to the websocket API. If you want to add authentication, add authentication middleware to your Express instance or run NGINX in front of Express instance.

--- a/README.md
+++ b/README.md
@@ -155,15 +155,17 @@ interface {
 }
 ```
 
-Returns `Partial<LogConfig>`:
+Returns:
 
 ```ts
 interface {
-  enabled: boolean;
-  level: number;
-  logToFile: boolean;
-  filename: string;
-  forceConsole: boolean;
+  config: {
+    enabled: boolean;
+    level: number;
+    logToFile: boolean;
+    filename: string;
+    forceConsole: boolean;
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,3 @@ interface {
 ## Authentication
 
 Z-Wave JS Server does not handle authentication and allows all connections to the websocket API. If you want to add authentication, add authentication middleware to your Express instance or run NGINX in front of Express instance.
-
-```
-
-```

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ interface {
 
 ## Client commands
 
-### Start Listening for events
+### Start listening to events
 
 ```ts
 interface {
@@ -127,6 +127,10 @@ interface {
   value: any
 }
 ```
+
+### Update the logging configuration
+
+> NOTE: You must provide at least one key/value pair as part of `config`
 
 ```ts
 interface {

--- a/README.md
+++ b/README.md
@@ -124,6 +124,21 @@ interface {
 }
 ```
 
+```ts
+interface {
+  messageId: string;
+  command: "update_log_config";
+  config: {
+    enabled?: boolean;
+    level?: number;
+    transports?: Transport[];
+    logToFile?: boolean;
+    filename?: string;
+    forceConsole?: boolean;
+  }
+}
+```
+
 ## Authentication
 
 Z-Wave JS Server does not handle authentication and allows all connections to the websocket API. If you want to add authentication, add authentication middleware to your Express instance or run NGINX in front of Express instance.

--- a/README.md
+++ b/README.md
@@ -165,9 +165,12 @@ interface {
   filename: string;
   forceConsole: boolean;
 }
-``
+```
 
 ## Authentication
 
 Z-Wave JS Server does not handle authentication and allows all connections to the websocket API. If you want to add authentication, add authentication middleware to your Express instance or run NGINX in front of Express instance.
+
+```
+
 ```

--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ interface {
   config: {
     enabled?: boolean;
     level?: number;
-    transports?: Transport[];
     logToFile?: boolean;
     filename?: string;
     forceConsole?: boolean;

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -1,0 +1,4 @@
+export enum DriverCommand {
+  startListening = "start_listening",
+  updateLogConfig = "update_log_config",
+}

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -1,4 +1,5 @@
 export enum DriverCommand {
   startListening = "start_listening",
   updateLogConfig = "update_log_config",
+  getLogConfig = "get_log_config",
 }

--- a/src/lib/incoming_message.ts
+++ b/src/lib/incoming_message.ts
@@ -13,8 +13,14 @@ interface IncomingCommandUpdateLogConfig extends IncomingCommandBase {
   config: Partial<LogConfig>;
 }
 
+interface IncomingCommandGetLogLevel extends IncomingCommandBase {
+  messageId: string;
+  command: DriverCommand.getLogConfig;
+}
+
 export type IncomingMessage =
   | IncomingCommandStartListening
   | IncomingCommandUpdateLogConfig
+  | IncomingCommandGetLogLevel
   | IncomingMessageNode
   | IncomingMessageController;

--- a/src/lib/incoming_message.ts
+++ b/src/lib/incoming_message.ts
@@ -1,3 +1,5 @@
+import { LogConfig } from "@zwave-js/core";
+import { DeepPartial } from "@zwave-js/shared";
 import { IncomingMessageController } from "./controller/incoming_message";
 import { IncomingCommandBase } from "./incoming_message_base";
 import { IncomingMessageNode } from "./node/incoming_message";
@@ -7,7 +9,14 @@ interface IncomingCommandStartListening extends IncomingCommandBase {
   command: "start_listening";
 }
 
+interface IncomingCommandUpdateLogConfig extends IncomingCommandBase {
+  messageId: string;
+  command: "update_log_config";
+  config: DeepPartial<LogConfig>;
+}
+
 export type IncomingMessage =
   | IncomingCommandStartListening
+  | IncomingCommandUpdateLogConfig
   | IncomingMessageNode
   | IncomingMessageController;

--- a/src/lib/incoming_message.ts
+++ b/src/lib/incoming_message.ts
@@ -1,5 +1,4 @@
 import { LogConfig } from "@zwave-js/core";
-import { DeepPartial } from "@zwave-js/shared";
 import { IncomingMessageController } from "./controller/incoming_message";
 import { DriverCommand } from "./command";
 import { IncomingCommandBase } from "./incoming_message_base";
@@ -11,7 +10,7 @@ interface IncomingCommandStartListening extends IncomingCommandBase {
 
 interface IncomingCommandUpdateLogConfig extends IncomingCommandBase {
   command: DriverCommand.updateLogConfig;
-  config: DeepPartial<LogConfig>;
+  config: Partial<LogConfig>;
 }
 
 export type IncomingMessage =

--- a/src/lib/incoming_message.ts
+++ b/src/lib/incoming_message.ts
@@ -14,7 +14,6 @@ interface IncomingCommandUpdateLogConfig extends IncomingCommandBase {
 }
 
 interface IncomingCommandGetLogConfig extends IncomingCommandBase {
-  messageId: string;
   command: DriverCommand.getLogConfig;
 }
 

--- a/src/lib/incoming_message.ts
+++ b/src/lib/incoming_message.ts
@@ -13,7 +13,7 @@ interface IncomingCommandUpdateLogConfig extends IncomingCommandBase {
   config: Partial<LogConfig>;
 }
 
-interface IncomingCommandGetLogLevel extends IncomingCommandBase {
+interface IncomingCommandGetLogConfig extends IncomingCommandBase {
   messageId: string;
   command: DriverCommand.getLogConfig;
 }
@@ -21,6 +21,6 @@ interface IncomingCommandGetLogLevel extends IncomingCommandBase {
 export type IncomingMessage =
   | IncomingCommandStartListening
   | IncomingCommandUpdateLogConfig
-  | IncomingCommandGetLogLevel
+  | IncomingCommandGetLogConfig
   | IncomingMessageNode
   | IncomingMessageController;

--- a/src/lib/incoming_message.ts
+++ b/src/lib/incoming_message.ts
@@ -1,17 +1,16 @@
 import { LogConfig } from "@zwave-js/core";
 import { DeepPartial } from "@zwave-js/shared";
 import { IncomingMessageController } from "./controller/incoming_message";
+import { DriverCommand } from "./command";
 import { IncomingCommandBase } from "./incoming_message_base";
 import { IncomingMessageNode } from "./node/incoming_message";
 
 interface IncomingCommandStartListening extends IncomingCommandBase {
-  messageId: string;
-  command: "start_listening";
+  command: DriverCommand.startListening;
 }
 
 interface IncomingCommandUpdateLogConfig extends IncomingCommandBase {
-  messageId: string;
-  command: "update_log_config";
+  command: DriverCommand.updateLogConfig;
   config: DeepPartial<LogConfig>;
 }
 

--- a/src/lib/outgoing_message.ts
+++ b/src/lib/outgoing_message.ts
@@ -30,7 +30,7 @@ interface OutgoingResultMessageError {
 export type ResultTypes = {
   start_listening: { state: ZwaveState };
 } & {
-  update_log_config: { success: boolean };
+  update_log_config: Record<string, never>;
 } & NodeResultTypes &
   ControllerResultTypes;
 

--- a/src/lib/outgoing_message.ts
+++ b/src/lib/outgoing_message.ts
@@ -29,6 +29,8 @@ interface OutgoingResultMessageError {
 
 export type ResultTypes = {
   start_listening: { state: ZwaveState };
+} & {
+  update_log_config: { success: boolean };
 } & NodeResultTypes &
   ControllerResultTypes;
 

--- a/src/lib/outgoing_message.ts
+++ b/src/lib/outgoing_message.ts
@@ -27,12 +27,15 @@ interface OutgoingResultMessageError {
   errorCode: string;
 }
 
-export type ResultTypes = {
-  start_listening: { state: ZwaveState };
-} & {
-  update_log_config: Record<string, never>;
-} & NodeResultTypes &
-  ControllerResultTypes;
+export type ResultTypes =
+  | {
+      start_listening: { state: ZwaveState };
+    }
+  | {
+      update_log_config: Record<string, never>;
+    }
+  | NodeResultTypes
+  | ControllerResultTypes;
 
 export interface OutgoingResultMessageSuccess {
   type: "result";

--- a/src/lib/outgoing_message.ts
+++ b/src/lib/outgoing_message.ts
@@ -32,7 +32,7 @@ interface OutgoingResultMessageError {
 export interface DriverResultTypes {
   [DriverCommand.startListening]: { state: ZwaveState };
   [DriverCommand.updateLogConfig]: Record<string, never>;
-  [DriverCommand.getLogConfig]: { config: LogConfig }
+  [DriverCommand.getLogConfig]: { config: Partial<LogConfig> };
 }
 
 export type ResultTypes = DriverResultTypes &

--- a/src/lib/outgoing_message.ts
+++ b/src/lib/outgoing_message.ts
@@ -1,3 +1,4 @@
+import { LogConfig } from "@zwave-js/core";
 import type { ZwaveState } from "./state";
 import { NodeResultTypes } from "./node/outgoing_message";
 import { ControllerResultTypes } from "./controller/outgoing_message";
@@ -31,6 +32,7 @@ interface OutgoingResultMessageError {
 export interface DriverResultTypes {
   [DriverCommand.startListening]: { state: ZwaveState };
   [DriverCommand.updateLogConfig]: Record<string, never>;
+  [DriverCommand.getLogConfig]: { config: LogConfig }
 }
 
 export type ResultTypes = DriverResultTypes &

--- a/src/lib/outgoing_message.ts
+++ b/src/lib/outgoing_message.ts
@@ -1,6 +1,7 @@
 import type { ZwaveState } from "./state";
 import { NodeResultTypes } from "./node/outgoing_message";
 import { ControllerResultTypes } from "./controller/outgoing_message";
+import { DriverCommand } from "./command";
 
 export interface OutgoingEvent {
   source: "controller" | "node";
@@ -27,11 +28,13 @@ interface OutgoingResultMessageError {
   errorCode: string;
 }
 
-export type ResultTypes = {
-  start_listening: { state: ZwaveState };
-} & {
-  update_log_config: Record<string, never>;
-} & NodeResultTypes &
+export interface DriverResultTypes {
+  [DriverCommand.startListening]: { state: ZwaveState };
+  [DriverCommand.updateLogConfig]: Record<string, never>;
+}
+
+export type ResultTypes = DriverResultTypes &
+  NodeResultTypes &
   ControllerResultTypes;
 
 export interface OutgoingResultMessageSuccess {

--- a/src/lib/outgoing_message.ts
+++ b/src/lib/outgoing_message.ts
@@ -27,15 +27,12 @@ interface OutgoingResultMessageError {
   errorCode: string;
 }
 
-export type ResultTypes =
-  | {
-      start_listening: { state: ZwaveState };
-    }
-  | {
-      update_log_config: Record<string, never>;
-    }
-  | NodeResultTypes
-  | ControllerResultTypes;
+export type ResultTypes = {
+  start_listening: { state: ZwaveState };
+} & {
+  update_log_config: Record<string, never>;
+} & NodeResultTypes &
+  ControllerResultTypes;
 
 export interface OutgoingResultMessageSuccess {
   type: "result";

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -15,6 +15,7 @@ import { IncomingMessageController } from "./controller/incoming_message";
 import { BaseError, ErrorCode, UnknownCommandError } from "./error";
 import { Instance } from "./instance";
 import { IncomingMessageNode } from "./node/incoming_message";
+import { DriverCommand } from "./command";
 class Client {
   public receiveEvents = false;
   private _outstandingPing = false;
@@ -64,7 +65,7 @@ class Client {
     }
 
     try {
-      if (msg.command === "start_listening") {
+      if (msg.command === DriverCommand.startListening) {
         this.sendResultSuccess(msg.messageId, {
           state: dumpState(this.driver),
         });
@@ -72,7 +73,7 @@ class Client {
         return;
       }
 
-      if (msg.command === "update_log_config") {
+      if (msg.command === DriverCommand.updateLogConfig) {
         this.driver.updateLogConfig(msg.config);
         this.sendResultSuccess(msg.messageId, {});
         return;

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -80,8 +80,8 @@ class Client {
       }
 
       if (msg.command === DriverCommand.getLogConfig) {
-        const { transports, ...logConfig } = this.driver.getLogConfig();
-        this.sendResultSuccess(msg.messageId, { config: logConfig });
+        const { transports, ...partialLogConfig } = this.driver.getLogConfig();
+        this.sendResultSuccess(msg.messageId, { config: partialLogConfig });
         return;
       }
 

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -80,6 +80,7 @@ class Client {
       }
 
       if (msg.command === DriverCommand.getLogConfig) {
+        // We don't want to return transports since that's used internally.
         const { transports, ...partialLogConfig } = this.driver.getLogConfig();
         this.sendResultSuccess(msg.messageId, { config: partialLogConfig });
         return;

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -80,9 +80,8 @@ class Client {
       }
 
       if (msg.command === DriverCommand.getLogConfig) {
-        this.sendResultSuccess(msg.messageId, {
-          config: this.driver.getLogConfig(),
-        });
+        const { transports, ...logConfig } = this.driver.getLogConfig();
+        this.sendResultSuccess(msg.messageId, { config: logConfig });
         return;
       }
 

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -72,6 +72,12 @@ class Client {
         return;
       }
 
+      if (msg.command === "update_log_config") {
+        this.driver.updateLogConfig(msg.config);
+        this.sendResultSuccess(msg.messageId, { success: true });
+        return;
+      }
+
       const [instance] = msg.command.split(".");
       if (this.instanceHandlers[instance]) {
         return this.sendResultSuccess(

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -74,7 +74,7 @@ class Client {
 
       if (msg.command === "update_log_config") {
         this.driver.updateLogConfig(msg.config);
-        this.sendResultSuccess(msg.messageId, { success: true });
+        this.sendResultSuccess(msg.messageId, {});
         return;
       }
 

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -79,6 +79,13 @@ class Client {
         return;
       }
 
+      if (msg.command === DriverCommand.getLogConfig) {
+        this.sendResultSuccess(msg.messageId, {
+          config: this.driver.getLogConfig(),
+        });
+        return;
+      }
+
       const [instance] = msg.command.split(".");
       if (this.instanceHandlers[instance]) {
         return this.sendResultSuccess(


### PR DESCRIPTION
Related to #115 and zwave-js/node-zwave-js#1754. This will allow us to add support to get and update the log configuration in the Python library and then expose a UI in Home Assistant to get and update the log levels without having to restart the server.

Resolves #115