### PR TITLE
Bump zwave-js to 7.0.0-beta2

### DIFF
--- a/API_SCHEMA.md
+++ b/API_SCHEMA.md
@@ -15,7 +15,7 @@ Base schema.
 
 - `Buffer` values were previously exposed with a `ValueType` of `string`. They are now exposed with a `ValueType` of `Buffer`
 
-# Schema 3
+# Schema 3 (WIP)
 
 - Renamed `controller.removeNodeFromAllAssocations` to `controller.removeNodeFromAllAssociations` to fix a typo
 - Numeric loglevels are converted to the corresponding string loglevel internally. driver.getLogConfig always returns the string loglevel regardless.
@@ -27,3 +27,4 @@ Base schema.
 - The `supportsSecurity` property was split off from the `isSecure` property because they have a different meaning.
 - The old `nodeType` and `roleType` properties were renamed to `zwavePlusNodeType` and `zwavePlusRoleType` to clarify that they refer to Z-Wave+.
 - The node `notification` event was reworked and decoupled from the Notification CC. The event callback now indicates which CC raised the event and its arguments are moved into a single object parameter.
+- Moved the `deviceClass` property from `ZWaveNode` to its base class `Endpoint` and consider the endpoint's device class where necessary

--- a/package-lock.json
+++ b/package-lock.json
@@ -164,63 +164,63 @@
       }
     },
     "@sentry/core": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.2.2.tgz",
