### PR TITLE
Extend dump to include full deviceclass object

### DIFF
--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -21,6 +21,7 @@ interface CommandClassState {
   id: number;
   name: string;
   version: number;
+  isSecure: boolean;
 }
 
 interface EndpointState extends Partial<Endpoint> {}
@@ -133,7 +134,7 @@ export const dumpNode = (node: ZWaveNode): NodeState => ({
   interviewAttempts: node.interviewAttempts,
   interviewStage: node.interviewStage,
   commandClasses: Array.from(node.getSupportedCCInstances(), (cc) =>
-    dumpCommandClass(cc)
+    dumpCommandClass(node, cc)
   ),
   endpoints: Array.from(node.getAllEndpoints(), (endpoint) =>
     dumpEndpoint(endpoint)
@@ -168,11 +169,13 @@ export const dumpDeviceClass = (
 });
 
 export const dumpCommandClass = (
+  node: ZWaveNode,
   commandClass: CommandClass
 ): CommandClassState => ({
   id: commandClass.ccId,
   name: CommandClasses[commandClass.ccId],
   version: commandClass.version,
+  isSecure: node.isCCSecure(commandClass.ccId),
 });
 
 export const dumpState = (driver: Driver): ZwaveState => {

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -24,28 +24,27 @@ interface CommandClassState {
   isSecure: boolean;
 }
 
-interface EndpointState extends Partial<Endpoint> {}
+type EndpointState = Partial<Endpoint>;
 
-interface DeviceClassState
-  extends Partial<
-    Modify<
-      DeviceClass,
-      {
-        basic: {
-          key: number;
-          label: string;
-        };
-        generic: {
-          key: number;
-          label: string;
-        };
-        specific: {
-          key: number;
-          label: string;
-        };
-      }
-    >
-  > {}
+type DeviceClassState = Partial<
+  Modify<
+    DeviceClass,
+    {
+      basic: {
+        key: number;
+        label: string;
+      };
+      generic: {
+        key: number;
+        label: string;
+      };
+      specific: {
+        key: number;
+        label: string;
+      };
+    }
+  >
+>;
 
 interface ValueState extends TranslatedValueID {
   metadata: ValueMetadata;
@@ -53,18 +52,17 @@ interface ValueState extends TranslatedValueID {
   value?: any;
 }
 
-interface NodeState
-  extends Partial<
-    Modify<
-      ZWaveNode,
-      {
-        deviceClass: DeviceClassState;
-        commandClasses: CommandClassState[];
-        endpoints: EndpointState[];
-        values: ValueState[];
-      }
-    >
-  > {}
+type NodeState = Partial<
+  Modify<
+    ZWaveNode,
+    {
+      deviceClass: DeviceClassState;
+      commandClasses: CommandClassState[];
+      endpoints: EndpointState[];
+      values: ValueState[];
+    }
+  >
+>;
 
 function getNodeValues(node: ZWaveNode): ValueState[] {
   if (!node.ready) {

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -6,13 +6,21 @@ import {
   TranslatedValueID,
   ValueMetadata,
   DeviceClass,
+  CommandClass,
 } from "zwave-js";
+import { CommandClasses } from "@zwave-js/core";
 
 type Modify<T, R> = Omit<T, keyof R> & R;
 
 export interface ZwaveState {
   controller: Partial<ZWaveController>;
   nodes: NodeState[];
+}
+
+interface CommandClassState {
+  id: number;
+  name: string;
+  version: number;
 }
 
 interface EndpointState extends Partial<Endpoint> {}
@@ -50,6 +58,7 @@ interface NodeState
       ZWaveNode,
       {
         deviceClass: DeviceClassState;
+        commandClasses: CommandClassState[];
         endpoints: EndpointState[];
         values: ValueState[];
       }
@@ -123,6 +132,9 @@ export const dumpNode = (node: ZWaveNode): NodeState => ({
   aggregatedEndpointCount: node.aggregatedEndpointCount,
   interviewAttempts: node.interviewAttempts,
   interviewStage: node.interviewStage,
+  commandClasses: Array.from(node.getSupportedCCInstances(), (cc) =>
+    dumpCommandClass(cc)
+  ),
   endpoints: Array.from(node.getAllEndpoints(), (endpoint) =>
     dumpEndpoint(endpoint)
   ),
@@ -153,6 +165,14 @@ export const dumpDeviceClass = (
   },
   mandatorySupportedCCs: deviceClass.mandatorySupportedCCs,
   mandatoryControlledCCs: deviceClass.mandatoryControlledCCs,
+});
+
+export const dumpCommandClass = (
+  commandClass: CommandClass
+): CommandClassState => ({
+  id: commandClass.ccId,
+  name: CommandClasses[commandClass.ccId],
+  version: commandClass.version,
 });
 
 export const dumpState = (driver: Driver): ZwaveState => {


### PR DESCRIPTION
**BREAKING CHANGE**

DeviceClass strings tend to change sometimes which is annoying as our discovery scheme in HA depends a lot on these deviceclass id's.

This change replaces the deviceClass to a full object containing both the key and label.

Discussed with @MartinHjelmare that we should do this breaking change before HA beta release (and adjust both integration and the lib for this change).

Closes #76
Closes #75 

The dump will look like this after this change:

```
"deviceClass": {
            "basic": {
              "key": 2,
              "label": "Static Controller"
            },
            "generic": {
              "key": 2,
              "label": "Static Controller"
            },
            "specific": {
              "key": 1,
              "label": "PC Controller"
            },
            "mandatorySupportedCCs": [
              
            ],
            "mandatoryControlledCCs": [
              32
            ]
          },
```