### PR TITLE
Bump zwave-js to 6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,13 @@
   "requires": true,
   "dependencies": {
     "@alcalzone/jsonl-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@alcalzone/jsonl-db/-/jsonl-db-1.2.3.tgz",
-      "integrity": "sha512-1LKEzZXR8c0WFC51+hym9PArZAjAyQDHMWmuBtp4oHKzh1Lisp6Ve4ihEJrgkKHiEla1IpSrLKDMCf2zbIwH8g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@alcalzone/jsonl-db/-/jsonl-db-1.2.4.tgz",
+      "integrity": "sha512-cnFdlBlPFeI3uXO1Nz7che91dD0YmTwJFTTCHevGHL8m/K0cLR3cYbZ1djudaTf5/dWNsfSCOyH91j9MTd1yjw==",
       "dev": true,
       "requires": {
-        "alcalzone-shared": "^3.0.1",
-        "fs-extra": "^9.0.1"
+        "alcalzone-shared": "^3.0.2",
+        "fs-extra": "^9.1.0"
       }
     },
     "@babel/code-frame": {
@@ -473,12 +473,12 @@
       }
     },
     "@zwave-js/config": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-6.2.0.tgz",
-      "integrity": "sha512-KUlOd4/nkqKpYLGj4j0sS2h0zj0WV5mnWgwFoXCAOgsac4Tv1KdqfDzuLz+WyO6L9eqD9oYcjTOfF10V+44jzQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-6.3.0.tgz",
+      "integrity": "sha512-hfMqQgC/R0v1lwrcJ/VmhVWjgjVMlrVTVJIcLkyW8LqHeuLRs6tKxftf/JkV45p9lNGVg/+hENApv044MQ1eoQ==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "^6.2.0",
+        "@zwave-js/core": "^6.3.0",
         "@zwave-js/shared": "^6.2.0",
         "alcalzone-shared": "^3.0.2",
         "ansi-colors": "^4.1.1",
@@ -489,9 +489,9 @@
       }
     },
     "@zwave-js/core": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-6.2.0.tgz",
-      "integrity": "sha512-JdYLOeb+gYK2pd1JP2wZXLsrYWbixbExinDroexx9OMkmu0UxH17TQ/jwIFrG0aVH54s0AEk8sp0hqQZ+Dkg3g==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-6.3.0.tgz",
+      "integrity": "sha512-0+gOIR2qqgn5pl6vw9erMNBpODEjwzLL/8bfgjY1nakR274A5A85AsMFHCXbgeFiCR9c7eUwRMPOgcQqJ8LkwQ==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^1.2.3",
@@ -505,12 +505,12 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-6.2.0.tgz",
-      "integrity": "sha512-PhHiTP1NvIiG7Uk+7a5ccttGiABJN6tWI7lViRV54PqIIuUKNb+ajlsmwlxcGFVW2VJZqCt2ZKwiCWq+krBe2A==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-6.3.0.tgz",
+      "integrity": "sha512-wof1LZNix56LQODpComnYO9GMb6h7m2plTQMcNw1AxiYkCaugHaZSDVaVccia5EjYjt+ONhD8WcvwCxvEag8qA==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "^6.2.0",
+        "@zwave-js/core": "^6.3.0",
         "alcalzone-shared": "^3.0.2",
         "serialport": "^9.0.1",
         "winston": "^3.3.3"
@@ -2384,9 +2384,9 @@
       }
     },
     "prebuild-install": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.0.tgz",
-      "integrity": "sha512-h2ZJ1PXHKWZpp1caLw0oX9sagVpL2YTk+ZwInQbQ3QqNd4J03O6MpFNmMTJlkfgPENWqe5kP0WjQLqz5OjLfsw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.1.tgz",
+      "integrity": "sha512-7GOJrLuow8yeiyv75rmvZyeMGzl8mdEX5gY69d6a6bHWmiPevwqFw+tQavhK0EYMaSg3/KD24cWqeQv1EWsqDQ==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3",
@@ -3184,17 +3184,17 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-6.2.0.tgz",
-      "integrity": "sha512-e/AODawVy3jmQd9eOXRErRN+ISw/vkLjPDOQGf0KR3a9ocL87ixyBdXrwtmP69P/yehOOlya+Rq5pvfPuVlbqA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-6.3.0.tgz",
+      "integrity": "sha512-qKYcLYCHSj/YSitYn5+CPLbnq+NKY8Efyy0MG8qY16piWNuNRVeBswtqC8lCt3M0KZINmaQPJa9lzBgriuWv2Q==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^1.2.3",
         "@sentry/integrations": "^5.24.2",
         "@sentry/node": "^5.24.2",
-        "@zwave-js/config": "^6.2.0",
-        "@zwave-js/core": "^6.2.0",
-        "@zwave-js/serial": "^6.2.0",
+        "@zwave-js/config": "^6.3.0",
+        "@zwave-js/core": "^6.3.0",
+        "@zwave-js/serial": "^6.3.0",
         "@zwave-js/shared": "^6.2.0",
         "alcalzone-shared": "^3.0.2",
         "ansi-colors": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ws": "^7.4.2"
   },
   "peerDependencies": {
-    "zwave-js": "^6.2"
+    "zwave-js": "^6.3"
   },
   "devDependencies": {
     "@types/node": "^14.14.20",
@@ -40,7 +40,7 @@
     "prettier": "^2.2.1",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3",
-    "zwave-js": "^6.2"
+    "zwave-js": "^6.3"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Replaces #112 and includes the necessary `package.json` changes