### PR TITLE
Bump zwave-js-server to 1.10.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "Full access to zwave-js driver through Websockets",
   "main": "dist/lib/index.js",
   "bin": {


### PR DESCRIPTION
So we can release the callback fix and handle replacing failed nodes properly in HA

https://github.com/home-assistant/core/pull/56599