### PR TITLE
Bump server version to 1.0.0-beta.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "description": "Full access to zwave-js driver throught Websockets",
   "main": "dist/lib/index.js",
   "bin": {


### PR DESCRIPTION
Follows https://github.com/zwave-js/zwave-js-server/pull/117 and #127 (Please merge those before merging this!)