### PR TITLE
Client should only receive events after start_listening command is received and state is sent

### DIFF
--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -82,7 +82,6 @@ export class Client {
           throw new SchemaIncompatibleError(this.schemaVersion);
         }
         this.sendResultSuccess(msg.messageId, {});
-        this.receiveEvents = true;
         return;
       }
 


### PR DESCRIPTION
I believe the reason why we are getting events before the state dump is because we set `client.receiveEvents` too early. We should only start forwarding events after `start_listening` is received and the state dump has been sent.

For reference, here's where the logic lives to determine whether or not we forward events: https://github.com/zwave-js/zwave-js-server/blob/master/src/lib/forward.ts#L97