### PR TITLE
Add node command to send raw Config CC values

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ interface {
 }
 ```
 
+### Controller level commands
+
+Refer to the [Z-Wave JS Controller methods documentation](https://zwave-js.github.io/node-zwave-js/#/api/controller?id=controller-methods) for more information on available commands. `zwave-js-server` uses [snake casing](https://en.wikipedia.org/wiki/Snake_case) for commands, so `beginInclusion` is called using the `node.begin_inclusion` command.
+
 ### Node level commands
 
 #### [Set value on a node](https://zwave-js.github.io/node-zwave-js/#/api/node?id=setvalue)

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ interface {
 
 ### Controller level commands
 
-Refer to the [Z-Wave JS Controller methods documentation](https://zwave-js.github.io/node-zwave-js/#/api/controller?id=controller-methods) for more information on available commands. `zwave-js-server` uses [snake casing](https://en.wikipedia.org/wiki/Snake_case) for commands, so `beginInclusion` is called using the `node.begin_inclusion` command.
+`zwave-js-server` supports all of the controller methods listed in the [Z-Wave JS documentation](https://zwave-js.github.io/node-zwave-js/#/api/controller?id=controller-methods). `zwave-js-server` uses [snake casing](https://en.wikipedia.org/wiki/Snake_case) for commands and prefixes every controller command with `controller.`, so `beginInclusion` is called using the `controller.begin_inclusion` command.
 
 ### Node level commands
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ interface {
 
 ## Client commands
 
-### Start listening to events
+### Server level commands
+
+#### Start listening to events
 
 ```ts
 interface {
@@ -112,23 +114,7 @@ interface {
 }
 ```
 
-### Set value on a node
-
-```ts
-interface {
-  messageId: string;
-  command: "node.set_value";
-  valueId: {
-    commandClass: CommandClasses;
-    endpoint?: number;
-    property: string | number;
-    propertyKey?: string | number;
-  },
-  value: any
-}
-```
-
-### Update the logging configuration
+#### Update the logging configuration
 
 > NOTE: You must provide at least one key/value pair as part of `config`
 
@@ -146,7 +132,7 @@ interface {
 }
 ```
 
-### Get the logging configuration
+#### Get the logging configuration
 
 ```ts
 interface {
@@ -166,6 +152,97 @@ interface {
     filename: string;
     forceConsole: boolean;
   }
+}
+```
+
+### Node level commands
+
+#### [Set value on a node](https://zwave-js.github.io/node-zwave-js/#/api/node?id=setvalue)
+
+```ts
+interface {
+  messageId: string;
+  command: "node.set_value";
+  nodeId: number;
+  valueId: {
+    commandClass: CommandClasses;
+    endpoint?: number;
+    property: string | number;
+    propertyKey?: string | number;
+  };
+  value: any;
+}
+```
+
+#### [Refresh node info](https://zwave-js.github.io/node-zwave-js/#/api/node?id=refreshinfo)
+
+```ts
+interface {
+  messageId: string;
+  command: "node.refresh_info";
+  nodeId: number;
+}
+```
+
+#### [Get defined Value IDs](https://zwave-js.github.io/node-zwave-js/#/api/node?id=getdefinedvalueids)
+
+```ts
+interface {
+  messageId: string;
+  command: "node.get_defined_value_ids";
+  nodeId: number;
+}
+```
+
+#### [Get value metadata](https://zwave-js.github.io/node-zwave-js/#/api/node?id=getvaluemetadata)
+
+```ts
+interface {
+  messageId: string;
+  command: "node.get_value_metadata";
+  nodeId: number;
+  valueId: {
+    commandClass: CommandClasses;
+    endpoint?: number;
+    property: string | number;
+    propertyKey?: string | number;
+  };
+}
+```
+
+#### [Abort Firmware Update](https://zwave-js.github.io/node-zwave-js/#/api/node?id=abortfirmwareupdate)
+
+```ts
+interface {
+  messageId: string;
+  command: "node.abort_firmware_update";
+  nodeId: number;
+}
+```
+
+#### [Poll value](https://zwave-js.github.io/node-zwave-js/#/api/node?id=pollvalue)
+
+```ts
+interface {
+  messageId: string;
+  command: "node.poll_value";
+  nodeId: number;
+  valueId: {
+    commandClass: CommandClasses;
+    endpoint?: number;
+    property: string | number;
+    propertyKey?: string | number;
+  };
+}
+```
+
+#### [Set raw configuration parameter value (Advanced)](https://zwave-js.github.io/node-zwave-js/#/api/CCs/Configuration?id=set)
+
+```ts
+interface {
+  messageId: string;
+  command: "node.set_raw_config_parameter_value";
+  nodeId: number;
 }
 ```
 

--- a/src/lib/node/command.ts
+++ b/src/lib/node/command.ts
@@ -5,4 +5,5 @@ export enum NodeCommand {
   getValueMetadata = "node.get_value_metadata",
   abortFirmwareUpdate = "node.abort_firmware_update",
   pollValue = "node.poll_value",
+  setRawConfigParameterValue = "node.set_raw_config_parameter_value",
 }

--- a/src/lib/node/incoming_message.ts
+++ b/src/lib/node/incoming_message.ts
@@ -1,4 +1,4 @@
-import { CommandClass, ConfigValue, ValueID } from "zwave-js";
+import { ConfigValue, ValueID } from "zwave-js";
 import { IncomingCommandBase } from "../incoming_message_base";
 import { NodeCommand } from "./command";
 

--- a/src/lib/node/incoming_message.ts
+++ b/src/lib/node/incoming_message.ts
@@ -1,4 +1,4 @@
-import { ValueID } from "zwave-js";
+import { CommandClass, ConfigValue, ValueID } from "zwave-js";
 import { IncomingCommandBase } from "../incoming_message_base";
 import { NodeCommand } from "./command";
 
@@ -37,10 +37,19 @@ export interface IncomingCommandNodePollValue extends IncomingCommandNodeBase {
   valueId: ValueID;
 }
 
+export interface IncomingCommandNodeSetRawConfigParameterValue
+  extends IncomingCommandNodeBase {
+  command: NodeCommand.setRawConfigParameterValue;
+  parameter: number;
+  value: ConfigValue;
+  valueSize: 1 | 2 | 4;
+}
+
 export type IncomingMessageNode =
   | IncomingCommandNodeSetValue
   | IncomingCommandNodeRefreshInfo
   | IncomingCommandNodeGetDefinedValueIDs
   | IncomingCommandNodeGetValueMetadata
   | IncomingCommandNodeAbortFirmwareUpdate
-  | IncomingCommandNodePollValue;
+  | IncomingCommandNodePollValue
+  | IncomingCommandNodeSetRawConfigParameterValue;

--- a/src/lib/node/message_handler.ts
+++ b/src/lib/node/message_handler.ts
@@ -34,6 +34,13 @@ export class NodeMessageHandler {
       case NodeCommand.pollValue:
         const value = await node.pollValue<any>(message.valueId);
         return { value };
+      case NodeCommand.setRawConfigParameterValue:
+        await node.commandClasses.Configuration.set(
+          message.parameter,
+          message.value,
+          message.valueSize
+        );
+        return {};
       default:
         throw new UnknownCommandError(command);
     }

--- a/src/lib/node/outgoing_message.ts
+++ b/src/lib/node/outgoing_message.ts
@@ -8,4 +8,5 @@ export interface NodeResultTypes {
   [NodeCommand.getValueMetadata]: ValueMetadata;
   [NodeCommand.abortFirmwareUpdate]: Record<string, never>;
   [NodeCommand.pollValue]: { value: any | undefined };
+  [NodeCommand.setRawConfigParameterValue]: Record<string, never>;
 }


### PR DESCRIPTION
One of the goals for the HA `set_config_parameter` service is to allow users to send raw values for bitwise parameters that are either split out into partial parameters if they are defined in the device config or as a single value without any metadata if they are not. This PR adds a node command that we can use for those use cases.