### PR TITLE
Bump zwave-js to 8.4.1 and zwave-js-server to 1.10.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -341,9 +341,9 @@
       }
     },
     "@serialport/binding-mock": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-9.2.3.tgz",
-      "integrity": "sha512-J9c9nyZFPpdAgTjjY1tF9+urYP2uouVL2/FZQ+XO/ejgMJaakCWx5qmmiWX1hl+TgqrydVUoQxH0ONLHboDVng==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-9.2.4.tgz",
+      "integrity": "sha512-dpEhACCs44oQhh6ajJfJdvQdK38Vq0N4W6iD/gdplglDCK7qXRQCMUjJIeKdS/HSEiWkC3bwumUhUufdsOyT4g==",
       "dev": true,
       "requires": {
         "@serialport/binding-abstract": "9.2.3",
@@ -362,13 +362,13 @@
       }
     },
     "@serialport/bindings": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.2.3.tgz",
-      "integrity": "sha512-OynzVDYYb+12Kb2CvRohpjmTMDVfa0MtpJH5YbCXZ6/XmaobmbyU+x7yXFdVcRhZoo6HQmx3AL+U8Dk6vujYdw==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.2.4.tgz",
+      "integrity": "sha512-l3IHtIL9aN42Xrqu9L8g/+jZcR0jfnXwRxHslDA8YRd7Jw9lo1qL/vqiIYkvC8NAW3Iz2JdWeM7Pr98l/rwjSQ==",
       "dev": true,
       "requires": {
         "@serialport/binding-abstract": "9.2.3",
-        "@serialport/parser-readline": "^9.0.7",
+        "@serialport/parser-readline": "9.2.4",
         "bindings": "^1.5.0",
         "debug": "^4.3.2",
         "nan": "^2.15.0",
@@ -387,54 +387,54 @@
       }
     },
     "@serialport/parser-byte-length": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-9.0.7.tgz",
-      "integrity": "sha512-evf7oOOSBMBn2AZZbgBFMRIyEzlsyQkhqaPm7IBCPTxMDXRf4tKkFYJHYZB0/6d1W4eI0meH079UqmSsh/uoDA==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-9.2.4.tgz",
+      "integrity": "sha512-sQD/iw4ZMU3xW9PLi0/GlvU6Y623jGeWecbMkO7izUo/6P7gtfv1c9ikd5h0kwL8AoAOpQA1lxdHIKox+umBUg==",
       "dev": true
     },
     "@serialport/parser-cctalk": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-9.0.7.tgz",
-      "integrity": "sha512-ert5jhMkeiTfr44TkbdySC09J8UwAsf/RxBucVN5Mz5enG509RggnkfFi4mfj3UCG2vZ7qsmM6gtZ62DshY02Q==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-9.2.4.tgz",
+      "integrity": "sha512-T4TU5vQMwmo9AB3gQLFDWbfJXlW5jd9guEsB/nqKjFHTv0FXPdZ7DQ2TpSp8RnHWxU3GX6kYTaDO20BKzc8GPQ==",
       "dev": true
     },
     "@serialport/parser-delimiter": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.7.tgz",
-      "integrity": "sha512-Vb2NPeXPZ/28M4m5x4OAHFd8jRAeddNCgvL+Q+H/hqFPY1w47JcMLchC7pigRW8Cnt1fklmzfwdNQ8Fb+kMkxQ==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.2.4.tgz",
+      "integrity": "sha512-4nvTAoYAgkxFiXrkI+3CA49Yd43CODjeszh89EK+I9c8wOZ+etZduRCzINYPiy26g7zO+GRAb9FoPCsY+sYcbQ==",
       "dev": true
     },
     "@serialport/parser-inter-byte-timeout": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-9.0.7.tgz",
-      "integrity": "sha512-lUZ3cwgUluBvJ1jf+0LQsqoiPYAokDO6+fRCw9HCfnrF/OS60Gm4rxuyo2uQIueqZkJ7NIFP+ibKsULrA47AEA==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-9.2.4.tgz",
+      "integrity": "sha512-SOAdvr0oBQIOCXX198hiTlxs4JTKg9j5piapw5tNq52fwDOWdbYrFneT/wN04UTMKaDrJuEvXq6T4rv4j7nJ5A==",
       "dev": true
     },
     "@serialport/parser-readline": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.7.tgz",
-      "integrity": "sha512-ydoLbgVQQPxWrwbe3Fhh4XnZexbkEQAC6M/qgRTzjnKvTjrD61CJNxLc3vyDaAPI9bJIhTiI7eTX3JB5jJv8Hg==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.2.4.tgz",
+      "integrity": "sha512-Z1/qrZTQUVhNSJP1hd9YfDvq0o7d87rNwAjjRKbVpa7Qi51tG5BnKt43IV3NFMyBlVcRe0rnIb3tJu57E0SOwg==",
       "dev": true,
       "requires": {
-        "@serialport/parser-delimiter": "^9.0.7"
+        "@serialport/parser-delimiter": "9.2.4"
       }
     },
     "@serialport/parser-ready": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-9.0.7.tgz",
-      "integrity": "sha512-3qYhI4cNUPAYqVYvdwV57Y+PVRl4dJf1fPBtMoWtwDgwopsAXTR93WCs49WuUq9JCyNW+8Hrfqv8x8eNAD5Dqg==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-9.2.4.tgz",
+      "integrity": "sha512-Pyi94Itjl6qAURwIZr/gmZpMAyTmKXThm6vL5DoAWGQjcRHWB0gwv2TY2v7N+mQLJYUKU3cMnvnATXxHm7xjxw==",
       "dev": true
     },
     "@serialport/parser-regex": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-9.0.7.tgz",
