### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "description": "Full access to zwave-js driver through Websockets",
   "main": "dist/lib/index.js",
   "bin": {


### PR DESCRIPTION
We can't use version 2.0.0 because it is rejected by old HA installations. So instead let's go to 1.1.0