### PR TITLE
Restart driver and server instance on Driver_Failed error

### DIFF
--- a/src/bin/server.ts
+++ b/src/bin/server.ts
@@ -66,12 +66,10 @@ async () => {
       if (options.securityKeys) {
         let key: keyof typeof options.securityKeys;
         for (key in options.securityKeys) {
-          if (key in options.securityKeys) {
-            options.securityKeys[key] = normalizeKey(
-              options.securityKeys[key]!,
-              `securityKeys.${key}`
-            );
-          }
+          options.securityKeys[key] = normalizeKey(
+            options.securityKeys[key]!,
+            `securityKeys.${key}`
+          );
         }
       }
       // If we get here, securityKeys.S0_Legacy is not defined, so we can safely use networkKey
@@ -88,7 +86,7 @@ async () => {
             "the Z-Wave JS docs for more information"
         );
         delete options.networkKey;
-      } else if (!options.networkKey && !options.securityKeys!.S0_Legacy)
+      } else if (!options.networkKey)
         throw new Error("Error: `securityKeys.S0_Legacy` key is missing.");
     } catch (err) {
       console.error(`Error: failed loading config file ${configPath}`);


### PR DESCRIPTION
Had some typing issues doing this the simple way (first two commits) so the solution ended up a bit more complicated. The end result is that if the driver doesn't start successfully or `Driver_Failed` is raised, the process will wait for five seconds and then attempt to start the driver again.

I was able to successfully test this using @kpine's method of unbinding and rebinding the USB driver (https://github.com/kpine/zwave-js-server-docker/wiki/Tips-and-Tricks#hard-resetting-a-usb-device)

Fixes #416