### PR TITLE
Improve typing to guard OutgoingEvent values

### DIFF
--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -33,7 +33,7 @@ export class EventForwarder {
         this.sendEvent(client, {
           source: "controller",
           event: "node added",
-          node: dumpNode(node, client.schemaVersion),
+          node: dumpNode(node, client.schemaVersion) as any,
         })
       );
       this.setupNode(node);
@@ -70,7 +70,7 @@ export class EventForwarder {
         this.sendEvent(client, {
           source: "controller",
           event: "node removed",
-          node: dumpNode(node, client.schemaVersion),
+          node: dumpNode(node, client.schemaVersion) as any,
         })
       )
     );
@@ -120,7 +120,7 @@ export class EventForwarder {
           source: "node",
           event: "ready",
           nodeId: changedNode.nodeId,
-          nodeState: dumpNode(changedNode, client.schemaVersion),
+          nodeState: dumpNode(changedNode, client.schemaVersion) as any,
         })
       );
     });
@@ -194,7 +194,7 @@ export class EventForwarder {
             source: "node",
             event: "metadata updated",
             nodeId: changedNode.nodeId,
-            args: newArgs,
+            args: newArgs as any,
           });
         });
       }

--- a/src/lib/outgoing_message.ts
+++ b/src/lib/outgoing_message.ts
@@ -15,7 +15,7 @@ type JSONValue =
   | boolean
   | null
   | JSONValue[]
-  | Record<string, JSONValue>;
+  | { [key: string]: JSONValue };
 
 export interface OutgoingEvent {
   source: "controller" | "node" | "driver";

--- a/src/lib/outgoing_message.ts
+++ b/src/lib/outgoing_message.ts
@@ -11,7 +11,14 @@ import { MulticastGroupResultTypes } from "./multicast_group/outgoing_message";
 export interface OutgoingEvent {
   source: "controller" | "node" | "driver";
   event: string;
-  [key: string]: unknown;
+  [key: string]:
+    | number
+    | number[]
+    | string
+    | string[]
+    | boolean
+    | boolean[]
+    | Object;
 }
 
 interface OutgoingVersionMessage {

--- a/src/lib/outgoing_message.ts
+++ b/src/lib/outgoing_message.ts
@@ -8,17 +8,19 @@ import { ErrorCode } from "./error";
 import { BroadcastNodeResultTypes } from "./broadcast_node/outgoing_message";
 import { MulticastGroupResultTypes } from "./multicast_group/outgoing_message";
 
+// https://github.com/microsoft/TypeScript/issues/1897#issuecomment-822032151
+type JSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JSONValue[]
+  | { [key: string]: JSONValue };
+
 export interface OutgoingEvent {
   source: "controller" | "node" | "driver";
   event: string;
-  [key: string]:
-    | number
-    | number[]
-    | string
-    | string[]
-    | boolean
-    | boolean[]
-    | Object;
+  [key: string]: JSONValue;
 }
 
 interface OutgoingVersionMessage {

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -1,4 +1,3 @@
-import type Transport from "winston-transport";
 import {
   Driver,
   ZWaveController,

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -1,3 +1,4 @@
+import type Transport from "winston-transport";
 import {
   Driver,
   ZWaveController,
@@ -26,7 +27,7 @@ import { numberFromLogLevel } from "../util/logger";
 
 type Modify<T, R> = Omit<T, keyof R> & R;
 
-type LogConfigState = Partial<LogConfig>;
+type LogConfigState = Omit<LogConfig, "transports">;
 export interface DriverState {
   logConfig: LogConfigState;
   statisticsEnabled: boolean;


### PR DESCRIPTION
As discussed, trying to improve the typing to avoid trying to send unserializable data. I think the problem with this is that the Object can contain an unserializable value, but I am not sure how to guard against that.