### PR TITLE
Add basic schema version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ interface {
 ```
 
 To start receive the state and get events, the client needs to send the `start_listening` command.
-See below for info about schemeVersion.
+See below for info about schemaVersion.
 
 ```ts
 interface {
   messageId: string;
   command: "start_listening";
-  schemeVersion: 1;
+  schemaVersion: 1;
 }
 ```
 
@@ -113,13 +113,13 @@ interface {
 interface {
   messageId: string;
   command: "start_listening";
-  schemeVersion: 1;
+  schemaVersion: 1;
 }
 ```
 
 #### Update the logging configuration
 
-[compatible with scheme version: 1+]
+[compatible with schema version: 1+]
 
 > NOTE: You must provide at least one key/value pair as part of `config`
 
@@ -139,7 +139,7 @@ interface {
 
 #### Get the logging configuration
 
-[compatible with scheme version: 1+]
+[compatible with schema version: 1+]
 
 ```ts
 interface {
@@ -170,7 +170,7 @@ interface {
 
 #### [Set value on a node](https://zwave-js.github.io/node-zwave-js/#/api/node?id=setvalue)
 
-[compatible with scheme version: 0+]
+[compatible with schema version: 0+]
 
 ```ts
 interface {
@@ -189,7 +189,7 @@ interface {
 
 #### [Refresh node info](https://zwave-js.github.io/node-zwave-js/#/api/node?id=refreshinfo)
 
-[compatible with scheme version: 0+]
+[compatible with schema version: 0+]
 
 ```ts
 interface {
@@ -201,7 +201,7 @@ interface {
 
 #### [Get defined Value IDs](https://zwave-js.github.io/node-zwave-js/#/api/node?id=getdefinedvalueids)
 
-[compatible with scheme version: 0+]
+[compatible with schema version: 0+]
 
 ```ts
 interface {
@@ -213,7 +213,7 @@ interface {
 
 #### [Get value metadata](https://zwave-js.github.io/node-zwave-js/#/api/node?id=getvaluemetadata)
 
-[compatible with scheme version: 0+]
+[compatible with schema version: 0+]
 
 ```ts
 interface {
@@ -231,7 +231,7 @@ interface {
 
 #### [Abort Firmware Update](https://zwave-js.github.io/node-zwave-js/#/api/node?id=abortfirmwareupdate)
 
-[compatible with scheme version: 0+]
+[compatible with schema version: 0+]
 
 ```ts
 interface {
@@ -243,7 +243,7 @@ interface {
 
 #### [Poll value](https://zwave-js.github.io/node-zwave-js/#/api/node?id=pollvalue)
 
-[compatible with scheme version: 1+]
+[compatible with schema version: 1+]
 
 ```ts
 interface {
@@ -261,7 +261,7 @@ interface {
 
 #### [Set raw configuration parameter value (Advanced)](https://zwave-js.github.io/node-zwave-js/#/api/CCs/Configuration?id=set)
 
-[compatible with scheme version: 1+]
+[compatible with schema version: 1+]
 
 ```ts
 interface {
@@ -271,11 +271,11 @@ interface {
 }
 ```
 
-## Scheme Version
+## Schema Version
 
-In an attempt to keep compatibility between different server and client versions, we introduced a (basic) API Scheme Version.
+In an attempt to keep compatibility between different server and client versions, we introduced a (basic) API Schema Version.
 
-1. **client connects** --> server sends back version info including the scheme versions it can handle:
+1. **client connects** --> server sends back version info including the schema versions it can handle:
 
    ```json
    {
@@ -283,40 +283,40 @@ In an attempt to keep compatibility between different server and client versions
      "driverVersion": "6.5.0",
      "serverVersion": "1.0.0",
      "homeId": 3967882672,
-     "minSchemeVersion": 0,
-     "maxSchemeVersion": 1
+     "minSchemaVersion": 0,
+     "maxSchemaVersion": 1
    }
    ```
 
-2. **Client decides what to do based on supported scheme version**.
-   For example drop connection if the supported server scheme is too old or just handle the supported scheme itself. For example most/all basic commands will just work but relatively new commands won't and the client decides to only not handle the stuff in the upgraded scheme.
+2. **Client decides what to do based on supported schema version**.
+   For example drop connection if the supported server schema is too old or just handle the supported schema itself. For example most/all basic commands will just work but relatively new commands won't and the client decides to only not handle the stuff in the upgraded schema.
 
-3. **Client needs to tell the server what scheme it wants to use.** This is done in the "start_listening" command:
+3. **Client needs to tell the server what schema it wants to use.** This is done in the "start_listening" command:
 
    ```json
    {
      "command": "start_listening",
      "messageId": 1,
-     "schemeVersion": 1
+     "schemaVersion": 1
    }
    ```
 
-   From this moment the server knows how to treat commands to/from this client. The server can handle multiple clients with different scheme versions.
+   From this moment the server knows how to treat commands to/from this client. The server can handle multiple clients with different schema versions.
 
-4. If no **scheme version parameter is provided** in the start_listening command, the server will use the **minimal Scheme version** (which is 0 at this time).
+4. If no **schema version parameter is provided** in the start_listening command, the server will use the **minimal Schema version** (which is 0 at this time).
 
-5. If the client sends a scheme version which is **out of range**, this will produce an error to the client an in the server's log:
+5. If the client sends a schema version which is **out of range**, this will produce an error to the client an in the server's log:
 
    ```json
    {
      "command": "start_listening",
      "messageId": 1,
-     "schemeVersion": 3
+     "schemaVersion": 3
    }
-   {"type":"result","success":false,"messageId":1,"errorCode":"scheme_incompatible"}
+   {"type":"result","success":false,"messageId":1,"errorCode":"schema_incompatible"}
    ```
 
-6. When we make **breaking changes** in the api, we **bump the scheme version**. When adding new commands/features, we also bump the api scheme and note in both code comments and documentation to which scheme version that feature is compatible with.
+6. When we make **breaking changes** in the api, we **bump the schema version**. When adding new commands/features, we also bump the api schema and note in both code comments and documentation to which schema version that feature is compatible with.
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ In an attempt to keep compatibility between different server and client versions
 
    From this moment the server knows how to treat commands to/from this client. The server can handle multiple clients with different schema versions.
 
-4. By default the server will use the minimum schema it supports if the `set_api_schema` command is omitted (which is 0 at this time).
+4. By default the server will use the minimum schema it supports (which is 0 at this time) if the `set_api_schema` command is omitted.
 
 5. If the client sends a schema version which is **out of range**, this will produce an error to the client and in the server's log:
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ interface {
 interface {
   messageId: string;
   command: "start_listening";
-  schemaVersion: 1;
 }
 ```
 
@@ -301,7 +300,7 @@ In an attempt to keep compatibility between different server and client versions
 
    From this moment the server knows how to treat commands to/from this client. The server can handle multiple clients with different schema versions.
 
-4. By default the server will use the minimum schema it supports if this command is omitted (which is 0 at this time).
+4. By default the server will use the minimum schema it supports if the `set_api_schema` command is omitted (which is 0 at this time).
 
 5. If the client sends a schema version which is **out of range**, this will produce an error to the client and in the server's log:
 

--- a/README.md
+++ b/README.md
@@ -62,13 +62,11 @@ interface {
 ```
 
 To start receive the state and get events, the client needs to send the `start_listening` command.
-See below for info about schemaVersion.
 
 ```ts
 interface {
   messageId: string;
   command: "start_listening";
-  schemaVersion: 1;
 }
 ```
 
@@ -291,11 +289,11 @@ In an attempt to keep compatibility between different server and client versions
 2. **Client decides what to do based on supported schema version**.
    For example drop connection if the supported server schema is too old or just handle the supported schema itself. For example most/all basic commands will just work but relatively new commands won't and the client decides to only not handle the stuff in the upgraded schema.
 
-3. **Client needs to tell the server what schema it wants to use.** This is done in the "start_listening" command:
+3. **Client needs to tell the server what schema it wants to use.** This is done with the "set_api_schema" command:
 
    ```json
    {
-     "command": "start_listening",
+     "command": "set_api_schema",
      "messageId": 1,
      "schemaVersion": 1
    }
@@ -303,13 +301,13 @@ In an attempt to keep compatibility between different server and client versions
 
    From this moment the server knows how to treat commands to/from this client. The server can handle multiple clients with different schema versions.
 
-4. If no **schema version parameter is provided** in the start_listening command, the server will use the **minimal Schema version** (which is 0 at this time).
+4. By default the server will use the minimum schema it supports if this command is omitted (which is 0 at this time).
 
 5. If the client sends a schema version which is **out of range**, this will produce an error to the client and in the server's log:
 
    ```json
    {
-     "command": "start_listening",
+     "command": "set_api_schema",
      "messageId": 1,
      "schemaVersion": 3
    }

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ In an attempt to keep compatibility between different server and client versions
 
 4. If no **schema version parameter is provided** in the start_listening command, the server will use the **minimal Schema version** (which is 0 at this time).
 
-5. If the client sends a schema version which is **out of range**, this will produce an error to the client an in the server's log:
+5. If the client sends a schema version which is **out of range**, this will produce an error to the client and in the server's log:
 
    ```json
    {

--- a/README.md
+++ b/README.md
@@ -62,11 +62,13 @@ interface {
 ```
 
 To start receive the state and get events, the client needs to send the `start_listening` command.
+See below for info about schemeVersion.
 
 ```ts
 interface {
   messageId: string;
   command: "start_listening";
+  schemeVersion: 1;
 }
 ```
 
@@ -111,10 +113,13 @@ interface {
 interface {
   messageId: string;
   command: "start_listening";
+  schemeVersion: 1;
 }
 ```
 
 #### Update the logging configuration
+
+[compatible with scheme version: 1+]
 
 > NOTE: You must provide at least one key/value pair as part of `config`
 
@@ -133,6 +138,8 @@ interface {
 ```
 
 #### Get the logging configuration
+
+[compatible with scheme version: 1+]
 
 ```ts
 interface {
@@ -163,6 +170,8 @@ interface {
 
 #### [Set value on a node](https://zwave-js.github.io/node-zwave-js/#/api/node?id=setvalue)
 
+[compatible with scheme version: 0+]
+
 ```ts
 interface {
   messageId: string;
@@ -180,6 +189,8 @@ interface {
 
 #### [Refresh node info](https://zwave-js.github.io/node-zwave-js/#/api/node?id=refreshinfo)
 
+[compatible with scheme version: 0+]
+
 ```ts
 interface {
   messageId: string;
@@ -190,6 +201,8 @@ interface {
 
 #### [Get defined Value IDs](https://zwave-js.github.io/node-zwave-js/#/api/node?id=getdefinedvalueids)
 
+[compatible with scheme version: 0+]
+
 ```ts
 interface {
   messageId: string;
@@ -199,6 +212,8 @@ interface {
 ```
 
 #### [Get value metadata](https://zwave-js.github.io/node-zwave-js/#/api/node?id=getvaluemetadata)
+
+[compatible with scheme version: 0+]
 
 ```ts
 interface {
@@ -216,6 +231,8 @@ interface {
 
 #### [Abort Firmware Update](https://zwave-js.github.io/node-zwave-js/#/api/node?id=abortfirmwareupdate)
 
+[compatible with scheme version: 0+]
+
 ```ts
 interface {
   messageId: string;
@@ -225,6 +242,8 @@ interface {
 ```
 
 #### [Poll value](https://zwave-js.github.io/node-zwave-js/#/api/node?id=pollvalue)
+
+[compatible with scheme version: 1+]
 
 ```ts
 interface {
@@ -242,6 +261,8 @@ interface {
 
 #### [Set raw configuration parameter value (Advanced)](https://zwave-js.github.io/node-zwave-js/#/api/CCs/Configuration?id=set)
 
+[compatible with scheme version: 1+]
+
 ```ts
 interface {
   messageId: string;
@@ -249,6 +270,53 @@ interface {
   nodeId: number;
 }
 ```
+
+## Scheme Version
+
+In an attempt to keep compatibility between different server and client versions, we introduced a (basic) API Scheme Version.
+
+1. **client connects** --> server sends back version info including the scheme versions it can handle:
+
+   ```json
+   {
+     "type": "version",
+     "driverVersion": "6.5.0",
+     "serverVersion": "1.0.0",
+     "homeId": 3967882672,
+     "minSchemeVersion": 0,
+     "maxSchemeVersion": 1
+   }
+   ```
+
+2. **Client decides what to do based on supported scheme version**.
+   For example drop connection if the supported server scheme is too old or just handle the supported scheme itself. For example most/all basic commands will just work but relatively new commands won't and the client decides to only not handle the stuff in the upgraded scheme.
+
+3. **Client needs to tell the server what scheme it wants to use.** This is done in the "start_listening" command:
+
+   ```json
+   {
+     "command": "start_listening",
+     "messageId": 1,
+     "schemeVersion": 1
+   }
+   ```
+
+   From this moment the server knows how to treat commands to/from this client. The server can handle multiple clients with different scheme versions.
+
+4. If no **scheme version parameter is provided** in the start_listening command, the server will use the **minimal Scheme version** (which is 0 at this time).
+
+5. If the client sends a scheme version which is **out of range**, this will produce an error to the client an in the server's log:
+
+   ```json
+   {
+     "command": "start_listening",
+     "messageId": 1,
+     "schemeVersion": 3
+   }
+   {"type":"result","success":false,"messageId":1,"errorCode":"scheme_incompatible"}
+   ```
+
+6. When we make **breaking changes** in the api, we **bump the scheme version**. When adding new commands/features, we also bump the api scheme and note in both code comments and documentation to which scheme version that feature is compatible with.
 
 ## Authentication
 

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -2,4 +2,5 @@ export enum DriverCommand {
   startListening = "start_listening",
   updateLogConfig = "update_log_config",
   getLogConfig = "get_log_config",
+  setApiSchema = "set_api_schema",
 }

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -1,7 +1,7 @@
 export const version = require("../../package.json").version;
 
-// minimal scheme version the server supports
-export const minSchemeVersion = 0;
+// minimal schema version the server supports
+export const minSchemaVersion = 0;
 
-// maximal/current scheme version the server supports
-export const maxSchemeVersion = 1;
+// maximal/current schema version the server supports
+export const maxSchemaVersion = 1;

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -1,1 +1,7 @@
 export const version = require("../../package.json").version;
+
+// minimal scheme version the server supports
+export const minSchemeVersion = 0;
+
+// maximal/current scheme version the server supports
+export const maxSchemeVersion = 1;

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -2,6 +2,7 @@ export enum ErrorCode {
   unknownError = "unknown_error",
   unknownCommand = "unknown_command",
   nodeNotFound = "node_not_found",
+  schemeIncompatible = "scheme_incompatible",
 }
 
 export class BaseError extends Error {
@@ -28,6 +29,14 @@ export class NodeNotFoundError extends BaseError {
   errorCode = ErrorCode.nodeNotFound;
 
   constructor(public nodeId: number) {
+    super();
+  }
+}
+
+export class SchemeIncompatibleError extends BaseError {
+  errorCode = ErrorCode.schemeIncompatible;
+
+  constructor(public schemeId: number) {
     super();
   }
 }

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -2,7 +2,7 @@ export enum ErrorCode {
   unknownError = "unknown_error",
   unknownCommand = "unknown_command",
   nodeNotFound = "node_not_found",
-  schemeIncompatible = "scheme_incompatible",
+  schemaIncompatible = "schema_incompatible",
 }
 
 export class BaseError extends Error {
@@ -33,10 +33,10 @@ export class NodeNotFoundError extends BaseError {
   }
 }
 
-export class SchemeIncompatibleError extends BaseError {
-  errorCode = ErrorCode.schemeIncompatible;
+export class SchemaIncompatibleError extends BaseError {
+  errorCode = ErrorCode.schemaIncompatible;
 
-  constructor(public schemeId: number) {
+  constructor(public schemaId: number) {
     super();
   }
 }

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -117,7 +117,7 @@ export class EventForwarder {
           source: "node",
           event: "ready",
           nodeId: changedNode.nodeId,
-          node: dumpNode(changedNode, client.schemaVersion),
+          nodeState: dumpNode(changedNode, client.schemaVersion),
         })
       );
     });

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -25,12 +25,12 @@ export class EventForwarder {
     // https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/controller/Controller.ts#L112
 
     this.clients.driver.controller.on("node added", (node: ZWaveNode) => {
-      // forward event to all connected clients, respecting schemeVersion it supports
+      // forward event to all connected clients, respecting schemaVersion it supports
       this.clients.clients.forEach((client) =>
         this.sendEvent(client, {
           source: "controller",
           event: "node added",
-          node: dumpNode(node, client.schemeVersion),
+          node: dumpNode(node, client.schemaVersion),
         })
       );
       this.setupNode(node);
@@ -62,12 +62,12 @@ export class EventForwarder {
       })
     );
     this.clients.driver.controller.on("node removed", (node) =>
-      // forward event to all connected clients, respecting schemeVersion it supports
+      // forward event to all connected clients, respecting schemaVersion it supports
       this.clients.clients.forEach((client) =>
         this.sendEvent(client, {
           source: "controller",
           event: "node removed",
-          node: dumpNode(node, client.schemeVersion),
+          node: dumpNode(node, client.schemaVersion),
         })
       )
     );
@@ -117,7 +117,7 @@ export class EventForwarder {
           source: "node",
           event: "ready",
           nodeId: changedNode.nodeId,
-          ...dumpNode(changedNode, client.schemeVersion),
+          ...dumpNode(changedNode, client.schemaVersion),
         })
       );
     });

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -117,7 +117,7 @@ export class EventForwarder {
           source: "node",
           event: "ready",
           nodeId: changedNode.nodeId,
-          ...dumpNode(changedNode, client.schemaVersion),
+          node: dumpNode(changedNode, client.schemaVersion),
         })
       );
     });

--- a/src/lib/incoming_message.ts
+++ b/src/lib/incoming_message.ts
@@ -6,7 +6,7 @@ import { IncomingMessageNode } from "./node/incoming_message";
 
 interface IncomingCommandStartListening extends IncomingCommandBase {
   command: DriverCommand.startListening;
-  schemeVersion: number | undefined;
+  schemaVersion: number | undefined;
 }
 
 interface IncomingCommandUpdateLogConfig extends IncomingCommandBase {

--- a/src/lib/incoming_message.ts
+++ b/src/lib/incoming_message.ts
@@ -6,6 +6,7 @@ import { IncomingMessageNode } from "./node/incoming_message";
 
 interface IncomingCommandStartListening extends IncomingCommandBase {
   command: DriverCommand.startListening;
+  schemeVersion: number | undefined;
 }
 
 interface IncomingCommandUpdateLogConfig extends IncomingCommandBase {

--- a/src/lib/incoming_message.ts
+++ b/src/lib/incoming_message.ts
@@ -6,7 +6,6 @@ import { IncomingMessageNode } from "./node/incoming_message";
 
 interface IncomingCommandStartListening extends IncomingCommandBase {
   command: DriverCommand.startListening;
-  schemaVersion: number | undefined;
 }
 
 interface IncomingCommandUpdateLogConfig extends IncomingCommandBase {
@@ -18,9 +17,15 @@ interface IncomingCommandGetLogConfig extends IncomingCommandBase {
   command: DriverCommand.getLogConfig;
 }
 
+interface IncomingCommandSetApiSchema extends IncomingCommandBase {
+  command: DriverCommand.setApiSchema;
+  schemaVersion: number;
+}
+
 export type IncomingMessage =
   | IncomingCommandStartListening
   | IncomingCommandUpdateLogConfig
   | IncomingCommandGetLogConfig
+  | IncomingCommandSetApiSchema
   | IncomingMessageNode
   | IncomingMessageController;

--- a/src/lib/outgoing_message.ts
+++ b/src/lib/outgoing_message.ts
@@ -15,8 +15,8 @@ interface OutgoingVersionMessage {
   driverVersion: string;
   serverVersion: string;
   homeId: number | undefined;
-  minSchemeVersion: number;
-  maxSchemeVersion: number;
+  minSchemaVersion: number;
+  maxSchemaVersion: number;
 }
 
 interface OutgoingEventMessage {

--- a/src/lib/outgoing_message.ts
+++ b/src/lib/outgoing_message.ts
@@ -15,6 +15,8 @@ interface OutgoingVersionMessage {
   driverVersion: string;
   serverVersion: string;
   homeId: number | undefined;
+  minSchemeVersion: number;
+  maxSchemeVersion: number;
 }
 
 interface OutgoingEventMessage {

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -8,14 +8,14 @@ import { IncomingMessage } from "./incoming_message";
 import { dumpState } from "./state";
 import { Server as HttpServer, createServer } from "http";
 import { EventEmitter, once } from "events";
-import { version, minSchemeVersion, maxSchemeVersion } from "./const";
+import { version, minSchemaVersion, maxSchemaVersion } from "./const";
 import { NodeMessageHandler } from "./node/message_handler";
 import { ControllerMessageHandler } from "./controller/message_handler";
 import { IncomingMessageController } from "./controller/incoming_message";
 import {
   BaseError,
   ErrorCode,
-  SchemeIncompatibleError,
+  SchemaIncompatibleError,
   UnknownCommandError,
 } from "./error";
 import { Instance } from "./instance";
@@ -25,7 +25,7 @@ import { DriverCommand } from "./command";
 export class Client {
   public receiveEvents = false;
   private _outstandingPing = false;
-  public schemeVersion = minSchemeVersion;
+  public schemaVersion = minSchemaVersion;
 
   private instanceHandlers: Record<
     Instance,
@@ -73,17 +73,17 @@ export class Client {
 
     try {
       if (msg.command === DriverCommand.startListening) {
-        // Handle scheme version
-        this.schemeVersion = msg.schemeVersion | minSchemeVersion;
+        // Handle schema version
+        this.schemaVersion = msg.schemaVersion | minSchemaVersion;
         if (
-          this.schemeVersion < minSchemeVersion ||
-          this.schemeVersion > maxSchemeVersion
+          this.schemaVersion < minSchemaVersion ||
+          this.schemaVersion > maxSchemaVersion
         ) {
-          throw new SchemeIncompatibleError(this.schemeVersion);
+          throw new SchemaIncompatibleError(this.schemaVersion);
         }
 
         this.sendResultSuccess(msg.messageId, {
-          state: dumpState(this.driver, this.schemeVersion),
+          state: dumpState(this.driver, this.schemaVersion),
         });
         this.receiveEvents = true;
         return;
@@ -128,8 +128,8 @@ export class Client {
       driverVersion: libVersion,
       serverVersion: version,
       homeId: this.driver.controller.homeId,
-      minSchemeVersion: minSchemeVersion,
-      maxSchemeVersion: maxSchemeVersion,
+      minSchemaVersion: minSchemaVersion,
+      maxSchemaVersion: maxSchemaVersion,
     });
   }
 

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -72,16 +72,21 @@ export class Client {
     }
 
     try {
-      if (msg.command === DriverCommand.startListening) {
+      if (msg.command === DriverCommand.setApiSchema) {
         // Handle schema version
-        this.schemaVersion = msg.schemaVersion | minSchemaVersion;
+        this.schemaVersion = msg.schemaVersion;
         if (
           this.schemaVersion < minSchemaVersion ||
           this.schemaVersion > maxSchemaVersion
         ) {
           throw new SchemaIncompatibleError(this.schemaVersion);
         }
+        this.sendResultSuccess(msg.messageId, {});
+        this.receiveEvents = true;
+        return;
+      }
 
+      if (msg.command === DriverCommand.startListening) {
         this.sendResultSuccess(msg.messageId, {
           state: dumpState(this.driver, this.schemaVersion),
         });

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -100,7 +100,7 @@ export const dumpValue = (
 
 export const dumpNode = (
   node: ZWaveNode,
-  schemeVersion: number
+  schemaVersion: number
 ): NodeState => ({
   nodeId: node.nodeId,
   index: node.index,
@@ -108,9 +108,9 @@ export const dumpNode = (
   userIcon: node.userIcon,
   status: node.status,
   ready: node.ready,
-  // deviceclass dump is extended in schemeVersion 1+
+  // deviceclass dump is extended in schemaVersion 1+
   deviceClass:
-    schemeVersion === 0 ? node.deviceClass : dumpDeviceClass(node.deviceClass),
+    schemaVersion === 0 ? node.deviceClass : dumpDeviceClass(node.deviceClass),
   isListening: node.isListening,
   isFrequentListening: node.isFrequentListening,
   isRouting: node.isRouting,
@@ -136,9 +136,9 @@ export const dumpNode = (
   aggregatedEndpointCount: node.aggregatedEndpointCount,
   interviewAttempts: node.interviewAttempts,
   interviewStage: node.interviewStage,
-  // CommandClasses dump supported from schemeVersion 1+
+  // CommandClasses dump supported from schemaVersion 1+
   commandClasses:
-    schemeVersion >= 1
+    schemaVersion >= 1
       ? Array.from(node.getSupportedCCInstances(), (cc) =>
           dumpCommandClass(node, cc)
         )
@@ -187,7 +187,7 @@ export const dumpCommandClass = (
 
 export const dumpState = (
   driver: Driver,
-  schemeVersion: number
+  schemaVersion: number
 ): ZwaveState => {
   const controller = driver.controller;
   return {
@@ -211,7 +211,7 @@ export const dumpState = (
       supportsTimers: controller.supportsTimers,
     },
     nodes: Array.from(controller.nodes.values(), (node) =>
-      dumpNode(node, schemeVersion)
+      dumpNode(node, schemaVersion)
     ),
   };
 };

--- a/src/test/integration.ts
+++ b/src/test/integration.ts
@@ -3,6 +3,7 @@ import ws from "ws";
 import { libVersion } from "zwave-js";
 import { ZwavejsServer } from "../lib/server";
 import { createMockDriver } from "../mock";
+import { minSchemeVersion, maxSchemeVersion } from "../lib/const";
 
 const PORT = 45001;
 
@@ -45,6 +46,8 @@ const runTest = async () => {
       driverVersion: libVersion,
       homeId: 1,
       serverVersion: require("../../package.json").version,
+      minSchemeVersion: minSchemeVersion,
+      maxSchemeVersion: maxSchemeVersion,
       type: "version",
     });
 

--- a/src/test/integration.ts
+++ b/src/test/integration.ts
@@ -3,7 +3,7 @@ import ws from "ws";
 import { libVersion } from "zwave-js";
 import { ZwavejsServer } from "../lib/server";
 import { createMockDriver } from "../mock";
-import { minSchemeVersion, maxSchemeVersion } from "../lib/const";
+import { minSchemaVersion, maxSchemaVersion } from "../lib/const";
 
 const PORT = 45001;
 
@@ -46,8 +46,8 @@ const runTest = async () => {
       driverVersion: libVersion,
       homeId: 1,
       serverVersion: require("../../package.json").version,
-      minSchemeVersion: minSchemeVersion,
-      maxSchemeVersion: maxSchemeVersion,
+      minSchemaVersion: minSchemaVersion,
+      maxSchemaVersion: maxSchemaVersion,
       type: "version",
     });
 


### PR DESCRIPTION
Like discussed we're seeking for a way to be compatible between server and HA versions.
I've implemented a very basic api schema for this.

1) client connects --> server sends back version info including the schema versions it can handle:

`
{"type":"version","driverVersion":"6.5.0","serverVersion":"1.0.0","homeId":3967882672,"minSchemaVersion":0,"maxSchemaVersion":1}
`

2) Client decides what to do. For example drop connection if the supported server schema is too old or just handle the supported scheme itself. For example most/all basic commands will just work but relatively new commands won't and the client decides to only not handle the stuff in the upgraded scheme.


3) Client needs to tell the server what schema it wants to use. This is done in the "start_listening" command:

`
{
  "command": "start_listening",
  "messageId": 1,
  "schemaVersion": 1
}
`

From this moment the server knows how to treat commands to/from this client. The server can handle multiple clients with different schema versions.

4) If no schema version parameter is provided in the start_listening command, the server will use the minimal Schema version (which is 0 at this time).

5) If the client sends a schema version which is out of range, this will produce an error to the client an in the server's log:

`
{
  "command": "start_listening",
  "messageId": 1,
  "schemaVersion": 3
}
{"type":"result","success":false,"messageId":1,"errorCode":"schema_incompatible"}
`

6) When we make breaking changes in the api, we should bump the schema version. When adding new commands/features, also bump the api schema and note in both code comments and documentation to which schema version that feature is compatible with.