### PR TITLE
Log additional properties of an error

### DIFF
--- a/src/lib/outgoing_message.ts
+++ b/src/lib/outgoing_message.ts
@@ -10,13 +10,14 @@ import { MulticastGroupResultTypes } from "./multicast_group/outgoing_message";
 import { EndpointResultTypes } from "./endpoint/outgoing_message";
 
 // https://github.com/microsoft/TypeScript/issues/1897#issuecomment-822032151
-type JSONValue =
+export type JSONValue =
   | string
   | number
   | boolean
   | null
   | JSONValue[]
-  | { [key: string]: JSONValue };
+  | { [key: string]: JSONValue }
+  | {};
 
 export interface OutgoingEvent {
   source: "controller" | "node" | "driver";
@@ -43,6 +44,7 @@ interface OutgoingResultMessageError {
   messageId: string;
   success: false;
   errorCode: Omit<ErrorCode, "zwaveError">;
+  args: JSONValue;
 }
 
 interface OutgoingResultMessageZWaveError {

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -152,7 +152,8 @@ export class Client {
     } catch (err: unknown) {
       if (err instanceof BaseError) {
         this.logger.error("Message error", err);
-        return this.sendResultError(msg.messageId, err.errorCode);
+        const { errorCode, name, message, stack, ...args } = err;
+        return this.sendResultError(msg.messageId, errorCode, args);
       }
       if (err instanceof ZWaveError) {
         this.logger.error("Z-Wave error", err);
@@ -160,7 +161,7 @@ export class Client {
       }
 
       this.logger.error("Unexpected error", err as Error);
-      this.sendResultError(msg.messageId, ErrorCode.unknownError);
+      this.sendResultError(msg.messageId, ErrorCode.unknownError, {});
     }
   }
 
@@ -187,12 +188,17 @@ export class Client {
     });
   }
 
-  sendResultError(messageId: string, errorCode: Omit<ErrorCode, "zwaveError">) {
+  sendResultError(
+    messageId: string,
+    errorCode: Omit<ErrorCode, "zwaveError">,
+    args: OutgoingMessages.JSONValue
+  ) {
     this.sendData({
       type: "result",
       success: false,
       messageId,
       errorCode,
+      args,
     });
   }
 


### PR DESCRIPTION
We capture additional context for some errors but we did not pass that back to the client - now we will