### PR TITLE
Switch from deprecated association method signatures to supported ones

### DIFF
--- a/src/lib/controller/incoming_message.ts
+++ b/src/lib/controller/incoming_message.ts
@@ -1,4 +1,4 @@
-import { Association } from "zwave-js";
+import { AssociationAddress } from "zwave-js";
 import { IncomingCommandBase } from "../incoming_message_base";
 import { ControllerCommand } from "./command";
 
@@ -64,12 +64,14 @@ export interface IncomingCommandControllerGetAssociationGroups
   extends IncomingCommandControllerBase {
   command: ControllerCommand.getAssociationGroups;
   nodeId: number;
+  endpoint?: number;
 }
 
 export interface IncomingCommandControllerGetAssociations
   extends IncomingCommandControllerBase {
   command: ControllerCommand.getAssociations;
   nodeId: number;
+  endpoint?: number;
 }
 
 export interface IncomingCommandControllerIsAssociationAllowed
@@ -77,7 +79,8 @@ export interface IncomingCommandControllerIsAssociationAllowed
   command: ControllerCommand.isAssociationAllowed;
   nodeId: number;
   group: number;
-  association: Association;
+  association: AssociationAddress;
+  endpoint?: number;
 }
 
 export interface IncomingCommandControllerAddAssociations
@@ -85,7 +88,8 @@ export interface IncomingCommandControllerAddAssociations
   command: ControllerCommand.addAssociations;
   nodeId: number;
   group: number;
-  associations: Association[];
+  associations: AssociationAddress[];
+  endpoint?: number;
 }
 
 export interface IncomingCommandControllerRemoveAssociations
@@ -93,7 +97,8 @@ export interface IncomingCommandControllerRemoveAssociations
   command: ControllerCommand.removeAssociations;
   nodeId: number;
   group: number;
-  associations: Association[];
+  associations: AssociationAddress[];
+  endpoint?: number;
 }
 export interface IncomingCommandControllerRemoveNodeFromAllAssociations
   extends IncomingCommandControllerBase {

--- a/src/lib/controller/message_handler.ts
+++ b/src/lib/controller/message_handler.ts
@@ -1,4 +1,4 @@
-import { AssociationAddress, Driver } from "zwave-js";
+import { Driver } from "zwave-js";
 import { UnknownCommandError } from "../error";
 import { ControllerCommand } from "./command";
 import { IncomingMessageController } from "./incoming_message";

--- a/src/lib/controller/message_handler.ts
+++ b/src/lib/controller/message_handler.ts
@@ -1,4 +1,4 @@
-import { Driver } from "zwave-js";
+import { AssociationAddress, Driver } from "zwave-js";
 import { UnknownCommandError } from "../error";
 import { ControllerCommand } from "./command";
 import { IncomingMessageController } from "./incoming_message";
@@ -61,7 +61,10 @@ export class ControllerMessageHandler {
         const groups: ControllerResultTypes[ControllerCommand.getAssociationGroups]["groups"] =
           {};
         driver.controller
-          .getAssociationGroups(message.nodeId)
+          .getAssociationGroups({
+            nodeId: message.nodeId,
+            endpoint: message.endpoint,
+          })
           .forEach((value, key) => (groups[key] = value));
         return { groups };
       }
@@ -69,13 +72,16 @@ export class ControllerMessageHandler {
         const associations: ControllerResultTypes[ControllerCommand.getAssociations]["associations"] =
           {};
         driver.controller
-          .getAssociations(message.nodeId)
+          .getAssociations({
+            nodeId: message.nodeId,
+            endpoint: message.endpoint,
+          })
           .forEach((value, key) => (associations[key] = value));
         return { associations };
       }
       case ControllerCommand.isAssociationAllowed: {
         const allowed = driver.controller.isAssociationAllowed(
-          message.nodeId,
+          { nodeId: message.nodeId, endpoint: message.endpoint },
           message.group,
           message.association
         );
@@ -83,7 +89,7 @@ export class ControllerMessageHandler {
       }
       case ControllerCommand.addAssociations: {
         await driver.controller.addAssociations(
-          message.nodeId,
+          { nodeId: message.nodeId, endpoint: message.endpoint },
           message.group,
           message.associations
         );
@@ -91,7 +97,7 @@ export class ControllerMessageHandler {
       }
       case ControllerCommand.removeAssociations: {
         await driver.controller.removeAssociations(
-          message.nodeId,
+          { nodeId: message.nodeId, endpoint: message.endpoint },
           message.group,
           message.associations
         );

--- a/src/lib/controller/outgoing_message.ts
+++ b/src/lib/controller/outgoing_message.ts
@@ -1,4 +1,4 @@
-import { Association, AssociationAddress, AssociationGroup } from "zwave-js";
+import { AssociationAddress, AssociationGroup } from "zwave-js";
 import { ControllerCommand } from "./command";
 
 export interface ControllerResultTypes {

--- a/src/lib/controller/outgoing_message.ts
+++ b/src/lib/controller/outgoing_message.ts
@@ -1,4 +1,4 @@
-import { Association, AssociationGroup } from "zwave-js";
+import { Association, AssociationAddress, AssociationGroup } from "zwave-js";
 import { ControllerCommand } from "./command";
 
 export interface ControllerResultTypes {
@@ -16,7 +16,7 @@ export interface ControllerResultTypes {
     groups: Record<number, AssociationGroup>;
   };
   [ControllerCommand.getAssociations]: {
-    associations: Record<number, readonly Association[]>;
+    associations: Record<number, readonly AssociationAddress[]>;
   };
   [ControllerCommand.isAssociationAllowed]: { allowed: boolean };
   [ControllerCommand.addAssociations]: Record<string, never>;


### PR DESCRIPTION
The `Association` type has been deprecated in favor of `AssociationAddress`. Similarly, instead of just providing a `nodeId`, we should provide an `AssociationAddress` for the node. I don't think this will break existing usage of these commands so no schema bump is needed