### PR TITLE
Rename port arg and guard against string as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Opens server on `ws://localhost:3000`.
 
 You can specify a configuration file with `--config`. This can be a JSON file or a JS file that exports the config. It needs to follow the [Z-Wave JS config format](https://zwave-js.github.io/node-zwave-js/#/api/driver?id=zwaveoptions).
 
-You can specify a different port for the websocket server to listen on with `--websocket-port`.
+You can specify a different port for the websocket server to listen on with `--port`.
 
 If you don't have a USB stick, you can add `--mock-driver` to use a fake stick.
 

--- a/src/bin/server.ts
+++ b/src/bin/server.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { exit } from "process";
 import { resolve } from "path";
 import { Driver } from "zwave-js";
 import { ZwavejsServer } from "../lib/server";
@@ -10,20 +11,18 @@ interface Args {
   _: Array<string>;
   config?: string;
   "mock-driver": boolean;
-  "websocket-port": number;
+  port: number;
 }
 
 (async () => {
-  const args = parseArgs<Args>([
-    "_",
-    "config",
-    "mock-driver",
-    "websocket-port",
-  ]);
+  const args = parseArgs<Args>(["_", "config", "mock-driver", "port"]);
 
   let wsPort = 3000;
-  if (args["websocket-port"]) {
-    wsPort = args["websocket-port"];
+  if (args["port"]) {
+    if (typeof args["port"] === "string") {
+      throw new Error("port must be a valid integer");
+    }
+    wsPort = args["port"];
   }
 
   if (args["mock-driver"]) {

--- a/src/bin/server.ts
+++ b/src/bin/server.ts
@@ -19,7 +19,7 @@ interface Args {
 
   let wsPort = 3000;
   if (args["port"]) {
-    if (typeof args["port"] === "string") {
+    if (typeof args["port"] !== "number") {
       throw new Error("port must be a valid integer");
     }
     wsPort = args["port"];


### PR DESCRIPTION
Follow up to https://github.com/zwave-js/zwave-js-server/pull/220

See my comment here about how the argument is parsed as a number: https://github.com/zwave-js/zwave-js-server/pull/220#discussion_r630451702