### PR TITLE
Add support for node and controller statistics

### DIFF
--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -188,6 +188,7 @@ export class EventForwarder {
     node.on(
       "metadata updated",
       (changedNode: ZWaveNode, args: ZWaveNodeMetadataUpdatedArgs) => {
+        // only forward value events for ready nodes
         if (!changedNode.ready) return;
         this.clients.clients.forEach((client) => {
           // Copy arguments for each client so transforms don't impact all clients
@@ -279,7 +280,6 @@ export class EventForwarder {
     );
 
     node.on("statistics updated", (statistics: NodeStatistics) => {
-      if (!node.ready) return;
       notifyNode(node, "statistics updated", { statistics });
     });
   }

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -1,6 +1,8 @@
 import {
   ControllerEvents,
+  ControllerStatistics,
   FirmwareUpdateStatus,
+  NodeStatistics,
   NodeStatus,
   ZWaveNode,
   ZWaveNodeEvents,
@@ -92,12 +94,14 @@ export class EventForwarder {
       })
     );
 
-    this.clients.driver.controller.on("statistics updated", (statistics) =>
-      this.forwardEvent({
-        source: "controller",
-        event: "statistics updated",
-        statistics: statistics as any,
-      })
+    this.clients.driver.controller.on(
+      "statistics updated",
+      (statistics: ControllerStatistics) =>
+        this.forwardEvent({
+          source: "controller",
+          event: "statistics updated",
+          statistics: statistics as any,
+        })
     );
   }
 
@@ -273,5 +277,10 @@ export class EventForwarder {
         });
       }
     );
+
+    node.on("statistics updated", (statistics: NodeStatistics) => {
+      if (!node.ready) return;
+      notifyNode(node, "statistics updated", { statistics });
+    });
   }
 }

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -100,7 +100,7 @@ export class EventForwarder {
         this.forwardEvent({
           source: "controller",
           event: "statistics updated",
-          statistics: Object.freeze(statistics),
+          statistics: statistics as any,
         })
     );
   }

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -100,7 +100,7 @@ export class EventForwarder {
         this.forwardEvent({
           source: "controller",
           event: "statistics updated",
-          statistics: statistics as any,
+          statistics: Object.freeze(statistics),
         })
     );
   }

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -64,6 +64,7 @@ export class EventForwarder {
         secure,
       })
     );
+
     this.clients.driver.controller.on("node removed", (node) =>
       // forward event to all connected clients, respecting schemaVersion it supports
       this.clients.clients.forEach((client) =>
@@ -74,6 +75,7 @@ export class EventForwarder {
         })
       )
     );
+
     this.clients.driver.controller.on("heal network progress", (progress) =>
       this.forwardEvent({
         source: "controller",
@@ -81,11 +83,20 @@ export class EventForwarder {
         progress: Object.fromEntries(progress),
       })
     );
+
     this.clients.driver.controller.on("heal network done", (result) =>
       this.forwardEvent({
         source: "controller",
         event: "heal network done",
         result: Object.fromEntries(result),
+      })
+    );
+
+    this.clients.driver.controller.on("statistics updated", (statistics) =>
+      this.forwardEvent({
+        source: "controller",
+        event: "statistics updated",
+        statistics: statistics as any,
       })
     );
   }


### PR DESCRIPTION
Adding statistics to the initial state dump for nodes and the controller, as well as support for these new event: https://github.com/zwave-js/node-zwave-js/pull/2736

Note that I had to freeze `ControllerStatistics` to keep TypeScript happy with the typing