### PR TITLE
Bump zwave-js-server to 1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Full access to zwave-js driver through Websockets",
   "main": "dist/lib/index.js",
   "bin": {


### PR DESCRIPTION
I'd like to get the last two PRs merged so we can update to thee latest everywhere ahead of beta.

Minor version increase because it was a minor version increase for `zwave-js`