### PR TITLE
Make old device class value available for backwards compat

### DIFF
--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -56,7 +56,7 @@ type NodeState = Partial<
   Modify<
     ZWaveNode,
     {
-      deviceClass: DeviceClassState;
+      deviceClassFull: DeviceClassState;
       commandClasses: CommandClassState[];
       endpoints: EndpointState[];
       values: ValueState[];
@@ -105,7 +105,9 @@ export const dumpNode = (node: ZWaveNode): NodeState => ({
   userIcon: node.userIcon,
   status: node.status,
   ready: node.ready,
-  deviceClass: dumpDeviceClass(node.deviceClass),
+  // This is for legacy compat with server < 1.0.0
+  deviceClass: node.deviceClass,
+  deviceClassFull: dumpDeviceClass(node.deviceClass),
   isListening: node.isListening,
   isFrequentListening: node.isFrequentListening,
   isRouting: node.isRouting,


### PR DESCRIPTION
This makes the old device class field available for better backwards compat with server <1.0.0. We can update the new Python lib to read the right field and require a newer server version.

This way the old HA installation can still function mostly with the newer server and we don't have to block it. 

I understand that this too is not ideal, as the thermostat is still broken. But at least most things work. We need to find a better solution inside HA for the next time.

This is a proposal. What do people think?

CC @marcelveldt @MartinHjelmare @raman325 