### PR TITLE
Restart log event forwarder when log config changes

### DIFF
--- a/src/lib/driver/message_handler.ts
+++ b/src/lib/driver/message_handler.ts
@@ -31,6 +31,9 @@ export class DriverMessageHandler {
       case DriverCommand.updateLogConfig:
         driver.updateLogConfig(message.config);
         const config = dumpLogConfig(driver, client.schemaVersion);
+        // If the logging event forwarder is enabled, we need to restart
+        // it so that it picks up the new config.
+        clientsController.restartLoggingEventForwarderIfNeeded();
         clientsController.clients.forEach((cl) => {
           cl.sendEvent({
             source: "driver",

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -26,7 +26,7 @@ export class LoggingEventForwarder {
   start() {
     var { transports, level } = this.driver.getLogConfig();
     // Set the log level before attaching the transport
-    this.logger.info("Starting log forwarder at " + level + " level");
+    this.logger.info("Starting logging event forwarder at " + level + " level");
     this.serverTransport = new WebSocketLogTransport(
       level as string,
       this.clients
@@ -37,7 +37,7 @@ export class LoggingEventForwarder {
   }
 
   stop() {
-    this.logger.info("Stopping log forwarder");
+    this.logger.info("Stopping logging event forwarder");
     const transports = this.driver
       .getLogConfig()
       .transports.filter((transport) => transport !== this.serverTransport);

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -13,15 +13,20 @@ export class LoggingEventForwarder {
    */
   private serverTransport?: WebSocketLogTransport;
 
-  constructor(private clients: ClientsController, private driver: Driver) {}
+  constructor(
+    private clients: ClientsController,
+    private driver: Driver,
+    private logger: Logger
+  ) {}
 
   public get started(): boolean {
-    return this.serverTransport != undefined;
+    return this.serverTransport !== undefined;
   }
 
   start() {
     var { transports, level } = this.driver.getLogConfig();
     // Set the log level before attaching the transport
+    this.logger.info("Starting log forwarder at " + level + " level");
     this.serverTransport = new WebSocketLogTransport(
       level as string,
       this.clients
@@ -32,11 +37,20 @@ export class LoggingEventForwarder {
   }
 
   stop() {
+    this.logger.info("Stopping log forwarder");
     const transports = this.driver
       .getLogConfig()
       .transports.filter((transport) => transport !== this.serverTransport);
     this.driver.updateLogConfig({ transports });
     delete this.serverTransport;
+  }
+
+  restartIfNeeded() {
+    var { level } = this.driver.getLogConfig();
+    if (this.started && this.serverTransport?.level != level) {
+      this.stop();
+      this.start();
+    }
   }
 }
 

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -284,9 +284,17 @@ export class ClientsController {
     return this.loggingEventForwarder?.started === true;
   }
 
+  public restartLoggingEventForwarderIfNeeded() {
+    this.loggingEventForwarder?.restartIfNeeded();
+  }
+
   public configureLoggingEventForwarder() {
     if (this.loggingEventForwarder === undefined) {
-      this.loggingEventForwarder = new LoggingEventForwarder(this, this.driver);
+      this.loggingEventForwarder = new LoggingEventForwarder(
+        this,
+        this.driver,
+        this.logger
+      );
     }
     if (!this.loggingEventForwarderStarted) {
       this.loggingEventForwarder?.start();


### PR DESCRIPTION
I could have sworn that the log event forwarder's log level would change automatically when the log config changed in the past, but it is definitely not working now. So instead, whenever the log config gets updated and the log level has changed, we will recreate the transport.

CC @AlCalzone - I was not able to reproduce https://github.com/zwave-js/node-zwave-js/discussions/3113 with this change - my logs showed up both in the HA UI and the console

@MartinHjelmare - I was also not able to reproduce the behavior you mentioned about having to reload the page or go somewhere else and come back. Logs don't always appear immediately because nothing has been logged but without reloading the page I triggered some events and they immediately appeared