-      "integrity": "sha512-qqWbvvXtymfXh7N5eEvk97MCnMURuyFIgqWdVD4MQM6yIfDCy36CyGfuQ3ViHTLZGdIfEOhLL9/f4kzf1RzqBA==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.2.3.tgz",
+      "integrity": "sha512-GpfHoSJiXchVXgyaMWVtIPVw2t97KkD1OJ4JdL3/TeH3auX5XvsN5iHTk+x/Er8t13IpOnvidH1xWdV1dnax2w==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.2.2",
-        "@sentry/minimal": "6.2.2",
-        "@sentry/types": "6.2.2",
-        "@sentry/utils": "6.2.2",
+        "@sentry/hub": "6.2.3",
+        "@sentry/minimal": "6.2.3",
+        "@sentry/types": "6.2.3",
+        "@sentry/utils": "6.2.3",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.2.2.tgz",
-      "integrity": "sha512-VR6uQGRYt6RP633FHShlSLj0LUKGVrlTeSlwCoooWM5FR9lmi6akAaweuxpG78/kZvXrAWpjX6/nuYwHKGwzGA==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.2.3.tgz",
+      "integrity": "sha512-D5Horfo2l0p52S7KPvy7qwWNMrE4IsCN8ODbfcCsfJu7hEXJmItbkbohIVSqO5neukhn5nu+x8kyCe9Q5u1Q6g==",
       "dev": true,
       "requires": {
-        "@sentry/types": "6.2.2",
-        "@sentry/utils": "6.2.2",
+        "@sentry/types": "6.2.3",
+        "@sentry/utils": "6.2.3",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/integrations": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.2.2.tgz",
-      "integrity": "sha512-B7oaQD3+dVZpgQIOWK19F12fxHKcU7AJXdcjw/gHRMLulLTYjGSFwgVS/zdaC+4W/zGO/HpZjFqqXqqRP9ipEg==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.2.3.tgz",
+      "integrity": "sha512-FVC+mttubnVY9YM2cINPI8TuNttBl2qpwODSoun+YIrXDA1uBzJjEQWfoM+QAq2dx0KPVtyFoZpUkVukvUNm+g==",
       "dev": true,
       "requires": {
-        "@sentry/types": "6.2.2",
-        "@sentry/utils": "6.2.2",
+        "@sentry/types": "6.2.3",
+        "@sentry/utils": "6.2.3",
         "localforage": "^1.8.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.2.2.tgz",
-      "integrity": "sha512-l0IgoGQgg1lTd4qDU8bQn25sbZBg8PwIHfuTLbGMlRr1flDXHOM1UXajWK/UKbAPelnU7M2JBSVzgl7PwjprzA==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.2.3.tgz",
+      "integrity": "sha512-Gpn9x4NQAG7E94EK1+hAz9GUcYrffTuqJ/XgqvHYk0jsHZ6RfsXYrmBac0ZwUxOivMf2t0n5opK0v5rhMDfF2w==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.2.2",
-        "@sentry/types": "6.2.2",
+        "@sentry/hub": "6.2.3",
+        "@sentry/types": "6.2.3",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.2.2.tgz",
-      "integrity": "sha512-HmQJx3C2C8cj3oC9piFuXJ7NzM+jW15u4RKcRXxJUgHNbZPR/RsScOOi5TbNZAO4k3A8fSJQD8aPj+dbPx/j/Q==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.2.3.tgz",
+      "integrity": "sha512-MaT8Uj+dOi1FPR4GkRGoQwaqxWKtfz+KpZ2RUT+x6aMqE8nieDFKts0i7O2vALg7LbRFzVsDsvK2GWcunfYkpA==",
       "dev": true,
       "requires": {
-        "@sentry/core": "6.2.2",
-        "@sentry/hub": "6.2.2",
-        "@sentry/tracing": "6.2.2",
-        "@sentry/types": "6.2.2",
-        "@sentry/utils": "6.2.2",
+        "@sentry/core": "6.2.3",
+        "@sentry/hub": "6.2.3",
+        "@sentry/tracing": "6.2.3",
+        "@sentry/types": "6.2.3",
+        "@sentry/utils": "6.2.3",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -228,31 +228,31 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.2.2.tgz",
-      "integrity": "sha512-mAkPoqtofNfka/u9rOVVDQPaEoTmr0AQh654g9ZqsaqsOJLKjB4FDLVNubWs90fjeKqHiYkI3ZHPak2TzHBPkw==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.2.3.tgz",
+      "integrity": "sha512-OnQZKp7qVera+Z4ly6hgybGgyf10p2VDXqwueXkMVeLD+PwlPG8a8NMpKkZ+QxwRbQbSFhRLQaib3NX34tusBQ==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.2.2",
-        "@sentry/minimal": "6.2.2",
-        "@sentry/types": "6.2.2",
-        "@sentry/utils": "6.2.2",
+        "@sentry/hub": "6.2.3",
+        "@sentry/minimal": "6.2.3",
+        "@sentry/types": "6.2.3",
+        "@sentry/utils": "6.2.3",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.2.2.tgz",
-      "integrity": "sha512-Y/1sRtw3a5JU4YdNBig8lLSVJ1UdYtuge+QP1CVLcLSAbq07Ok1bvF+Z+BlNcnHqle2Fl8aKuryG5Yu86enOyQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.2.3.tgz",
+      "integrity": "sha512-BpA+9FherWgYlkMD/82bGFh/gAqZNlZX5UE8vWLKyyzNyOEEz3v9ScxE8dOSWE4v5iXJR1O3jjxaTcRQxPVgCA==",
       "dev": true
     },
     "@sentry/utils": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.2.2.tgz",
-      "integrity": "sha512-qaee6X6VDNZ8HeO83/veaKw0KuhDE7j1R+Yryme3PywFzsoTzutDrEQjb7gvcHAhBaAYX8IHUBHgxcFI9BxI+w==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.2.3.tgz",
+      "integrity": "sha512-YnkJm97wSvck39eRpqWjIuuwbvzPilvAcMqhbUy9yK/UBQMDGUzAKCOKH40udw1DwMUCWjJ71mOCDgUorE4Fog==",
       "dev": true,
       "requires": {
-        "@sentry/types": "6.2.2",
+        "@sentry/types": "6.2.3",
         "tslib": "^1.9.3"
       }
     },
@@ -481,12 +481,12 @@
       }
     },
     "@zwave-js/config": {
-      "version": "7.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-7.0.0-beta.1.tgz",
-      "integrity": "sha512-G3aAs32pn8pXHrp9M0rjkI9S3g9pp58LUs5MuaIdFj8GeRbPsixGYMOJFPW6K/HfystmhiCqHRrDywi58EPGRQ==",
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-7.0.0-beta.2.tgz",
+      "integrity": "sha512-gE3zzIGzBJtU70cr8wrlUcLrGpwMKpeWD5QnwSU1ZyFi3Gj9kHzTuMfjZR9r4Ooq7+BOO8GBc9OHzD+hNxsDSg==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "7.0.0-beta.1",
+        "@zwave-js/core": "7.0.0-beta.2",
         "@zwave-js/shared": "7.0.0-beta.1",
         "alcalzone-shared": "^3.0.2",
         "ansi-colors": "^4.1.1",
@@ -498,9 +498,9 @@
       }
     },
     "@zwave-js/core": {
-      "version": "7.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-7.0.0-beta.1.tgz",
-      "integrity": "sha512-CvHKl1kBqYPndYEtSIYoiqcryRczua7FgHu8i0FK+0zpCnuFTQzpD0f86TEPb9P3Pp6LZoqxybvRBQGJq2hCLQ==",
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-7.0.0-beta.2.tgz",
+      "integrity": "sha512-8GmfpwInN9O2SF4ksmK11aPByYn4Wug90B/kCsAOMacyYdEG/a1IIeggQYxu2kniwpTv1MNGgTlwoMVAuBp6qQ==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^1.2.4",
@@ -514,12 +514,12 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "7.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-7.0.0-beta.1.tgz",
-      "integrity": "sha512-vOwW+nuX7HAUe4V3OtITSOdVaTp6wIby7EpV6BeCCAHymIYj2ZGp5/MQGt9pp/adx8m9QEePKynzPITCqysxgQ==",
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-7.0.0-beta.2.tgz",
+      "integrity": "sha512-qQFFVuzr6EjwFo2IWgS90/Pld0wIVD6tsqYl5uEfHcYcYdHg2DGpPGrq14DU2jpPE5GpBXohZfPJ/0mKZ3g1vg==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "7.0.0-beta.1",
+        "@zwave-js/core": "7.0.0-beta.2",
         "alcalzone-shared": "^3.0.2",
         "serialport": "^9.0.7",
         "winston": "^3.3.3"
@@ -3013,17 +3013,17 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "7.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-7.0.0-beta.1.tgz",
-      "integrity": "sha512-kgFeItRqEzxygFVoHYua/0QlzRxmsB9WXYz+5sMuJiYEEvkXPc/4jleD3SLudbjXLRkTmamk/aQGpiFiB0TRZA==",
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-7.0.0-beta.2.tgz",
+      "integrity": "sha512-J0eUDt9D1BF9M18A+By7c0rr1E/lwIV7c4K9B8JpekbZGUze+FGNCkPJjqH2Frr8BN172QuQdRGgJJq4XwxQNQ==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^1.2.4",
         "@sentry/integrations": "^6.2.1",
         "@sentry/node": "^6.2.1",
-        "@zwave-js/config": "7.0.0-beta.1",
-        "@zwave-js/core": "7.0.0-beta.1",
-        "@zwave-js/serial": "7.0.0-beta.1",
+        "@zwave-js/config": "7.0.0-beta.2",
+        "@zwave-js/core": "7.0.0-beta.2",
+        "@zwave-js/serial": "7.0.0-beta.2",
         "@zwave-js/shared": "7.0.0-beta.1",
         "alcalzone-shared": "^3.0.2",
         "ansi-colors": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ws": "^7.4.2"
   },
   "peerDependencies": {
-    "zwave-js": "^7.0.0-beta.1"
+    "zwave-js": "^7.0.0-beta.2"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -42,7 +42,7 @@
     "prettier": "^2.2.1",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3",
-    "zwave-js": "^7.0.0-beta.1"
+    "zwave-js": "^7.0.0-beta.2"
   },
   "husky": {
     "hooks": {

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -108,7 +108,7 @@ interface NodeStateSchema0 {
   isRouting: ZWaveNode["isRouting"];
   maxBaudRate: ZWaveNode["maxDataRate"];
   isSecure: ZWaveNode["isSecure"];
-  version?: number;
+  version: number | null;
   isBeaming: ZWaveNode["supportsBeaming"];
   manufacturerId: ZWaveNode["manufacturerId"];
   productId: ZWaveNode["productId"];
@@ -300,8 +300,7 @@ export const dumpNode = (node: ZWaveNode, schemaVersion: number): NodeState => {
         ? null
         : Boolean(node.isFrequentListening);
     base.maxBaudRate = node.maxDataRate;
-    base.version =
-      node.protocolVersion === undefined ? undefined : node.protocolVersion + 1;
+    base.version = node.protocolVersion ? node.protocolVersion + 1 : null;
     base.isBeaming = node.supportsBeaming;
     base.nodeType = node.zwavePlusNodeType;
     base.roleType = node.zwavePlusRoleType;

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -51,9 +51,7 @@ interface EndpointStateSchema0 {
 
 type EndpointStateSchema1 = Modify<
   EndpointStateSchema0,
-  {
-    deviceClass: DeviceClassState | null;
-  }
+  { deviceClass: DeviceClassState | null }
 >;
 
 type EndpointState = EndpointStateSchema0 | EndpointStateSchema1;

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -295,10 +295,9 @@ export const dumpNode = (node: ZWaveNode, schemaVersion: number): NodeState => {
 
   // Handle schema 3 changes by transforming them into the properties that schema < 3 expects.
   if (schemaVersion < 3) {
-    base.isFrequentListening =
-      node.isFrequentListening === undefined
-        ? null
-        : Boolean(node.isFrequentListening);
+    base.isFrequentListening = node.isFrequentListening
+      ? Boolean(node.isFrequentListening)
+      : null;
     base.maxBaudRate = node.maxDataRate;
     base.version = node.protocolVersion ? node.protocolVersion + 1 : null;
     base.isBeaming = node.supportsBeaming;


### PR DESCRIPTION
As part of updating to `7.0.0-beta2` the endpoint schema has changed. In this PR we add the new deviceClass property while considering backwards compatibility