### PR TITLE
Make interviewStage property a string (schema 4)

### DIFF
--- a/API_SCHEMA.md
+++ b/API_SCHEMA.md
@@ -28,3 +28,7 @@ Base schema.
 - The old `nodeType` and `roleType` properties were renamed to `zwavePlusNodeType` and `zwavePlusRoleType` to clarify that they refer to Z-Wave+.
 - The node `notification` event was reworked and decoupled from the Notification CC. The event callback now indicates which CC raised the event and its arguments are moved into a single object parameter.
 - Moved the `deviceClass` property from `ZWaveNode` to its base class `Endpoint` and consider the endpoint's device class where necessary
+
+# Schema 4
+
+- Node `interviewStage` property was changed from type `number` to type `string`

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -186,19 +186,22 @@ type NodeStateSchema1 = Modify<
 
 type NodeStateSchema2 = NodeStateSchema1;
 
-type NodeStateSchema3 = Modify<
-  Omit<NodeStateSchema2, "maxBaudRate" | "version" | "isBeaming" | "roleType">,
-  {
-    isFrequentListening: ZWaveNode["isFrequentListening"];
-    maxDataRate: ZWaveNode["maxDataRate"];
-    supportedDataRates: ZWaveNode["supportedDataRates"];
-    protocolVersion: ZWaveNode["protocolVersion"];
-    supportsBeaming: ZWaveNode["supportsBeaming"];
-    supportsSecurity: ZWaveNode["supportsSecurity"];
-    zwavePlusNodeType: ZWaveNode["zwavePlusNodeType"];
-    zwavePlusRoleType: ZWaveNode["zwavePlusRoleType"];
-    nodeType: ZWaveNode["nodeType"];
-  }
+type NodeStateSchema3 = Omit<
+  Modify<
+    NodeStateSchema2,
+    {
+      isFrequentListening: ZWaveNode["isFrequentListening"];
+      maxDataRate: ZWaveNode["maxDataRate"];
+      supportedDataRates: ZWaveNode["supportedDataRates"];
+      protocolVersion: ZWaveNode["protocolVersion"];
+      supportsBeaming: ZWaveNode["supportsBeaming"];
+      supportsSecurity: ZWaveNode["supportsSecurity"];
+      zwavePlusNodeType: ZWaveNode["zwavePlusNodeType"];
+      zwavePlusRoleType: ZWaveNode["zwavePlusRoleType"];
+      nodeType: ZWaveNode["nodeType"];
+    }
+  >,
+  "maxBaudRate" | "version" | "isBeaming" | "roleType"
 >;
 
 type NodeStateSchema4 = Modify<NodeStateSchema3, { interviewStage?: string }>;

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -390,6 +390,7 @@ export const dumpNode = (node: ZWaveNode, schemaVersion: number): NodeState => {
     values: getNodeValues(node, schemaVersion),
   };
 
+  // In schema 4 we started using the interview stage string instead of the enum number
   if (schemaVersion <= 3) base.interviewStage = node.interviewStage;
 
   // Handle schema 3 changes by transforming them into the properties that schema < 3 expects.


### PR DESCRIPTION
Right now we store the enum number value which is subject to change according to Al. It will be more useful to get the string translation of the interview stage. We shouldn't depend on the string value either but this way we don't have to maintain a mapping downstream