### PR TITLE
Dump Configuration CC Metadata

### DIFF
--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -7,8 +7,9 @@ import {
 } from "zwave-js";
 import { CommandClasses } from "@zwave-js/core";
 import { OutgoingEvent } from "./outgoing_message";
-import { dumpMetadata, dumpNode } from "./state";
+import { dumpConfigurationMetadata, dumpMetadata, dumpNode } from "./state";
 import { Client, ClientsController } from "./server";
+import { ConfigurationMetadata } from "zwave-js/build/lib/commandclass/ConfigurationCC";
 
 export class EventForwarder {
   /**
@@ -169,10 +170,17 @@ export class EventForwarder {
           // Copy arguments for each client so transforms don't impact all clients
           const newArgs = { ...args };
           if (newArgs.metadata != undefined) {
-            newArgs.metadata = dumpMetadata(
-              newArgs.metadata,
-              client.schemaVersion
-            );
+            if (newArgs.commandClass === CommandClasses.Configuration) {
+              newArgs.metadata = dumpConfigurationMetadata(
+                newArgs.metadata as ConfigurationMetadata,
+                client.schemaVersion
+              );
+            } else {
+              newArgs.metadata = dumpMetadata(
+                newArgs.metadata,
+                client.schemaVersion
+              );
+            }
           }
           this.sendEvent(client, {
             source: "node",

--- a/src/lib/node/message_handler.ts
+++ b/src/lib/node/message_handler.ts
@@ -1,10 +1,12 @@
 import { Driver } from "zwave-js";
+import { CommandClasses } from "@zwave-js/core";
 import { NodeNotFoundError, UnknownCommandError } from "../error";
 import { Client } from "../server";
-import { dumpMetadata } from "../state";
+import { dumpConfigurationMetadata, dumpMetadata } from "../state";
 import { NodeCommand } from "./command";
 import { IncomingMessageNode } from "./incoming_message";
 import { NodeResultTypes } from "./outgoing_message";
+import { ConfigurationMetadata } from "zwave-js/build/lib/commandclass/ConfigurationCC";
 
 export class NodeMessageHandler {
   static async handle(
@@ -30,6 +32,13 @@ export class NodeMessageHandler {
         const valueIds = node.getDefinedValueIDs();
         return { valueIds };
       case NodeCommand.getValueMetadata:
+        if (message.valueId.commandClass == CommandClasses.Configuration) {
+          return dumpConfigurationMetadata(
+            node.getValueMetadata(message.valueId) as ConfigurationMetadata,
+            client.schemaVersion
+          );
+        }
+
         return dumpMetadata(
           node.getValueMetadata(message.valueId),
           client.schemaVersion

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -9,6 +9,11 @@ import {
   CommandClass,
 } from "zwave-js";
 import { CommandClasses } from "@zwave-js/core";
+import {
+  ConfigurationMetadata,
+  ConfigValue,
+  ValueFormat,
+} from "zwave-js/build/lib/commandclass/ConfigurationCC";
 
 type Modify<T, R> = Omit<T, keyof R> & R;
 
@@ -81,19 +86,28 @@ interface ValueState extends TranslatedValueID {
 
 interface MetadataState {
   type: ValueMetadata["type"];
-  default?: ValueMetadata["default"];
+  default?: ValueMetadata["default"] | ConfigValue;
   readable: ValueMetadata["readable"];
   writeable: ValueMetadata["writeable"];
   description?: ValueMetadata["description"];
   label?: ValueMetadata["label"];
   ccSpecific?: ValueMetadata["ccSpecific"];
-  min?: number;
-  max?: number;
+  min?: number | ConfigValue;
+  max?: number | ConfigValue;
   minLength?: number;
   maxLength?: number;
   steps?: number;
   states?: Record<number, string>;
   unit?: string;
+  valueSize?: number;
+  format?: ValueFormat;
+  name?: string;
+  info?: string;
+  noBulkSupport?: boolean;
+  isAdvanced?: boolean;
+  requiresReInclusion?: boolean;
+  allowManualEntry?: boolean;
+  isFromConfig?: boolean;
 }
 
 interface NodeStateSchema0 {
@@ -212,7 +226,7 @@ export const dumpValue = (
 };
 
 export const dumpMetadata = (
-  metadata: ValueMetadata,
+  metadata: ValueMetadata | ConfigurationMetadata,
   schemaVersion: number
 ): MetadataState => {
   let newMetadata: MetadataState = {
@@ -251,6 +265,42 @@ export const dumpMetadata = (
 
   if ("unit" in metadata) {
     newMetadata.unit = metadata.unit;
+  }
+
+  if ("valueSize" in metadata) {
+    newMetadata.valueSize = metadata.valueSize;
+  }
+
+  if ("format" in metadata) {
+    newMetadata.format = metadata.format;
+  }
+
+  if ("name" in metadata) {
+    newMetadata.name = metadata.name;
+  }
+
+  if ("info" in metadata) {
+    newMetadata.info = metadata.info;
+  }
+
+  if ("noBulkSupport" in metadata) {
+    newMetadata.noBulkSupport = metadata.noBulkSupport;
+  }
+
+  if ("isAdvanced" in metadata) {
+    newMetadata.isAdvanced = metadata.isAdvanced;
+  }
+
+  if ("requiresReInclusion" in metadata) {
+    newMetadata.requiresReInclusion = metadata.requiresReInclusion;
+  }
+
+  if ("allowManualEntry" in metadata) {
+    newMetadata.allowManualEntry = metadata.allowManualEntry;
+  }
+
+  if ("isFromConfig" in metadata) {
+    newMetadata.isFromConfig = metadata.isFromConfig;
   }
 
   if (schemaVersion < 2 && newMetadata.type === "buffer") {

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -86,14 +86,14 @@ interface ValueState extends TranslatedValueID {
 
 interface MetadataState {
   type: ValueMetadata["type"];
-  default?: ValueMetadata["default"] | ConfigValue;
+  default?: ValueMetadata["default"];
   readable: ValueMetadata["readable"];
   writeable: ValueMetadata["writeable"];
   description?: ValueMetadata["description"];
   label?: ValueMetadata["label"];
   ccSpecific?: ValueMetadata["ccSpecific"];
-  min?: number | ConfigValue;
-  max?: number | ConfigValue;
+  min?: number;
+  max?: number;
   minLength?: number;
   maxLength?: number;
   steps?: number;


### PR DESCRIPTION
I missed adding metadata properties that are specific to the Configuration CC

Fixes https://github.com/home-assistant/core/issues/48483

Once this PR is merged, I think we can drop the `as ConfigurationMetadata` part: https://github.com/zwave-js/node-zwave-js/pull/2193