### PR TITLE
chore: bump zwave-js to 8.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -23,6 +23,18 @@
           "requires": {
             "debug": "^4.3.1"
           }
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
         }
       }
     },
@@ -35,6 +47,20 @@
         "axios": "^0.21.1",
         "execa": "^5.0.0",
         "fs-extra": "^9.1.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/code-frame": {
@@ -622,13 +648,13 @@
       }
     },
     "@zwave-js/config": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.0.8.tgz",
-      "integrity": "sha512-i22fgpPwVj6FIJhDTUUkRURqdp3r7c/0pUfj2I6CSKYBpF4FX4Rd+CCXQn8TIXbiPbuqsTeftakVNme1vQnNaQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.1.0.tgz",
+      "integrity": "sha512-kKVihObXQd0DMrrAa2iGtc6V8Z3KFQP6vOYU1kKcNjlh3UumDgidwJHUa1lHo9I8Lr5ik07YQxElcYd+SvqKew==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "8.0.6",
-        "@zwave-js/shared": "8.0.3",
+        "@zwave-js/core": "8.1.0",
+        "@zwave-js/shared": "8.1.0",
         "alcalzone-shared": "^4.0.0",
         "ansi-colors": "^4.1.1",
         "fs-extra": "^10.0.0",
@@ -636,29 +662,16 @@
         "json5": "^2.2.0",
         "semver": "^7.3.5",
         "winston": "^3.3.3"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
       }
     },
     "@zwave-js/core": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-8.0.6.tgz",
-      "integrity": "sha512-vnmJe+EiwYovSUJV15RC5Ebf4EBc3e60hzWnIkJNdH7gVRFYkvkEc4jKn1kPgwAwmIrUY77YdPfhj8YT0qYn8w==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-8.1.0.tgz",
+      "integrity": "sha512-T910/BKJafMgDBuJ7a8c083Q54PflD7tptjVeE20eZ3XdLmbzFpdy11ocyxhUtovwYyvrv6Qw2PnGkQABGdoVQ==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^1.3.0",
-        "@zwave-js/shared": "8.0.3",
+        "@zwave-js/shared": "8.1.0",
         "@zwave-js/winston-daily-rotate-file": "^4.5.6-0",
         "alcalzone-shared": "^4.0.0",
         "ansi-colors": "^4.1.1",
@@ -680,40 +693,27 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-8.0.7.tgz",
-      "integrity": "sha512-QZUCapr/hYlEYrzYb8zt+ohtUb8UzGUHQ7Um60bZnXWOUqIJMbqma230Nt8DDMmHYAi+vwpoB58kcAwGrE2Ffw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-8.1.0.tgz",
+      "integrity": "sha512-XnsTG86kI8NDT3ACdGO9704PgQtegFHnT1Ri/xOziTfeBczFHIVElxuACkenX11ad+NjZAaCgJKFBTJHIVPyrw==",
       "dev": true,
       "requires": {
-        "@sentry/node": "^6.10.0",
-        "@zwave-js/core": "8.0.6",
-        "@zwave-js/shared": "8.0.3",
+        "@sentry/node": "^6.11.0",
+        "@zwave-js/core": "8.1.0",
+        "@zwave-js/shared": "8.1.0",
         "alcalzone-shared": "^4.0.0",
         "serialport": "^9.2.0",
         "winston": "^3.3.3"
       }
     },
     "@zwave-js/shared": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-8.0.3.tgz",
-      "integrity": "sha512-WOFphykYnBbknVVqJa2fw1gj56JSvS19jUiKern5hksgMgBsi+ehXyCqzUCFpLPLC27Bo+Ps9tRqx0xAKtyLkA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-8.1.0.tgz",
+      "integrity": "sha512-vu9hMG3aih1pkGx4VWDJy4eRiLXFCo6nyt59Rqhan7KEh/AgLF3C/pmV13VnaalcHPKsY1Yt5ARAjFNYchQZkA==",
       "dev": true,
       "requires": {
         "alcalzone-shared": "^4.0.0",
         "fs-extra": "^10.0.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
       }
     },
     "@zwave-js/winston-daily-rotate-file": {
@@ -963,9 +963,9 @@
       }
     },
     "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
     "callsites": {
@@ -1607,12 +1607,11 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
       "dev": true,
       "requires": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
@@ -1756,9 +1755,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "dev": true
     },
     "has-flag": {
@@ -2519,9 +2518,9 @@
       }
     },
     "prebuild-install": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.3.tgz",
