### PR TITLE
Bump schema and server version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.10.3",
+  "version": "1.11.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.11.4",
+  "version": "1.10.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.10.3",
+  "version": "1.11.4",
   "description": "Full access to zwave-js driver through Websockets",
   "main": "dist/lib/index.js",
   "bin": {
@@ -25,7 +25,7 @@
     "ws": "^8.0.0"
   },
   "peerDependencies": {
-    "zwave-js": "^8.1.1"
+    "zwave-js": "^8.3.1"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -42,7 +42,7 @@
     "prettier": "^2.3.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^8.1.1",
+    "zwave-js": "^8.3.1",
     "alcalzone-shared": "^4.0.0"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.11.4",
+  "version": "1.10.4",
   "description": "Full access to zwave-js driver through Websockets",
   "main": "dist/lib/index.js",
   "bin": {

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -4,4 +4,4 @@ export const version = require("../../package.json").version;
 export const minSchemaVersion = 0;
 
 // maximal/current schema version the server supports
-export const maxSchemaVersion = 8;
+export const maxSchemaVersion = 9;


### PR DESCRIPTION
Per the conversation in devs_zwave, we want to bump the schema version and release a new server version. This will allow us to force users to update to the latest server in our next release because we plan to add S2 support and want to ensure users are using zwave-js 8.3.1 at a minimum.

I chose a patch release for this since the API isn't changing

CC @MartinHjelmare 