### PR TITLE
Allow S2 keys in OZW format for migration from networkKey

### DIFF
--- a/src/bin/server.ts
+++ b/src/bin/server.ts
@@ -5,14 +5,11 @@ import { ZwavejsServer } from "../lib/server";
 import { createMockDriver } from "../mock";
 import { parseArgs } from "../util/parse-args";
 
-const normalizeKey = (
-  key: Buffer | string,
-  keyName: string,
-  supportOZWFormat: boolean = false
-): Buffer => {
+const normalizeKey = (key: Buffer | string, keyName: string): Buffer => {
   if (Buffer.isBuffer(key)) return key;
   if (key.length === 32) return Buffer.from(key, "hex");
-  if (supportOZWFormat && key.includes("0x"))
+  // Convert from OpenZWave format
+  if (key.includes("0x"))
     return Buffer.from(key.replace(/0x/g, "").replace(/, /g, ""), "hex");
   throw new Error(`Invalid key format for ${keyName} option`);
 };
@@ -86,8 +83,7 @@ interface Args {
         if (!options.securityKeys) options.securityKeys = {};
         options.securityKeys.S0_Legacy = normalizeKey(
           options.networkKey,
-          "networkKey",
-          true
+          "networkKey"
         );
         console.warn(
           "The `networkKey` option is deprecated in favor of `securityKeys` option. To eliminate " +


### PR DESCRIPTION
This allows for migrations from `"networkKey"`, which are allowed to be in OZW format, to `"S0_Legacy"` without requiring a change in key format. Client applications can choose to migrate key formats on their own.

First reported at https://community.home-assistant.io/t/zwave-js-fails-to-load/342679. Based on the error, I am assuming the user had a previously working addon, so the key must have originally been entered in the OZW format, and after upgrading the addon it migrated it to the `S0_Legacy` option name, which doesn't allow OZW format keys.