### PR TITLE
Bump zwave-js to 8.1.1 and zwave-js-server to 1.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1595,9 +1595,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.2.tgz",
+      "integrity": "sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA==",
       "dev": true
     },
     "fs-constants": {
@@ -2107,9 +2107,9 @@
       }
     },
     "localforage": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.9.0.tgz",
-      "integrity": "sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
       "dev": true,
       "requires": {
         "lie": "3.1.1"
@@ -3294,9 +3294,9 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.1.0.tgz",
-      "integrity": "sha512-3qLsAtw/xIpDc+pTjRjw63a0amsjCXq+xi/bXQ41sWvGa2q5JDBq23pBZG5C3rkpFfsIhREf5zgcKuJP7eSL+w==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.1.1.tgz",
+      "integrity": "sha512-LyK06qNIZZNjjhu0+L3HSNBLFD64S8t4nQyYp0+Xj3TYf/4XTB9dTjX/DVIt1f2L9OIZS1CeSvLuxlz1F+Mvng==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "description": "Full access to zwave-js driver through Websockets",
   "main": "dist/lib/index.js",
   "bin": {
@@ -25,7 +25,7 @@
     "ws": "^8.0.0"
   },
   "peerDependencies": {
-    "zwave-js": "^8.1.0"
+    "zwave-js": "^8.1.1"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -42,7 +42,7 @@
     "prettier": "^2.3.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^8.1.0",
+    "zwave-js": "^8.1.1",
     "alcalzone-shared": "^4.0.0"
   },
   "husky": {


### PR DESCRIPTION
We have already merged the corresponding S2 changes in the lib so we should release this so we can start working on a dependency upgrade in core