### PR TITLE
Send the right log config to each client based on their schema version

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ interface {
   config: {
     logConfig: {
       enabled: boolean;
-      level: string | number; // type depends on schema version, the latest schemas use string
+      level: string | number; // schema versions <= 2 use number, schema versions >= 3 use string
       logToFile: boolean;
       filename: string;
       forceConsole: boolean;
@@ -201,7 +201,7 @@ Returns:
 interface {
   config: {
     enabled: boolean;
-    level: string | number; // type depends on schema version, the latest schemas use string
+    level: string | number; // schema versions <= 2 use number, schema versions >= 3 use string
     logToFile: boolean;
     filename: string;
     forceConsole: boolean;

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ interface {
   config: {
     logConfig: {
       enabled: boolean;
-      level: number;
+      level: string | number; // type depends on schema version, the latest schemas use string
       logToFile: boolean;
       filename: string;
       forceConsole: boolean;
@@ -176,7 +176,7 @@ interface {
   command: "driver.update_log_config";
   config: {
     enabled?: boolean;
-    level?: number;
+    level?: string | number;
     logToFile?: boolean;
     filename?: string;
     forceConsole?: boolean;
@@ -201,7 +201,7 @@ Returns:
 interface {
   config: {
     enabled: boolean;
-    level: number;
+    level: string | number; // type depends on schema version, the latest schemas use string
     logToFile: boolean;
     filename: string;
     forceConsole: boolean;

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ interface {
   config: {
     logConfig: {
       enabled: boolean;
-      level: string | number; // schema versions <= 2 use number, schema versions >= 3 use string
+      level: string | number; // schema versions >= 3 use string, <= 2 use number
       logToFile: boolean;
       filename: string;
       forceConsole: boolean;
@@ -201,7 +201,7 @@ Returns:
 interface {
   config: {
     enabled: boolean;
-    level: string | number; // schema versions <= 2 use number, schema versions >= 3 use string
+    level: string | number; // schema versions >= 3 use string, <= 2 use number
     logToFile: boolean;
     filename: string;
     forceConsole: boolean;

--- a/src/lib/driver/message_handler.ts
+++ b/src/lib/driver/message_handler.ts
@@ -34,11 +34,10 @@ export class DriverMessageHandler {
         // it so that it picks up the new config.
         clientsController.restartLoggingEventForwarderIfNeeded();
         clientsController.clients.forEach((cl) => {
-          const config = dumpLogConfig(driver, cl.schemaVersion);
           cl.sendEvent({
             source: "driver",
             event: "log config updated",
-            config,
+            config: dumpLogConfig(driver, cl.schemaVersion),
           });
         });
         return {};

--- a/src/lib/driver/message_handler.ts
+++ b/src/lib/driver/message_handler.ts
@@ -30,11 +30,11 @@ export class DriverMessageHandler {
         return { config: dumpLogConfig(driver, client.schemaVersion) };
       case DriverCommand.updateLogConfig:
         driver.updateLogConfig(message.config);
-        const config = dumpLogConfig(driver, client.schemaVersion);
         // If the logging event forwarder is enabled, we need to restart
         // it so that it picks up the new config.
         clientsController.restartLoggingEventForwarderIfNeeded();
         clientsController.clients.forEach((cl) => {
+          const config = dumpLogConfig(driver, cl.schemaVersion);
           cl.sendEvent({
             source: "driver",
             event: "log config updated",


### PR DESCRIPTION
Fixes https://github.com/zwave-js/zwave-js-server/issues/335 which includes the background behind this fix