### PR TITLE
Bump zwave-js-server to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Full access to zwave-js driver through Websockets",
   "main": "dist/lib/index.js",
   "bin": {


### PR DESCRIPTION
This should follow https://github.com/zwave-js/zwave-js-server/pull/169

Also would we consider this a minor release to support zwave-js 7.0.0 or should we bump to 2.0.0?