-      "integrity": "sha512-5XF+FXbhqQ/5bVKM4NaGs1m+E9KjfmeCx/obwsKaUZognQF67jwoTfjJJWNP/21jKfxdl8XoCYjZjASl3XKRAw==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-9.2.4.tgz",
+      "integrity": "sha512-sI/cVvPOYz+Dbv4ZdnW16qAwvXiFf/1pGASQdbveRTlgJDdz7sRNlCBifzfTN2xljwvCTZYqiudKvDdC1TepRQ==",
       "dev": true
     },
     "@serialport/stream": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-9.2.3.tgz",
-      "integrity": "sha512-JPueqym5YP1esufgndB2EjwHcVwshbeKbHuuxAglHlNYEN5X2K6sNmjVZmdy8UPeUpxrrnmXOTDG1Psr3RiZnA==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-9.2.4.tgz",
+      "integrity": "sha512-bLye8Ub4vUFQGmkh8qEqehr7SE7EJs2yDs0h9jzuL5oKi+F34CFmWkEErO8GAOQ8YNn7p6b3GxUgs+0BrHHDZQ==",
       "dev": true,
       "requires": {
         "debug": "^4.3.2"
@@ -692,9 +692,9 @@
       }
     },
     "@zwave-js/config": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.4.0.tgz",
-      "integrity": "sha512-6RQVgJHKsVtu7PrPcmtnc1S3P11rPHLMHSrhek5S0HP0j44pI/FoRhrlvfJTnwHUpZJer1vqiNdMxI+JarsP1A==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.4.1.tgz",
+      "integrity": "sha512-yO1ZgH0aIPw7oadb7XDCe0uHY/pAmaS/miAweOnAvZhOfXWQxMBGffDXKBtRBWKAok67QKhgXxsKSM9hBGLOMw==",
       "dev": true,
       "requires": {
         "@zwave-js/core": "8.3.1",
@@ -2775,21 +2775,21 @@
       "dev": true
     },
     "serialport": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/serialport/-/serialport-9.2.3.tgz",
-      "integrity": "sha512-6wvZjwZ09imEftdR78TMKQ75eG6oSXZJHO8JRE0tHtNjUeaMvmSvCqOy/oKLdIUh6hvphmrNiPLO2K1UPmsU1A==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/serialport/-/serialport-9.2.4.tgz",
+      "integrity": "sha512-QRn9/iYTK7qXfACskR+f2NIXwSZf/DwPQgFNRP89THFoX2sQVsMyNQZ9quB1XP5RujL7wYTRtZ/eSGSACI1d3A==",
       "dev": true,
       "requires": {
-        "@serialport/binding-mock": "9.2.3",
-        "@serialport/bindings": "9.2.3",
-        "@serialport/parser-byte-length": "9.0.7",
-        "@serialport/parser-cctalk": "9.0.7",
-        "@serialport/parser-delimiter": "9.0.7",
-        "@serialport/parser-inter-byte-timeout": "9.0.7",
-        "@serialport/parser-readline": "9.0.7",
-        "@serialport/parser-ready": "9.0.7",
-        "@serialport/parser-regex": "9.0.7",
-        "@serialport/stream": "9.2.3",
+        "@serialport/binding-mock": "9.2.4",
+        "@serialport/bindings": "9.2.4",
+        "@serialport/parser-byte-length": "9.2.4",
+        "@serialport/parser-cctalk": "9.2.4",
+        "@serialport/parser-delimiter": "9.2.4",
+        "@serialport/parser-inter-byte-timeout": "9.2.4",
+        "@serialport/parser-readline": "9.2.4",
+        "@serialport/parser-ready": "9.2.4",
+        "@serialport/parser-regex": "9.2.4",
+        "@serialport/stream": "9.2.4",
         "debug": "^4.3.2"
       },
       "dependencies": {
@@ -3349,16 +3349,16 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.4.0.tgz",
-      "integrity": "sha512-Ij39c+lkanyo0CHiByxKbAGamsxZqEywWmIFUjW7GuQ3aThIKT1MNqbIlGNMlS5U+CmbMie7GMlCYNDngdTBFw==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.4.1.tgz",
+      "integrity": "sha512-DodnSnKEFfJPUUHjkY0BaaEeOCtM8cRuKpK26kP8gUFhdj+aYA5q1o/0FSwIQo3Ym/tHwgDCbQnNQj9Xn46sUg==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^1.3.0",
         "@alcalzone/pak": "^0.7.0",
         "@sentry/integrations": "^6.12.0",
         "@sentry/node": "^6.12.0",
-        "@zwave-js/config": "8.4.0",
+        "@zwave-js/config": "8.4.1",
         "@zwave-js/core": "8.3.1",
         "@zwave-js/serial": "8.3.1",
         "@zwave-js/shared": "8.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "description": "Full access to zwave-js driver through Websockets",
   "main": "dist/lib/index.js",
   "bin": {
@@ -25,7 +25,7 @@
     "ws": "^8.0.0"
   },
   "peerDependencies": {
-    "zwave-js": "^8.3.1"
+    "zwave-js": "^8.4.1"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -42,7 +42,7 @@
     "prettier": "^2.3.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^8.3.1",
+    "zwave-js": "^8.4.1",
     "alcalzone-shared": "^4.0.0"
   },
   "husky": {


### PR DESCRIPTION
This is mainly so we can add support for the OZW network key format