### PR TITLE
Add node ping command

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,18 @@ interface {
 }
 ```
 
+#### [Ping](https://zwave-js.github.io/node-zwave-js/#/api/node?id=ping)
+
+[compatible with schema version: 5+]
+
+```ts
+interface {
+  messageId: string;
+  command: "node.ping";
+  nodeId: number;
+}
+```
+
 ## Schema Version
 
 In an attempt to keep compatibility between different server and client versions, we've introduced a (basic) API Schema Version.

--- a/src/lib/node/command.ts
+++ b/src/lib/node/command.ts
@@ -9,4 +9,5 @@ export enum NodeCommand {
   setRawConfigParameterValue = "node.set_raw_config_parameter_value",
   refreshValues = "node.refresh_values",
   refreshCCValues = "node.refresh_cc_values",
+  ping = "node.ping",
 }

--- a/src/lib/node/incoming_message.ts
+++ b/src/lib/node/incoming_message.ts
@@ -66,6 +66,10 @@ export interface IncomingCommandNodeRefreshCCValues
   commandClass: CommandClasses;
 }
 
+export interface IncomingCommandNodePing extends IncomingCommandNodeBase {
+  command: NodeCommand.ping;
+}
+
 export type IncomingMessageNode =
   | IncomingCommandNodeSetValue
   | IncomingCommandNodeRefreshInfo
@@ -76,4 +80,5 @@ export type IncomingMessageNode =
   | IncomingCommandNodePollValue
   | IncomingCommandNodeSetRawConfigParameterValue
   | IncomingCommandNodeRefreshValues
-  | IncomingCommandNodeRefreshCCValues;
+  | IncomingCommandNodeRefreshCCValues
+  | IncomingCommandNodePing;

--- a/src/lib/node/message_handler.ts
+++ b/src/lib/node/message_handler.ts
@@ -80,6 +80,9 @@ export class NodeMessageHandler {
       case NodeCommand.refreshCCValues:
         await node.refreshCCValues(message.commandClass);
         return {};
+      case NodeCommand.ping:
+        const responded = await node.ping();
+        return { responded };
       default:
         throw new UnknownCommandError(command);
     }

--- a/src/lib/node/outgoing_message.ts
+++ b/src/lib/node/outgoing_message.ts
@@ -12,4 +12,5 @@ export interface NodeResultTypes {
   [NodeCommand.setRawConfigParameterValue]: Record<string, never>;
   [NodeCommand.refreshValues]: Record<string, never>;
   [NodeCommand.refreshCCValues]: Record<string, never>;
+  [NodeCommand.ping]: { responded: boolean };
 }


### PR DESCRIPTION
Ping provides the ability to determine if a node is reachable or not. It can help revive failed nodes, or put to sleep nodes that zwave-js thinks are still awake.

### Test Results

#### Ping listening node
Command and response
```
{ "command": "node.ping", "nodeId": 7, "messageId": 99 }
{"type":"result","success":true,"messageId":99,"result":{"responded":true}}
```

zwave-js logs
```
21:47:54.140 CNTRLR » [Node 007] pinging the node...
21:47:54.151 SERIAL » 0x010800130701002507c0                                              (10 bytes)
21:47:54.152 DRIVER » [Node 007] [REQ] [SendData]
                      │ transmit options: 0x25
                      │ callback id:      7
                      └─[NoOperationCC]
21:47:54.178 SERIAL « [ACK]                                                                   (0x06)
21:47:54.186 SERIAL « 0x0104011301e8                                                       (6 bytes)
21:47:54.186 SERIAL » [ACK]                                                                   (0x06)
21:47:54.188 DRIVER « [RES] [SendData]
                        was sent: true
21:47:55.408 SERIAL « 0x011800130700007900bc7f7f7f7f010103000000004204000073              (26 bytes)
21:47:55.409 SERIAL » [ACK]                                                                   (0x06)
21:47:55.414 DRIVER « [REQ] [SendData]
                        callback id:     7
                        transmit status: OK
21:47:55.420 CNTRLR « [Node 007] ping successful
```

#### Ping sleeping node
Command and response
```
{ "command": "node.ping", "nodeId": 2, "messageId": 100 }
{"type":"result","success":true,"messageId":100,"result":{"responded":false}}
```

zwave-js logs
```
21:48:01.022 CNTRLR » [Node 002] pinging the node...
21:48:01.029 SERIAL » 0x010800130201002508ca                                              (10 bytes)
21:48:01.030 DRIVER » [Node 002] [REQ] [SendData]
                      │ transmit options: 0x25
                      │ callback id:      8
                      └─[NoOperationCC]
21:48:01.051 SERIAL « [ACK]                                                                   (0x06)
21:48:01.061 SERIAL « 0x0104011301e8                                                       (6 bytes)
21:48:01.062 SERIAL » [ACK]                                                                   (0x06)
21:48:01.063 DRIVER « [RES] [SendData]
                        was sent: true
21:48:05.350 SERIAL « 0x01180013080101ac007f7f7f7f7f01010700000000020700002d              (26 bytes)
21:48:05.351 SERIAL » [ACK]                                                                   (0x06)
21:48:05.355 DRIVER « [REQ] [SendData]
                        callback id:     8
                        transmit status: NoAck
21:48:05.360 CNTRLR   [Node 002] The node did not respond after 1 attempts.
                      It is probably asleep, moving its messages to the wakeup queue.
21:48:05.361 CNTRLR   [Node 002] ping failed: The node is asleep
```