### PR TITLE
Add commands to initiate firmware update

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,36 @@ interface {
 }
 ```
 
+#### [Begin Firmware Update](https://zwave-js.github.io/node-zwave-js/#/api/node?id=beginfirmwareupdate)
+
+##### Format must be guessed
+
+[compatible with schema version: 5+]
+
+```ts
+interface {
+  messageId: string;
+  command: "node.begin_firmware_update_guess_format";
+  nodeId: number;
+  firmwareFilename: string;
+  firmwareFile: Buffer;
+}
+```
+
+##### Format is known
+
+[compatible with schema version: 5+]
+
+```ts
+interface {
+  messageId: string;
+  command: "node.begin_firmware_update_known_format";
+  nodeId: number;
+  firmwareFile: Buffer;
+  firmwareFileFormat: FirmwareFileFormat;
+}
+```
+
 #### [Abort Firmware Update](https://zwave-js.github.io/node-zwave-js/#/api/node?id=abortfirmwareupdate)
 
 [compatible with schema version: 0+]

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -4,4 +4,4 @@ export const version = require("../../package.json").version;
 export const minSchemaVersion = 0;
 
 // maximal/current schema version the server supports
-export const maxSchemaVersion = 4;
+export const maxSchemaVersion = 5;

--- a/src/lib/node/command.ts
+++ b/src/lib/node/command.ts
@@ -3,6 +3,8 @@ export enum NodeCommand {
   refreshInfo = "node.refresh_info",
   getDefinedValueIDs = "node.get_defined_value_ids",
   getValueMetadata = "node.get_value_metadata",
+  beginFirmwareUpdateGuessFormat = "node.begin_firmware_update_guess_format",
+  beginFirmwareUpdateKnownFormat = "node.begin_firmware_update_known_format",
   abortFirmwareUpdate = "node.abort_firmware_update",
   pollValue = "node.poll_value",
   setRawConfigParameterValue = "node.set_raw_config_parameter_value",

--- a/src/lib/node/incoming_message.ts
+++ b/src/lib/node/incoming_message.ts
@@ -1,5 +1,5 @@
 import { ConfigValue, ValueID } from "zwave-js";
-import { CommandClasses } from "@zwave-js/core";
+import { CommandClasses, FirmwareFileFormat } from "@zwave-js/core";
 import { IncomingCommandBase } from "../incoming_message_base";
 import { NodeCommand } from "./command";
 
@@ -28,6 +28,21 @@ export interface IncomingCommandNodeGetValueMetadata
   command: NodeCommand.getValueMetadata;
   valueId: ValueID;
 }
+
+export interface IncomingCommandNodeBeginFirmwareUpdateGuessFormat
+  extends IncomingCommandNodeBase {
+  command: NodeCommand.beginFirmwareUpdateGuessFormat;
+  firmwareFilename: string;
+  firmwareFile: Buffer;
+}
+
+export interface IncomingCommandNodeBeginFirmwareUpdateKnownFormat
+  extends IncomingCommandNodeBase {
+  command: NodeCommand.beginFirmwareUpdateKnownFormat;
+  firmwareFile: Buffer;
+  firmwareFileFormat: FirmwareFileFormat;
+}
+
 export interface IncomingCommandNodeAbortFirmwareUpdate
   extends IncomingCommandNodeBase {
   command: NodeCommand.abortFirmwareUpdate;
@@ -62,6 +77,8 @@ export type IncomingMessageNode =
   | IncomingCommandNodeRefreshInfo
   | IncomingCommandNodeGetDefinedValueIDs
   | IncomingCommandNodeGetValueMetadata
+  | IncomingCommandNodeBeginFirmwareUpdateGuessFormat
+  | IncomingCommandNodeBeginFirmwareUpdateKnownFormat
   | IncomingCommandNodeAbortFirmwareUpdate
   | IncomingCommandNodePollValue
   | IncomingCommandNodeSetRawConfigParameterValue

--- a/src/lib/node/outgoing_message.ts
+++ b/src/lib/node/outgoing_message.ts
@@ -6,6 +6,8 @@ export interface NodeResultTypes {
   [NodeCommand.refreshInfo]: Record<string, never>;
   [NodeCommand.getDefinedValueIDs]: { valueIds: TranslatedValueID[] };
   [NodeCommand.getValueMetadata]: ValueMetadata;
+  [NodeCommand.beginFirmwareUpdateGuessFormat]: Record<string, never>;
+  [NodeCommand.beginFirmwareUpdateKnownFormat]: Record<string, never>;
   [NodeCommand.abortFirmwareUpdate]: Record<string, never>;
   [NodeCommand.pollValue]: { value: any | undefined };
   [NodeCommand.setRawConfigParameterValue]: Record<string, never>;


### PR DESCRIPTION
A couple of thoughts in no particular order:
1. I don't have any devices with updatable firmware so I am unable to test this. I may try to throw random files at it to verify it fails but haven't gotten that far yet.
2. We've seen that buffers will serialize out from the server to the client so is it safe to assume we can deserialize in the other direction?
3. I thought it would be useful to have two separate commands, one where the file format is known and one where it has to be guessed, because I could see both being useful.
4. I used the example reference here: https://zwave-js.github.io/node-zwave-js/#/api/node?id=beginfirmwareupdate but did not include any catch blocks. My understanding from #210 is that we will now catch the zwave-js error and send it back to the client, so I don't see a use in changing that.