### PR TITLE
Send originating client `log config updated` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ interface {
 
 [compatible with schema version: 4+]
 
-Start receiving logs as events. Look at the [`logging` event documentation](#logging) for more info.
+Start receiving logs as events. Look at the [`logging` event documentation](#logging) for more information about the events.
 
 ```ts
 interface {

--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ interface {
 
 [compatible with schema version: 4+]
 
+Start receiving logs as events. Look at the [`logging` event documentation](#logging) for more info.
+
 ```ts
 interface {
   messageId: string;
@@ -264,6 +266,8 @@ interface {
 #### Stop listening to logging events
 
 [compatible with schema version: 4+]
+
+Stop receiving logs as events.
 
 ```ts
 interface {
@@ -523,11 +527,20 @@ interface {
 
 All `zwave-js` events as documented are forwarded on to clients that have sent the `start_listening` command.
 
+```ts
+interface {
+  type: "event";
+  source: "driver" | "controller" | "node";
+  event: string;
+  ... // Additional parameters dependent on the event, see zwave-js docs for more details
+}
+```
+
 ### `zwave-js-server` Events
 
 #### `log config updated`
 
-This event is sent with the `driver` as `source` whenever a client issues the `driver.update_log_config` command with the updated log config.
+This event is sent whenever a client issues the `driver.update_log_config` command with the updated log config.
 
 ```ts
 interface {
@@ -536,6 +549,29 @@ interface {
     source: "driver";
     event: "log config updated";
     config: Partial<LogConfig>; // Includes everything but `transports`
+  }
+}
+```
+
+#### `logging`
+
+This event is sent whenever `zwave-js` logs a statement. Clients will only receive these events when they have issued the `driver.start_listening_logs` command.
+
+```ts
+interface {
+  type: "event";
+  event: {
+    source: "driver";
+    event: "logging";
+    formattedMessage: string;
+    direction: string;
+    primaryTags?: string;
+    secondaryTags?: string;
+    secondaryTagPadding?: number;
+    multiline?: boolean;
+    timestamp?: string;
+    label?: string;
+    message: string | string[];
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -511,9 +511,32 @@ interface {
 ```ts
 interface {
   messageId: string;
-  command: "<prefix>.get_cc_versiono"
+  command: "<prefix>.get_cc_version"
   index: number
   commandClass: CommandClasses
+}
+```
+
+## Events
+
+### `zwave-js` Events
+
+All `zwave-js` events as documented are forwarded on to clients that have sent the `start_listening` command.
+
+### `zwave-js-server` Events
+
+#### `log config updated`
+
+This event is sent with the `driver` as `source` whenever a client issues the `driver.update_log_config` command with the updated log config.
+
+```ts
+interface {
+  type: "event";
+  event: {
+    source: "driver";
+    event: "log config updated";
+    config: Partial<LogConfig>; // Includes everything but `transports`
+  }
 }
 ```
 

--- a/src/lib/driver/message_handler.ts
+++ b/src/lib/driver/message_handler.ts
@@ -30,11 +30,12 @@ export class DriverMessageHandler {
         return { config: dumpLogConfig(driver, client.schemaVersion) };
       case DriverCommand.updateLogConfig:
         driver.updateLogConfig(message.config);
+        const config = dumpLogConfig(driver, client.schemaVersion);
         clientsController.clients.forEach((cl) => {
           cl.sendEvent({
             source: "driver",
             event: "log config updated",
-            config: dumpLogConfig(driver, client.schemaVersion),
+            config,
           });
         });
         return {};

--- a/src/lib/driver/message_handler.ts
+++ b/src/lib/driver/message_handler.ts
@@ -29,18 +29,14 @@ export class DriverMessageHandler {
       case DriverCommand.getLogConfig:
         return { config: dumpLogConfig(driver, client.schemaVersion) };
       case DriverCommand.updateLogConfig:
-        const currentLogConfig = dumpLogConfig(driver, client.schemaVersion);
         driver.updateLogConfig(message.config);
-        const newLogConfig = dumpLogConfig(driver, client.schemaVersion);
-        if (currentLogConfig !== newLogConfig) {
-          clientsController.clients.forEach((cl) => {
-            cl.sendEvent({
-              source: "driver",
-              event: "log config updated",
-              config: newLogConfig,
-            });
+        clientsController.clients.forEach((cl) => {
+          cl.sendEvent({
+            source: "driver",
+            event: "log config updated",
+            config: dumpLogConfig(driver, client.schemaVersion),
           });
-        }
+        });
         return {};
       case DriverCommand.isStatisticsEnabled:
         return { statisticsEnabled: driver.statisticsEnabled };

--- a/src/lib/driver/message_handler.ts
+++ b/src/lib/driver/message_handler.ts
@@ -29,16 +29,18 @@ export class DriverMessageHandler {
       case DriverCommand.getLogConfig:
         return { config: dumpLogConfig(driver, client.schemaVersion) };
       case DriverCommand.updateLogConfig:
+        const currentLogConfig = dumpLogConfig(driver, client.schemaVersion);
         driver.updateLogConfig(message.config);
-        clientsController.clients.forEach((cl) => {
-          if (cl !== client) {
+        const newLogConfig = dumpLogConfig(driver, client.schemaVersion);
+        if (currentLogConfig !== newLogConfig) {
+          clientsController.clients.forEach((cl) => {
             cl.sendEvent({
               source: "driver",
               event: "log config updated",
-              config: dumpLogConfig(driver, cl.schemaVersion),
+              config: newLogConfig,
             });
-          }
-        });
+          });
+        }
         return {};
       case DriverCommand.isStatisticsEnabled:
         return { statisticsEnabled: driver.statisticsEnabled };


### PR DESCRIPTION
I removed the guard on sending the event to the initiating client because that way the logic for the command to update the log config doesn't have to worry about maintaining the state - see linked PR for an example, specifically here: https://github.com/home-assistant-libs/zwave-js-server-python/blob/8ebe5cff3245fb15a87a7a8a163a63d6236edce5/zwave_js_server/model/driver.py#L71-L79