### PR TITLE
Split driver commands out into separate handler and add new commands

### DIFF
--- a/API_SCHEMA.md
+++ b/API_SCHEMA.md
@@ -15,7 +15,7 @@ Base schema.
 
 - `Buffer` values were previously exposed with a `ValueType` of `string`. They are now exposed with a `ValueType` of `Buffer`
 
-# Schema 3 (WIP)
+# Schema 3
 
 - Renamed `controller.removeNodeFromAllAssocations` to `controller.removeNodeFromAllAssociations` to fix a typo
 - Numeric loglevels are converted to the corresponding string loglevel internally. driver.getLogConfig always returns the string loglevel regardless.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ interface {
 
 ### Set API schema version
 
+[compatible with schema version: 0+]
+
 ```ts
 interface {
   messageId: string;

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ interface {
 
 #### Get the config of the driver
 
-[compatible with schema version: 0+]
+[compatible with schema version: 4+]
 
 ```ts
 interface {
@@ -164,7 +164,7 @@ interface {
 
 #### Update the logging configuration
 
-[compatible with schema version: 1+]
+[compatible with schema version: 4+]
 
 > NOTE: You must provide at least one key/value pair as part of `config`
 
@@ -184,7 +184,7 @@ interface {
 
 #### Get the logging configuration
 
-[compatible with schema version: 1+]
+[compatible with schema version: 4+]
 
 ```ts
 interface {
@@ -209,7 +209,7 @@ interface {
 
 #### Enable data usage statistics collection
 
-[compatible with schema version: 0+]
+[compatible with schema version: 4+]
 
 ```ts
 interface {
@@ -220,7 +220,7 @@ interface {
 
 #### Disable data usage statistics collection
 
-[compatible with schema version: 0+]
+[compatible with schema version: 4+]
 
 ```ts
 interface {
@@ -231,7 +231,7 @@ interface {
 
 #### Get whether statistics are enabled
 
-[compatible with schema version: 0+]
+[compatible with schema version: 4+]
 
 ```ts
 interface {

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ interface {
 ```ts
 interface {
   messageId: string;
-  command: "driver.enable_statistics";
+  command: "driver.disable_statistics";
 }
 ```
 
@@ -234,7 +234,7 @@ interface {
 ```ts
 interface {
   messageId: string;
-  command: "driver.statistics_enabled";
+  command: "driver.is_statistics_enabled";
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,46 @@ interface {
 }
 ```
 
+### Set API schema version
+
+```ts
+interface {
+  messageId: string;
+  command: "set_api_schema";
+  schemaVersion: number;
+}
+```
+
+### Driver level commands
+
+#### Get the config of the driver
+
+[compatible with schema version: 0+]
+
+```ts
+interface {
+  messageId: string;
+  command: "driver.get_config";
+}
+```
+
+Returns:
+
+```ts
+interface {
+  config: {
+    logConfig: {
+      enabled: boolean;
+      level: number;
+      logToFile: boolean;
+      filename: string;
+      forceConsole: boolean;
+    };
+    statisticsEnabled: boolean;
+  }
+}
+```
+
 #### Update the logging configuration
 
 [compatible with schema version: 1+]
@@ -129,7 +169,7 @@ interface {
 ```ts
 interface {
   messageId: string;
-  command: "update_log_config";
+  command: "driver.update_log_config";
   config: {
     enabled?: boolean;
     level?: number;
@@ -147,7 +187,7 @@ interface {
 ```ts
 interface {
   messageId: string;
-  command: "get_log_config";
+  command: "driver.get_log_config";
 }
 ```
 
@@ -162,6 +202,47 @@ interface {
     filename: string;
     forceConsole: boolean;
   }
+}
+```
+
+#### Enable data usage statistics collection
+
+[compatible with schema version: 0+]
+
+```ts
+interface {
+  messageId: string;
+  command: "driver.enable_statistics";
+}
+```
+
+#### Disable data usage statistics collection
+
+[compatible with schema version: 0+]
+
+```ts
+interface {
+  messageId: string;
+  command: "driver.enable_statistics";
+}
+```
+
+#### Get whether statistics are enabled
+
+[compatible with schema version: 0+]
+
+```ts
+interface {
+  messageId: string;
+  command: "driver.statistics_enabled";
+}
+```
+
+Returns:
+
+```ts
+interface {
+  statisticsEnabled: boolean;
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -518,12 +518,12 @@
       }
     },
     "@zwave-js/config": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-7.1.0.tgz",
-      "integrity": "sha512-AqoiYteDAH3UF5cSISEwJG/M0TkfeIli9Dxrq8bz34y736rbqE1GyYkBXNwKKrLdOfQcUyfZkapY8k7Nfx7jxw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-7.2.1.tgz",
+      "integrity": "sha512-oaqDrhZWBpbU4eKAJ4BbLFaFcr7g+X9EnrGIu3EIF9XUPM5+dL01azZ4hc32XDSHCv4x87/7eN2kEXDGYAE1Dw==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "7.1.0",
+        "@zwave-js/core": "7.2.1",
         "@zwave-js/shared": "7.0.0",
         "alcalzone-shared": "^3.0.2",
         "ansi-colors": "^4.1.1",
@@ -535,9 +535,9 @@
       }
     },
     "@zwave-js/core": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-7.1.0.tgz",
-      "integrity": "sha512-BgjejWR84hwJrM8mGfcNwVA+n466C/ZSQWOimGdwf5QollVT1Ks2a+2ZrjyTIIVwC+fC8iuuMt6eE/xsaj9ahw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-7.2.1.tgz",
+      "integrity": "sha512-yRlMhaLP5WBXN1VbvileubE8H7lL5xPGzVoVjlQPeLTGa9V1NNt+v4XnXoA2PrYoMkuuxEsVkB6MxV7CSUtK4w==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^1.2.4",
@@ -551,12 +551,12 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-7.1.0.tgz",
-      "integrity": "sha512-dyUUHiXkXAUc/Rkd7TT+9/tb2oJE6r8NlPCntHX/przNlvIL9qRD1Z+b6H5ORYjo//g4DHfKy/1MobJ/2YxaKg==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-7.2.1.tgz",
+      "integrity": "sha512-rPd+PQFm4OvDQITAnUYvK8V/Ve1zY+u6PhjhykdEdzPrXfPGKUAar+OHr14Bn94Ph4keGpFTUBzoWwMswnR3yw==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "7.1.0",
+        "@zwave-js/core": "7.2.1",
         "alcalzone-shared": "^3.0.2",
         "serialport": "^9.0.7",
         "winston": "^3.3.3"
@@ -3158,17 +3158,17 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-7.1.0.tgz",
-      "integrity": "sha512-DMvw7Lm2uRljEqZIil1vhAKXRzH88LAMXfzxMxCiDwfkX3RXPL7/j+0JPg0+OPzmiB6gt7iL/nQzrOn+iqBOow==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-7.2.1.tgz",
+      "integrity": "sha512-LVA9380+3g+PlIfFUMkbqhbRNTK1e7u8XHMFsfYONlpx7yKf82UAqvFO39Jcyg94kewWYc1b+oja/34H63hb/w==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^1.2.4",
         "@sentry/integrations": "^6.2.1",
         "@sentry/node": "^6.2.1",
-        "@zwave-js/config": "7.1.0",
-        "@zwave-js/core": "7.1.0",
-        "@zwave-js/serial": "7.1.0",
+        "@zwave-js/config": "7.2.1",
+        "@zwave-js/core": "7.2.1",
+        "@zwave-js/serial": "7.2.1",
         "@zwave-js/shared": "7.0.0",
         "alcalzone-shared": "^3.0.2",
         "ansi-colors": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ws": "^7.4.2"
   },
   "peerDependencies": {
-    "zwave-js": "^7.1.0"
+    "zwave-js": "^7.2.1"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -42,7 +42,7 @@
     "prettier": "^2.2.1",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3",
-    "zwave-js": "^7.1.0"
+    "zwave-js": "^7.2.1"
   },
   "husky": {
     "hooks": {

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -1,8 +1,6 @@
-export enum DriverCommand {
+export enum ServerCommand {
   startListening = "start_listening",
   updateLogConfig = "update_log_config",
   getLogConfig = "get_log_config",
   setApiSchema = "set_api_schema",
-  enableStatistics = "enable_statistics",
-  disableStatistics = "disable_statistics",
 }

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -3,4 +3,6 @@ export enum DriverCommand {
   updateLogConfig = "update_log_config",
   getLogConfig = "get_log_config",
   setApiSchema = "set_api_schema",
+  enableStatistics = "enable_statistics",
+  disableStatistics = "disable_statistics",
 }

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -4,4 +4,4 @@ export const version = require("../../package.json").version;
 export const minSchemaVersion = 0;
 
 // maximal/current schema version the server supports
-export const maxSchemaVersion = 3;
+export const maxSchemaVersion = 4;

--- a/src/lib/driver/command.ts
+++ b/src/lib/driver/command.ts
@@ -1,0 +1,6 @@
+export enum DriverCommand {
+  updateLogConfig = "driver.update_log_config",
+  getLogConfig = "driver.get_log_config",
+  enableStatistics = "driver.enable_statistics",
+  disableStatistics = "driver.disable_statistics",
+}

--- a/src/lib/driver/command.ts
+++ b/src/lib/driver/command.ts
@@ -4,5 +4,5 @@ export enum DriverCommand {
   getLogConfig = "driver.get_log_config",
   enableStatistics = "driver.enable_statistics",
   disableStatistics = "driver.disable_statistics",
-  statisticsEnabled = "driver.statistics_enabled",
+  isStatisticsEnabled = "driver.is_statistics_enabled",
 }

--- a/src/lib/driver/command.ts
+++ b/src/lib/driver/command.ts
@@ -1,6 +1,8 @@
 export enum DriverCommand {
+  getConfig = "driver.get_config",
   updateLogConfig = "driver.update_log_config",
   getLogConfig = "driver.get_log_config",
   enableStatistics = "driver.enable_statistics",
   disableStatistics = "driver.disable_statistics",
+  statisticsEnabled = "driver.statistics_enabled",
 }

--- a/src/lib/driver/incoming_message.ts
+++ b/src/lib/driver/incoming_message.ts
@@ -1,0 +1,28 @@
+import { LogConfig } from "@zwave-js/core";
+import { DriverCommand } from "./command";
+import { IncomingCommandBase } from "../incoming_message_base";
+
+interface IncomingCommandUpdateLogConfig extends IncomingCommandBase {
+  command: DriverCommand.updateLogConfig;
+  config: Partial<LogConfig>;
+}
+
+interface IncomingCommandGetLogConfig extends IncomingCommandBase {
+  command: DriverCommand.getLogConfig;
+}
+
+interface IncomingCommandEnableStatistics extends IncomingCommandBase {
+  command: DriverCommand.enableStatistics;
+  applicationName: string;
+  applicationVersion: string;
+}
+
+interface IncomingCommandDisableStatistics extends IncomingCommandBase {
+  command: DriverCommand.disableStatistics;
+}
+
+export type IncomingMessageDriver =
+  | IncomingCommandUpdateLogConfig
+  | IncomingCommandGetLogConfig
+  | IncomingCommandDisableStatistics
+  | IncomingCommandEnableStatistics;

--- a/src/lib/driver/incoming_message.ts
+++ b/src/lib/driver/incoming_message.ts
@@ -25,8 +25,8 @@ interface IncomingCommandDisableStatistics extends IncomingCommandBase {
   command: DriverCommand.disableStatistics;
 }
 
-interface IncomingCommandStatisticsEnabled extends IncomingCommandBase {
-  command: DriverCommand.statisticsEnabled;
+interface IncomingCommandIsStatisticsEnabled extends IncomingCommandBase {
+  command: DriverCommand.isStatisticsEnabled;
 }
 
 export type IncomingMessageDriver =
@@ -35,4 +35,4 @@ export type IncomingMessageDriver =
   | IncomingCommandGetLogConfig
   | IncomingCommandDisableStatistics
   | IncomingCommandEnableStatistics
-  | IncomingCommandStatisticsEnabled;
+  | IncomingCommandIsStatisticsEnabled;

--- a/src/lib/driver/incoming_message.ts
+++ b/src/lib/driver/incoming_message.ts
@@ -2,6 +2,10 @@ import { LogConfig } from "@zwave-js/core";
 import { DriverCommand } from "./command";
 import { IncomingCommandBase } from "../incoming_message_base";
 
+interface IncomingCommandGetConfig extends IncomingCommandBase {
+  command: DriverCommand.getConfig;
+}
+
 interface IncomingCommandUpdateLogConfig extends IncomingCommandBase {
   command: DriverCommand.updateLogConfig;
   config: Partial<LogConfig>;
@@ -21,8 +25,14 @@ interface IncomingCommandDisableStatistics extends IncomingCommandBase {
   command: DriverCommand.disableStatistics;
 }
 
+interface IncomingCommandStatisticsEnabled extends IncomingCommandBase {
+  command: DriverCommand.statisticsEnabled;
+}
+
 export type IncomingMessageDriver =
+  | IncomingCommandGetConfig
   | IncomingCommandUpdateLogConfig
   | IncomingCommandGetLogConfig
   | IncomingCommandDisableStatistics
-  | IncomingCommandEnableStatistics;
+  | IncomingCommandEnableStatistics
+  | IncomingCommandStatisticsEnabled;

--- a/src/lib/driver/message_handler.ts
+++ b/src/lib/driver/message_handler.ts
@@ -1,0 +1,47 @@
+import { Driver } from "zwave-js";
+import { UnknownCommandError } from "../error";
+import { Client } from "../server";
+import { DriverCommand } from "./command";
+import { IncomingMessageDriver } from "./incoming_message";
+import { DriverResultTypes } from "./outgoing_message";
+import { numberFromLogLevel } from "../../util/logger";
+
+export class DriverMessageHandler {
+  static async handle(
+    message: IncomingMessageDriver,
+    driver: Driver,
+    client: Client
+  ): Promise<DriverResultTypes[DriverCommand]> {
+    const { command } = message;
+
+    switch (message.command) {
+      case DriverCommand.disableStatistics:
+        driver.disableStatistics();
+        return {};
+      case DriverCommand.enableStatistics:
+        driver.enableStatistics({
+          applicationName: message.applicationName,
+          applicationVersion: message.applicationVersion,
+        });
+        return {};
+      case DriverCommand.getLogConfig:
+        const { transports, ...partialLogConfig } = driver.getLogConfig();
+
+        if (
+          client.schemaVersion < 3 &&
+          typeof partialLogConfig.level === "string"
+        ) {
+          let levelNum = numberFromLogLevel(partialLogConfig.level);
+          if (levelNum != undefined) {
+            partialLogConfig.level = levelNum;
+          }
+        }
+        return { config: partialLogConfig };
+      case DriverCommand.updateLogConfig:
+        driver.updateLogConfig(message.config);
+        return {};
+      default:
+        throw new UnknownCommandError(command);
+    }
+  }
+}

--- a/src/lib/driver/message_handler.ts
+++ b/src/lib/driver/message_handler.ts
@@ -15,7 +15,7 @@ export class DriverMessageHandler {
     const { command } = message;
     switch (message.command) {
       case DriverCommand.getConfig:
-        return dumpDriver(driver, client.schemaVersion);
+        return { config: dumpDriver(driver, client.schemaVersion) };
       case DriverCommand.disableStatistics:
         driver.disableStatistics();
         return {};

--- a/src/lib/driver/message_handler.ts
+++ b/src/lib/driver/message_handler.ts
@@ -25,6 +25,7 @@ export class DriverMessageHandler {
         });
         return {};
       case DriverCommand.getLogConfig:
+        // We don't want to return transports since that's used internally.
         const { transports, ...partialLogConfig } = driver.getLogConfig();
 
         if (

--- a/src/lib/driver/message_handler.ts
+++ b/src/lib/driver/message_handler.ts
@@ -30,7 +30,7 @@ export class DriverMessageHandler {
       case DriverCommand.updateLogConfig:
         driver.updateLogConfig(message.config);
         return {};
-      case DriverCommand.statisticsEnabled:
+      case DriverCommand.isStatisticsEnabled:
         return { statisticsEnabled: driver.statisticsEnabled };
       default:
         throw new UnknownCommandError(command);

--- a/src/lib/driver/outgoing_message.ts
+++ b/src/lib/driver/outgoing_message.ts
@@ -1,0 +1,9 @@
+import { LogConfig } from "@zwave-js/core";
+import { DriverCommand } from "./command";
+
+export interface DriverResultTypes {
+  [DriverCommand.updateLogConfig]: Record<string, never>;
+  [DriverCommand.getLogConfig]: { config: Partial<LogConfig> };
+  [DriverCommand.disableStatistics]: Record<string, never>;
+  [DriverCommand.enableStatistics]: Record<string, never>;
+}

--- a/src/lib/driver/outgoing_message.ts
+++ b/src/lib/driver/outgoing_message.ts
@@ -8,5 +8,5 @@ export interface DriverResultTypes {
   [DriverCommand.getLogConfig]: { config: Partial<LogConfig> };
   [DriverCommand.disableStatistics]: Record<string, never>;
   [DriverCommand.enableStatistics]: Record<string, never>;
-  [DriverCommand.statisticsEnabled]: { statisticsEnabled: boolean };
+  [DriverCommand.isStatisticsEnabled]: { statisticsEnabled: boolean };
 }

--- a/src/lib/driver/outgoing_message.ts
+++ b/src/lib/driver/outgoing_message.ts
@@ -3,7 +3,7 @@ import { DriverState } from "../state";
 import { DriverCommand } from "./command";
 
 export interface DriverResultTypes {
-  [DriverCommand.getConfig]: DriverState;
+  [DriverCommand.getConfig]: { config: DriverState };
   [DriverCommand.updateLogConfig]: Record<string, never>;
   [DriverCommand.getLogConfig]: { config: Partial<LogConfig> };
   [DriverCommand.disableStatistics]: Record<string, never>;

--- a/src/lib/driver/outgoing_message.ts
+++ b/src/lib/driver/outgoing_message.ts
@@ -1,9 +1,12 @@
 import { LogConfig } from "@zwave-js/core";
+import { DriverState } from "../state";
 import { DriverCommand } from "./command";
 
 export interface DriverResultTypes {
+  [DriverCommand.getConfig]: DriverState;
   [DriverCommand.updateLogConfig]: Record<string, never>;
   [DriverCommand.getLogConfig]: { config: Partial<LogConfig> };
   [DriverCommand.disableStatistics]: Record<string, never>;
   [DriverCommand.enableStatistics]: Record<string, never>;
+  [DriverCommand.statisticsEnabled]: { statisticsEnabled: boolean };
 }

--- a/src/lib/incoming_message.ts
+++ b/src/lib/incoming_message.ts
@@ -1,35 +1,26 @@
 import { LogConfig } from "@zwave-js/core";
 import { IncomingMessageController } from "./controller/incoming_message";
-import { DriverCommand } from "./command";
+import { ServerCommand } from "./command";
 import { IncomingCommandBase } from "./incoming_message_base";
 import { IncomingMessageNode } from "./node/incoming_message";
+import { IncomingMessageDriver } from "./driver/incoming_message";
 
 interface IncomingCommandStartListening extends IncomingCommandBase {
-  command: DriverCommand.startListening;
+  command: ServerCommand.startListening;
 }
 
 interface IncomingCommandUpdateLogConfig extends IncomingCommandBase {
-  command: DriverCommand.updateLogConfig;
+  command: ServerCommand.updateLogConfig;
   config: Partial<LogConfig>;
 }
 
 interface IncomingCommandGetLogConfig extends IncomingCommandBase {
-  command: DriverCommand.getLogConfig;
+  command: ServerCommand.getLogConfig;
 }
 
 interface IncomingCommandSetApiSchema extends IncomingCommandBase {
-  command: DriverCommand.setApiSchema;
+  command: ServerCommand.setApiSchema;
   schemaVersion: number;
-}
-
-interface IncomingCommandEnableStatistics extends IncomingCommandBase {
-  command: DriverCommand.enableStatistics;
-  applicationName: string;
-  applicationVersion: string;
-}
-
-interface IncomingCommandDisableStatistics extends IncomingCommandBase {
-  command: DriverCommand.disableStatistics;
 }
 
 export type IncomingMessage =
@@ -37,7 +28,6 @@ export type IncomingMessage =
   | IncomingCommandUpdateLogConfig
   | IncomingCommandGetLogConfig
   | IncomingCommandSetApiSchema
-  | IncomingCommandDisableStatistics
-  | IncomingCommandEnableStatistics
   | IncomingMessageNode
-  | IncomingMessageController;
+  | IncomingMessageController
+  | IncomingMessageDriver;

--- a/src/lib/incoming_message.ts
+++ b/src/lib/incoming_message.ts
@@ -22,10 +22,22 @@ interface IncomingCommandSetApiSchema extends IncomingCommandBase {
   schemaVersion: number;
 }
 
+interface IncomingCommandEnableStatistics extends IncomingCommandBase {
+  command: DriverCommand.enableStatistics;
+  applicationName: string;
+  applicationVersion: string;
+}
+
+interface IncomingCommandDisableStatistics extends IncomingCommandBase {
+  command: DriverCommand.disableStatistics;
+}
+
 export type IncomingMessage =
   | IncomingCommandStartListening
   | IncomingCommandUpdateLogConfig
   | IncomingCommandGetLogConfig
   | IncomingCommandSetApiSchema
+  | IncomingCommandDisableStatistics
+  | IncomingCommandEnableStatistics
   | IncomingMessageNode
   | IncomingMessageController;

--- a/src/lib/outgoing_message.ts
+++ b/src/lib/outgoing_message.ts
@@ -2,7 +2,8 @@ import { LogConfig } from "@zwave-js/core";
 import type { ZwaveState } from "./state";
 import { NodeResultTypes } from "./node/outgoing_message";
 import { ControllerResultTypes } from "./controller/outgoing_message";
-import { DriverCommand } from "./command";
+import { ServerCommand } from "./command";
+import { DriverResultTypes } from "./driver/outgoing_message";
 
 export interface OutgoingEvent {
   source: "controller" | "node";
@@ -31,17 +32,16 @@ interface OutgoingResultMessageError {
   errorCode: string;
 }
 
-export interface DriverResultTypes {
-  [DriverCommand.startListening]: { state: ZwaveState };
-  [DriverCommand.updateLogConfig]: Record<string, never>;
-  [DriverCommand.getLogConfig]: { config: Partial<LogConfig> };
-  [DriverCommand.disableStatistics]: Record<string, never>;
-  [DriverCommand.enableStatistics]: Record<string, never>;
+export interface ServerResultTypes {
+  [ServerCommand.startListening]: { state: ZwaveState };
+  [ServerCommand.updateLogConfig]: Record<string, never>;
+  [ServerCommand.getLogConfig]: { config: Partial<LogConfig> };
 }
 
-export type ResultTypes = DriverResultTypes &
+export type ResultTypes = ServerResultTypes &
   NodeResultTypes &
-  ControllerResultTypes;
+  ControllerResultTypes &
+  DriverResultTypes;
 
 export interface OutgoingResultMessageSuccess {
   type: "result";

--- a/src/lib/outgoing_message.ts
+++ b/src/lib/outgoing_message.ts
@@ -35,6 +35,8 @@ export interface DriverResultTypes {
   [DriverCommand.startListening]: { state: ZwaveState };
   [DriverCommand.updateLogConfig]: Record<string, never>;
   [DriverCommand.getLogConfig]: { config: Partial<LogConfig> };
+  [DriverCommand.disableStatistics]: Record<string, never>;
+  [DriverCommand.enableStatistics]: Record<string, never>;
 }
 
 export type ResultTypes = DriverResultTypes &

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -121,6 +121,19 @@ export class Client {
         return;
       }
 
+      if (msg.command === DriverCommand.disableStatistics) {
+        this.driver.disableStatistics();
+        this.sendResultSuccess(msg.messageId, {});
+      }
+
+      if (msg.command === DriverCommand.enableStatistics) {
+        this.driver.enableStatistics({
+          applicationName: msg.applicationName,
+          applicationVersion: msg.applicationVersion,
+        });
+        this.sendResultSuccess(msg.messageId, {});
+      }
+
       const instance = msg.command.split(".")[0] as Instance;
       if (this.instanceHandlers[instance]) {
         return this.sendResultSuccess(

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -5,7 +5,7 @@ import { libVersion } from "zwave-js";
 import { EventForwarder } from "./forward";
 import type * as OutgoingMessages from "./outgoing_message";
 import { IncomingMessage } from "./incoming_message";
-import { dumpState } from "./state";
+import { dumpLogConfig, dumpState } from "./state";
 import { Server as HttpServer, createServer } from "http";
 import { EventEmitter, once } from "events";
 import { version, minSchemaVersion, maxSchemaVersion } from "./const";
@@ -21,7 +21,6 @@ import {
 import { Instance } from "./instance";
 import { IncomingMessageNode } from "./node/incoming_message";
 import { ServerCommand } from "./command";
-import { numberFromLogLevel } from "../util/logger";
 import { DriverMessageHandler } from "./driver/message_handler";
 import { IncomingMessageDriver } from "./driver/incoming_message";
 
@@ -110,19 +109,9 @@ export class Client {
       }
 
       if (msg.command === ServerCommand.getLogConfig) {
-        // We don't want to return transports since that's used internally.
-        const { transports, ...partialLogConfig } = this.driver.getLogConfig();
-
-        if (
-          this.schemaVersion < 3 &&
-          typeof partialLogConfig.level === "string"
-        ) {
-          let levelNum = numberFromLogLevel(partialLogConfig.level);
-          if (levelNum != undefined) {
-            partialLogConfig.level = levelNum;
-          }
-        }
-        this.sendResultSuccess(msg.messageId, { config: partialLogConfig });
+        this.sendResultSuccess(msg.messageId, {
+          config: dumpLogConfig(this.driver, this.schemaVersion),
+        });
         return;
       }
 

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -1,5 +1,6 @@
 import type { Driver } from "zwave-js";
 import { EventEmitter } from "events";
+import { LogConfig } from "@zwave-js/core";
 
 class MockController extends EventEmitter {
   homeId = 1;
@@ -11,8 +12,17 @@ class MockDriver extends EventEmitter {
 
   public ready = true;
 
+  public statisticsEnabled = true;
+
   async start() {
     this.emit("driver ready");
+  }
+
+  public getLogConfig(): Partial<LogConfig> {
+    return {
+      enabled: true,
+      level: "debug",
+    };
   }
 
   async destroy() {}

--- a/src/test/integration.ts
+++ b/src/test/integration.ts
@@ -65,7 +65,7 @@ const runTest = async () => {
       result: {
         state: {
           driver: {
-            config: { enabled: true, level: "debug" },
+            config: { enabled: true, level: 5 },
             statisticsEnabled: true,
           },
           controller: { homeId: 1 },

--- a/src/test/integration.ts
+++ b/src/test/integration.ts
@@ -64,6 +64,10 @@ const runTest = async () => {
       messageId: "my-msg-id!",
       result: {
         state: {
+          driver: {
+            config: { enabled: true, level: "debug" },
+            statisticsEnabled: true,
+          },
           controller: { homeId: 1 },
           nodes: [],
         },

--- a/src/test/integration.ts
+++ b/src/test/integration.ts
@@ -65,7 +65,7 @@ const runTest = async () => {
       result: {
         state: {
           driver: {
-            config: { enabled: true, level: 5 },
+            logConfig: { enabled: true, level: 5 },
             statisticsEnabled: true,
           },
           controller: { homeId: 1 },


### PR DESCRIPTION
The existing `get_log_config` and `update_log_config` commands are now available as `driver.get_log_config` and `driver.update_log_config`. In addition:
- `driver.enable_statistics`, `driver.disable_statistics`, `driver.statistics_enabled`, and `driver.get_config` commands added
- `dumpState` now include the driver config
