### PR TITLE
Fix notification event, add missing properties, and update client to accept schemaVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ You can filter the output by a specific node ID:
 ts-node src/bin/client.ts --node 52
 ```
 
+To specify a schema version other than the latest (`maxSchemaVersion`):
+
+```shell
+ts-node src/bin/client.ts --schemaVersion 0
+```
+
 All these options can be combined.
 
 ## API

--- a/src/bin/client.ts
+++ b/src/bin/client.ts
@@ -19,11 +19,8 @@ const schemaVersion = args.schemaVersion
 const url = args._[0] || "ws://localhost:3000";
 const filterNode = args.node ? Number(args.node) : undefined;
 
-if (schemaVersion > maxSchemaVersion) {
-  console.log(
-    "Schema version must be less than or equal to ",
-    maxSchemaVersion
-  );
+if (schemaVersion > maxSchemaVersion || schemaVersion < 0) {
+  console.log("Schema version must be between 0 and ", maxSchemaVersion);
   process.exit();
 }
 

--- a/src/bin/client.ts
+++ b/src/bin/client.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import ws from "ws";
+import { maxSchemaVersion } from "../lib/const";
 import { OutgoingMessage, ResultTypes } from "../lib/outgoing_message";
 import { parseArgs } from "../util/parse-args";
 
@@ -8,11 +9,23 @@ interface Args {
   _: Array<string>;
   dump: boolean;
   node: string;
+  schemaVersion: string;
 }
 
-const args = parseArgs<Args>(["_", "dump", "node"]);
+const args = parseArgs<Args>(["_", "dump", "node", "schemaVersion"]);
+const schemaVersion = args.schemaVersion
+  ? Number(args.schemaVersion)
+  : maxSchemaVersion;
 const url = args._[0] || "ws://localhost:3000";
 const filterNode = args.node ? Number(args.node) : undefined;
+
+if (schemaVersion > maxSchemaVersion) {
+  console.log(
+    "Schema version must be less than or equal to ",
+    maxSchemaVersion
+  );
+  process.exit();
+}
 
 if (!args.dump) {
   console.info("Connecting to", url);
@@ -21,6 +34,13 @@ if (!args.dump) {
 const socket = new ws(url);
 
 socket.on("open", function open() {
+  socket.send(
+    JSON.stringify({
+      messageId: "api-schema-id",
+      command: "set_api_schema",
+      schemaVersion: maxSchemaVersion,
+    })
+  );
   socket.send(
     JSON.stringify({
       messageId: "start-listening-result",

--- a/src/bin/client.ts
+++ b/src/bin/client.ts
@@ -19,7 +19,11 @@ const schemaVersion = args.schemaVersion
 const url = args._[0] || "ws://localhost:3000";
 const filterNode = args.node ? Number(args.node) : undefined;
 
-if (isNaN(schemaVersion) || schemaVersion > maxSchemaVersion || schemaVersion < 0) {
+if (
+  isNaN(schemaVersion) ||
+  schemaVersion > maxSchemaVersion ||
+  schemaVersion < 0
+) {
   console.log("Schema version must be between 0 and ", maxSchemaVersion);
   process.exit();
 }

--- a/src/bin/client.ts
+++ b/src/bin/client.ts
@@ -35,7 +35,7 @@ socket.on("open", function open() {
     JSON.stringify({
       messageId: "api-schema-id",
       command: "set_api_schema",
-      schemaVersion: maxSchemaVersion,
+      schemaVersion: schemaVersion,
     })
   );
   socket.send(

--- a/src/bin/client.ts
+++ b/src/bin/client.ts
@@ -19,7 +19,7 @@ const schemaVersion = args.schemaVersion
 const url = args._[0] || "ws://localhost:3000";
 const filterNode = args.node ? Number(args.node) : undefined;
 
-if (schemaVersion > maxSchemaVersion || schemaVersion < 0) {
+if (isNaN(schemaVersion) || schemaVersion > maxSchemaVersion || schemaVersion < 0) {
   console.log("Schema version must be between 0 and ", maxSchemaVersion);
   process.exit();
 }

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -194,7 +194,7 @@ export class EventForwarder {
               source: "node",
               event: "notification",
               nodeId: changedNode.nodeId,
-              notificationLabel: args.notificationLabel,
+              notificationLabel: args.eventLabel,
             };
             if ("parameters" in args) {
               eventData["parameters"] = args.parameters;

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -9,6 +9,7 @@ import { CommandClasses } from "@zwave-js/core";
 import { OutgoingEvent } from "./outgoing_message";
 import { dumpMetadata, dumpNode } from "./state";
 import { Client, ClientsController } from "./server";
+import { ZWaveNotificationCallback } from "zwave-js/build/lib/node/Types";
 
 export class EventForwarder {
   /**

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -9,7 +9,6 @@ import { CommandClasses } from "@zwave-js/core";
 import { OutgoingEvent } from "./outgoing_message";
 import { dumpMetadata, dumpNode } from "./state";
 import { Client, ClientsController } from "./server";
-import { ZWaveNotificationCallback } from "zwave-js/build/lib/node/Types";
 
 export class EventForwarder {
   /**

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -330,6 +330,12 @@ export const dumpNode = (node: ZWaveNode, schemaVersion: number): NodeState => {
   node3.nodeType = node.nodeType;
   node3.zwavePlusNodeType = node.zwavePlusNodeType;
   node3.zwavePlusRoleType = node.zwavePlusRoleType;
+  node3.deviceClass = node.deviceClass
+    ? dumpDeviceClass(node.deviceClass)
+    : null;
+  node3.commandClasses = Array.from(node.getSupportedCCInstances(), (cc) =>
+    dumpCommandClass(node, cc)
+  );
 
   return node3;
 };

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -293,7 +293,8 @@ export const dumpNode = (node: ZWaveNode, schemaVersion: number): NodeState => {
         ? null
         : Boolean(node.isFrequentListening);
     base.maxBaudRate = node.maxDataRate;
-    base.version = node.protocolVersion;
+    base.version =
+      node.protocolVersion === undefined ? undefined : node.protocolVersion + 1;
     base.isBeaming = node.supportsBeaming;
     base.nodeType = node.zwavePlusNodeType;
     base.roleType = node.zwavePlusRoleType;

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -293,8 +293,7 @@ export const dumpNode = (node: ZWaveNode, schemaVersion: number): NodeState => {
         ? null
         : Boolean(node.isFrequentListening);
     base.maxBaudRate = node.maxDataRate;
-    base.version =
-      node.protocolVersion === undefined ? undefined : node.protocolVersion + 1;
+    base.version = node.protocolVersion;
     base.isBeaming = node.supportsBeaming;
     base.nodeType = node.zwavePlusNodeType;
     base.roleType = node.zwavePlusRoleType;


### PR DESCRIPTION
I made two mistakes:

- Referenced the wrong argument in the notification event
- I was missing properties in schema 3

This PR corrects it.

I also added a `schemaVersion` argument for the client and default to using the latest schema (we currently always use schema 0 which makes testing a little hard 😉 )