-      "integrity": "sha512-iqqSR84tNYQUQHRXalSKdIaM8Ov1QxOVuBNWI7+BzZWv6Ih9k75wOnH1rGQ9WWTaaLkTpxWKIciOF0KyfM74+Q==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
+      "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3",
@@ -3295,19 +3294,19 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.0.8.tgz",
-      "integrity": "sha512-b1NcF1vLY9T2NcHT6yLmd9xwCx2Ufa9jDuAxoPWtLDeVcLWBwUoiBESM+URzK8yNCh/LPLpu/z7i022rEWRPMA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.1.0.tgz",
+      "integrity": "sha512-3qLsAtw/xIpDc+pTjRjw63a0amsjCXq+xi/bXQ41sWvGa2q5JDBq23pBZG5C3rkpFfsIhREf5zgcKuJP7eSL+w==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^1.3.0",
         "@alcalzone/pak": "^0.6.0",
-        "@sentry/integrations": "^6.10.0",
-        "@sentry/node": "^6.10.0",
-        "@zwave-js/config": "8.0.8",
-        "@zwave-js/core": "8.0.6",
-        "@zwave-js/serial": "8.0.7",
-        "@zwave-js/shared": "8.0.3",
+        "@sentry/integrations": "^6.11.0",
+        "@sentry/node": "^6.11.0",
+        "@zwave-js/config": "8.1.0",
+        "@zwave-js/core": "8.1.0",
+        "@zwave-js/serial": "8.1.0",
+        "@zwave-js/shared": "8.1.0",
         "alcalzone-shared": "^4.0.0",
         "ansi-colors": "^4.1.1",
         "axios": "^0.21.1",
@@ -3320,19 +3319,6 @@
         "source-map-support": "^0.5.19",
         "winston": "^3.3.3",
         "xstate": "^4.23.1"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3294,9 +3294,9 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.1.0.tgz",
-      "integrity": "sha512-3qLsAtw/xIpDc+pTjRjw63a0amsjCXq+xi/bXQ41sWvGa2q5JDBq23pBZG5C3rkpFfsIhREf5zgcKuJP7eSL+w==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.1.1.tgz",
+      "integrity": "sha512-LyK06qNIZZNjjhu0+L3HSNBLFD64S8t4nQyYp0+Xj3TYf/4XTB9dTjX/DVIt1f2L9OIZS1CeSvLuxlz1F+Mvng==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "Full access to zwave-js driver through Websockets",
   "main": "dist/lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ws": "^8.0.0"
   },
   "peerDependencies": {
-    "zwave-js": "^8.1.0"
+    "zwave-js": "^8.1.1"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -42,7 +42,7 @@
     "prettier": "^2.3.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^8.1.0"
+    "zwave-js": "^8.1.1"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ws": "^8.0.0"
   },
   "peerDependencies": {
-    "zwave-js": "^8.0.8"
+    "zwave-js": "^8.1.0"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -42,7 +42,7 @@
     "prettier": "^2.3.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^8.0.8"
+    "zwave-js": "^8.1.0"
   },
   "husky": {
     "hooks": {

--- a/src/lib/controller/message_handler.ts
+++ b/src/lib/controller/message_handler.ts
@@ -14,7 +14,7 @@ export class ControllerMessageHandler {
     switch (message.command) {
       case ControllerCommand.beginInclusion: {
         const success = await driver.controller.beginInclusion(
-          message.includeNonSecure!
+          message.includeNonSecure
         );
         return { success };
       }
@@ -37,7 +37,7 @@ export class ControllerMessageHandler {
       case ControllerCommand.replaceFailedNode: {
         const success = await driver.controller.replaceFailedNode(
           message.nodeId,
-          message.includeNonSecure!
+          message.includeNonSecure
         );
         return { success };
       }

--- a/src/lib/controller/message_handler.ts
+++ b/src/lib/controller/message_handler.ts
@@ -14,7 +14,7 @@ export class ControllerMessageHandler {
     switch (message.command) {
       case ControllerCommand.beginInclusion: {
         const success = await driver.controller.beginInclusion(
-          message.includeNonSecure
+          message.includeNonSecure!
         );
         return { success };
       }
@@ -37,7 +37,7 @@ export class ControllerMessageHandler {
       case ControllerCommand.replaceFailedNode: {
         const success = await driver.controller.replaceFailedNode(
           message.nodeId,
-          message.includeNonSecure
+          message.includeNonSecure!
         );
         return { success };
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "types": ["node"],
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "strict": true
+    "strict": true,
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
Updating `zwave-js` should solve a little DDOS problem we have with our telemetry infrastructure right now.