### PR TITLE
Check inside Server.start if driver is ready

### DIFF
--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -249,6 +249,9 @@ export class ZwavejsServer extends EventEmitter {
   }
 
   async start() {
+    if (!this.driver.ready) {
+      throw new Error("Cannot start server when driver not ready");
+    }
     this.server = createServer();
     this.wsServer = new ws.Server({ server: this.server });
     this.sockets = new Clients(this.driver, this.logger);

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -9,6 +9,8 @@ class MockController extends EventEmitter {
 class MockDriver extends EventEmitter {
   public controller = new MockController();
 
+  public ready = true;
+
   async start() {
     this.emit("driver ready");
   }


### PR DESCRIPTION
This will help libraries to correctly launch the server only when the driver is ready. This is currently happening in ZJS2MQTT (https://github.com/zwave-js/zwavejs2mqtt/issues/602) and can cause issues when a client reconnects too early.

Marking this as a draft because I don't want to merge this until ZJS2MQTT has time to handle it. 