### PR TITLE
Bump zwave-js-server 1.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Full access to zwave-js driver through Websockets",
   "main": "dist/lib/index.js",
   "bin": {


### PR DESCRIPTION
To release https://github.com/zwave-js/zwave-js-server/pull/356 to fix https://github.com/zwave-js/zwave-js-server/issues/355