### PR TITLE
Bump zwave-js from 7.2.1 to 7.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -518,12 +518,12 @@
       }
     },
     "@zwave-js/config": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-7.2.2.tgz",
-      "integrity": "sha512-uBjKz49fLCDRs3ohpkIcw5oSjMggqoOMpILP5q0P5HDra3olRQgATzUuqtIvSY8U9aY14uJbtaTiwWUyQaUnbA==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-7.2.4.tgz",
+      "integrity": "sha512-2XzT1CRLeTqxhgF1+dyAkYLR1xWQG7Wqd/sLp9pDw+81ugZQWXMy1ymRy8+ABvXRIXYmOm3tXR2vgKPts4Pz4Q==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "7.2.2",
+        "@zwave-js/core": "7.2.4",
         "@zwave-js/shared": "7.0.0",
         "alcalzone-shared": "^3.0.2",
         "ansi-colors": "^4.1.1",
@@ -535,9 +535,9 @@
       }
     },
     "@zwave-js/core": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-7.2.2.tgz",
-      "integrity": "sha512-nXmo8aUTbrfn5VZl+P8tBfxhhuDIFnCeePJ+BQvC/YYfwisSWD4AGXykHc//CU/uLXhwunMvZIvnB5To5D/QIg==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-7.2.4.tgz",
+      "integrity": "sha512-zYWyMKyrSqLjyDxOp+9A40y1tyrxvkBP8KUg0waf5hwfiC30LJJaIxuleN3A26MjoV0DDZRI+UY8BT/EoVrqAw==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^1.2.4",
@@ -551,12 +551,12 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-7.2.2.tgz",
-      "integrity": "sha512-98jQLi/sFw1VwzcsMs7DmHDp2TCaPP3QykifYgOkHQ62r9IZulBJW9oy/wZKk11r0n95r/oTYrQCNByv86hveA==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-7.2.4.tgz",
+      "integrity": "sha512-Yypha5qhOnGRl26qFc492a+qRYI5aHS5a01NXr9CmPi9esm5hxm3QiECh57LAoF00/u/VIdM5WmauAeVv5tgxQ==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "7.2.2",
+        "@zwave-js/core": "7.2.4",
         "alcalzone-shared": "^3.0.2",
         "serialport": "^9.0.7",
         "winston": "^3.3.3"
@@ -3128,9 +3128,9 @@
       "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw=="
     },
     "xstate": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.17.1.tgz",
-      "integrity": "sha512-3q7so9qAKFnz9/t7BNQXQtV+9fwDATCOkC+0tAvVqczboEbu6gz2dvPPVCCkj55Hyzgro9aSOntGSPGLei82BA==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.18.0.tgz",
+      "integrity": "sha512-cjj22XXxTWIkMrghyoUWjUlDFcd7MQGeKYy8bkdtcIeogZjF98mep9CHv8xLO3j4PZQF5qgcAGGT8FUn99mF1Q==",
       "dev": true
     },
     "yallist": {
@@ -3158,17 +3158,17 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-7.2.2.tgz",
-      "integrity": "sha512-q6aL83ZyTpJBctYc7W8KfziavI0VxFdqdC2JSJjqq6pKPF08OSwSoGTWsaJ+z/WnyP7gIkkWHAGZImMz68ZLGQ==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-7.2.4.tgz",
+      "integrity": "sha512-omRdVDtZpiLyYIdNn7EbRfjtOVW4//Dtk83Nt+sWBVEmtrbDELOAWd93/ZJJHazhbrttIMGFnbdK+L0chEKklQ==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^1.2.4",
         "@sentry/integrations": "^6.2.1",
         "@sentry/node": "^6.2.1",
-        "@zwave-js/config": "7.2.2",
-        "@zwave-js/core": "7.2.2",
-        "@zwave-js/serial": "7.2.2",
+        "@zwave-js/config": "7.2.4",
+        "@zwave-js/core": "7.2.4",
+        "@zwave-js/serial": "7.2.4",
         "@zwave-js/shared": "7.0.0",
         "alcalzone-shared": "^3.0.2",
         "ansi-colors": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ws": "^7.4.2"
   },
   "peerDependencies": {
-    "zwave-js": "^7.2.1"
+    "zwave-js": "^7.2.4"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -42,7 +42,7 @@
     "prettier": "^2.2.1",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3",
-    "zwave-js": "^7.2.1"
+    "zwave-js": "^7.2.4"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
7.2.4: https://github.com/zwave-js/node-zwave-js/releases/tag/v7.2.4
7.2.3: https://github.com/zwave-js/node-zwave-js/releases/tag/v7.2.3
7.2.2: https://github.com/zwave-js/node-zwave-js/releases/tag/v7.2.2

This needs to be merged before #195 