### PR TITLE
Bump zwave-js-server to 1.10.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "description": "Full access to zwave-js driver through Websockets",
   "main": "dist/lib/index.js",
   "bin": {

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -4,4 +4,4 @@ export const version = require("../../package.json").version;
 export const minSchemaVersion = 0;
 
 // maximal/current schema version the server supports
-export const maxSchemaVersion = 9;
+export const maxSchemaVersion = 10;


### PR DESCRIPTION
To release https://github.com/zwave-js/zwave-js-server/pull/403 - I think we should bump the schema version as part of the change to make sure people are on the latest so have done that here as well