### PR TITLE
Add inclusion support for SmartStart and S2 w/ QR code

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,10 @@ interface {
 }
 ```
 
+### Utility commands
+
+`zwave-js-server` supports all of the utility methods listed in the [Z-Wave JS documentation](https://zwave-js.github.io/node-zwave-js/#/api/utils). `zwave-js-server` uses [snake casing](https://en.wikipedia.org/wiki/Snake_case) for commands and prefixes every controller command with `utils.`, so `parseQRCodeString` is called using the `utils.parse_qr_code_string` command.
+
 ## Events
 
 ### `zwave-js` Events

--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ interface {
 
 `zwave-js-server` supports all of the controller methods listed in the [Z-Wave JS documentation](https://zwave-js.github.io/node-zwave-js/#/api/controller?id=controller-methods). `zwave-js-server` uses [snake casing](https://en.wikipedia.org/wiki/Snake_case) for commands and prefixes every controller command with `controller.`, so `beginInclusion` is called using the `controller.begin_inclusion` command.
 
+> NOTE: For the most part, `controller` commands have the same inputs as documented in the Z-Wave JS documentation. The two exceptions are `controller.begin_inclusion` and `controller.provision_smart_start_node`; in addition to the input types that are documented, these commands will also accept the QR code string directly and will convert the string to a `QRProvisioningInformation` object automatically.
+
 ### Node level commands
 
 #### [Set value on a node](https://zwave-js.github.io/node-zwave-js/#/api/node?id=setvalue)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "@zwave-js/server",
   "version": "1.10.8",
   "description": "Full access to zwave-js driver through Websockets",
+  "homepage": "https://github.com/zwave-js/zwave-js-server#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zwave-js/zwave-js-server.git"
+  },
+  "bugs": {
+    "url": "https://github.com/zwave-js/zwave-js-server/issues"
+  },
   "main": "dist/lib/index.js",
   "bin": {
     "zwave-server": "dist/bin/server.js",

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -4,4 +4,4 @@ export const version = require("../../package.json").version;
 export const minSchemaVersion = 0;
 
 // maximal/current schema version the server supports
-export const maxSchemaVersion = 10;
+export const maxSchemaVersion = 11;

--- a/src/lib/controller/command.ts
+++ b/src/lib/controller/command.ts
@@ -21,4 +21,8 @@ export enum ControllerCommand {
   getNodeNeighbors = "controller.get_node_neighbors",
   grantSecurityClasses = "controller.grant_security_classes",
   validateDSKAndEnterPIN = "controller.validate_dsk_and_enter_pin",
+  provisionSmartStartNode = "controller.provision_smart_start_node",
+  unprovisionSmartStartNode = "controller.unprovision_smart_start_node",
+  getProvisioningEntry = "controller.get_provisioning_entry",
+  getProvisioningEntries = "controller.get_provisioning_entries",
 }

--- a/src/lib/controller/incoming_message.ts
+++ b/src/lib/controller/incoming_message.ts
@@ -33,6 +33,7 @@ export interface IncomingCommandControllerStopInclusion
 export interface IncomingCommandControllerBeginExclusion
   extends IncomingCommandControllerBase {
   command: ControllerCommand.beginExclusion;
+  unprovision?: boolean;
 }
 
 export interface IncomingCommandControllerStopExclusion

--- a/src/lib/controller/incoming_message.ts
+++ b/src/lib/controller/incoming_message.ts
@@ -2,8 +2,10 @@ import {
   AssociationAddress,
   InclusionGrant,
   InclusionOptions,
+  PlannedProvisioningEntry,
   ReplaceNodeOptions,
 } from "zwave-js";
+import type { QRProvisioningInformation } from "@zwave-js/core";
 import { IncomingCommandBase } from "../incoming_message_base";
 import { ControllerCommand } from "./command";
 
@@ -148,6 +150,30 @@ export interface IncomingCommandControllerValidateDSKAndEnterPIN
   pin: string;
 }
 
+export interface IncomingCommandControllerProvisionSmartStartNode
+  extends IncomingCommandControllerBase {
+  command: ControllerCommand.provisionSmartStartNode;
+  entry: PlannedProvisioningEntry | string;
+}
+
+export interface IncomingCommandControllerUnprovisionSmartStartNode
+  extends IncomingCommandControllerBase {
+  command: ControllerCommand.unprovisionSmartStartNode;
+  dskOrNodeId: string | number;
+}
+
+export interface IncomingCommandControllerGetProvisioningEntry
+  extends IncomingCommandControllerBase {
+  command: ControllerCommand.getProvisioningEntry;
+  dsk: string;
+}
+
+export interface IncomingCommandControllerGetProvisioningEntries
+  extends IncomingCommandControllerBase {
+  command: ControllerCommand.getProvisioningEntries;
+  pin: string;
+}
+
 export type IncomingMessageController =
   | IncomingCommandControllerBeginInclusion
   | IncomingCommandControllerBeginInclusionLegacy
@@ -169,4 +195,8 @@ export type IncomingMessageController =
   | IncomingCommandControllerRemoveNodeFromAllAssociations
   | IncomingCommandControllerGetNodeNeighbors
   | IncomingCommandControllerGrantSecurityClasses
-  | IncomingCommandControllerValidateDSKAndEnterPIN;
+  | IncomingCommandControllerValidateDSKAndEnterPIN
+  | IncomingCommandControllerProvisionSmartStartNode
+  | IncomingCommandControllerUnprovisionSmartStartNode
+  | IncomingCommandControllerGetProvisioningEntry
+  | IncomingCommandControllerGetProvisioningEntries;

--- a/src/lib/controller/incoming_message.ts
+++ b/src/lib/controller/incoming_message.ts
@@ -172,7 +172,6 @@ export interface IncomingCommandControllerGetProvisioningEntry
 export interface IncomingCommandControllerGetProvisioningEntries
   extends IncomingCommandControllerBase {
   command: ControllerCommand.getProvisioningEntries;
-  pin: string;
 }
 
 export type IncomingMessageController =

--- a/src/lib/controller/incoming_message.ts
+++ b/src/lib/controller/incoming_message.ts
@@ -153,7 +153,7 @@ export interface IncomingCommandControllerValidateDSKAndEnterPIN
 export interface IncomingCommandControllerProvisionSmartStartNode
   extends IncomingCommandControllerBase {
   command: ControllerCommand.provisionSmartStartNode;
-  entry: PlannedProvisioningEntry | string;
+  entry: PlannedProvisioningEntry | string | QRProvisioningInformation;
 }
 
 export interface IncomingCommandControllerUnprovisionSmartStartNode

--- a/src/lib/controller/message_handler.ts
+++ b/src/lib/controller/message_handler.ts
@@ -209,7 +209,11 @@ function processInclusionOptions(
       options.strategy === InclusionStrategy.Default ||
       options.strategy === InclusionStrategy.Security_S2
     ) {
-      if (!("provisioning" in options)) {
+      if ("provisioning" in options) {
+        if (typeof options.provisioning === "string") {
+          options.provisioning = parseQRCodeString(options.provisioning);
+        }
+      } else {
         let grantSecurityClassesPromise:
           | DeferredPromise<InclusionGrant | false>
           | undefined;

--- a/src/lib/controller/message_handler.ts
+++ b/src/lib/controller/message_handler.ts
@@ -211,7 +211,15 @@ function processInclusionOptions(
       options.strategy === InclusionStrategy.Default ||
       options.strategy === InclusionStrategy.Security_S2
     ) {
+      // When using Security_S2 inclusion, the user can either provide the provisioning details ahead
+      // of time or go through a standard inclusion process and let the driver/client prompt them
+      // for provisioning details based on information received from the device. We have to handle
+      // each scenario separately.
       if ("provisioning" in options) {
+        // There are three input options when providing provisioning details ahead of time:
+        // PlannedProvisioningEntry, QRProvisioningInformation, or a QR code string which the server
+        // will automatically parse into a QRProvisioningInformation object before proceeding with the
+        // inclusion process
         if (typeof options.provisioning === "string") {
           options.provisioning = parseQRCodeString(options.provisioning);
         }

--- a/src/lib/controller/message_handler.ts
+++ b/src/lib/controller/message_handler.ts
@@ -93,7 +93,9 @@ export class ControllerMessageHandler {
         return { success };
       }
       case ControllerCommand.beginExclusion: {
-        const success = await driver.controller.beginExclusion();
+        const success = await driver.controller.beginExclusion(
+          message.unprovision
+        );
         return { success };
       }
       case ControllerCommand.stopExclusion: {

--- a/src/lib/controller/outgoing_message.ts
+++ b/src/lib/controller/outgoing_message.ts
@@ -1,4 +1,8 @@
-import { AssociationAddress, AssociationGroup } from "zwave-js";
+import {
+  AssociationAddress,
+  AssociationGroup,
+  SmartStartProvisioningEntry,
+} from "zwave-js";
 import { ControllerCommand } from "./command";
 
 export interface ControllerResultTypes {
@@ -28,4 +32,12 @@ export interface ControllerResultTypes {
   [ControllerCommand.getNodeNeighbors]: { neighbors: readonly number[] };
   [ControllerCommand.grantSecurityClasses]: Record<string, never>;
   [ControllerCommand.validateDSKAndEnterPIN]: Record<string, never>;
+  [ControllerCommand.provisionSmartStartNode]: Record<string, never>;
+  [ControllerCommand.unprovisionSmartStartNode]: Record<string, never>;
+  [ControllerCommand.getProvisioningEntry]: {
+    entry: SmartStartProvisioningEntry | undefined;
+  };
+  [ControllerCommand.getProvisioningEntries]: {
+    entries: SmartStartProvisioningEntry[];
+  };
 }

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -8,6 +8,7 @@ export enum ErrorCode {
   zwaveError = "zwave_error",
   inclusionPhaseNotInProgress = "inclusion_phase_not_in_progress",
   inclusionAlreadyInProgress = "inclusion_already_in_progress",
+  invalidParamsPassedToCommand = "invalid_params_passed_to_command",
 }
 
 export class BaseError extends Error {
@@ -77,4 +78,8 @@ export class InclusionPhaseNotInProgressError extends BaseError {
 
 export class InclusionAlreadyInProgressError extends BaseError {
   errorCode = ErrorCode.inclusionAlreadyInProgress;
+}
+
+export class InvalidParamsPassedToCommandError extends BaseError {
+  errorCode = ErrorCode.invalidParamsPassedToCommand;
 }

--- a/src/lib/incoming_message.ts
+++ b/src/lib/incoming_message.ts
@@ -7,6 +7,7 @@ import { IncomingMessageDriver } from "./driver/incoming_message";
 import { IncomingMessageBroadcastNode } from "./broadcast_node/incoming_message";
 import { IncomingMessageMulticastGroup } from "./multicast_group/incoming_message";
 import { IncomingMessageEndpoint } from "./endpoint/incoming_message";
+import { IncomingMessageUtils } from "./utils/incoming_message";
 
 interface IncomingCommandStartListening extends IncomingCommandBase {
   command: ServerCommand.startListening;
@@ -36,4 +37,5 @@ export type IncomingMessage =
   | IncomingMessageDriver
   | IncomingMessageMulticastGroup
   | IncomingMessageBroadcastNode
-  | IncomingMessageEndpoint;
+  | IncomingMessageEndpoint
+  | IncomingMessageUtils;

--- a/src/lib/instance.ts
+++ b/src/lib/instance.ts
@@ -5,4 +5,5 @@ export enum Instance {
   multicast_group = "multicast_group",
   node = "node",
   endpoint = "endpoint",
+  utils = "utils",
 }

--- a/src/lib/outgoing_message.ts
+++ b/src/lib/outgoing_message.ts
@@ -8,6 +8,7 @@ import { ErrorCode } from "./error";
 import { BroadcastNodeResultTypes } from "./broadcast_node/outgoing_message";
 import { MulticastGroupResultTypes } from "./multicast_group/outgoing_message";
 import { EndpointResultTypes } from "./endpoint/outgoing_message";
+import { UtilsResultTypes } from "./utils/outgoing_message";
 
 // https://github.com/microsoft/TypeScript/issues/1897#issuecomment-822032151
 export type JSONValue =
@@ -68,7 +69,8 @@ export type ResultTypes = ServerResultTypes &
   DriverResultTypes &
   MulticastGroupResultTypes &
   BroadcastNodeResultTypes &
-  EndpointResultTypes;
+  EndpointResultTypes &
+  UtilsResultTypes;
 
 export interface OutgoingResultMessageSuccess {
   type: "result";

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -31,6 +31,8 @@ import { MulticastGroupMessageHandler } from "./multicast_group/message_handler"
 import { IncomingMessageMulticastGroup } from "./multicast_group/incoming_message";
 import { EndpointMessageHandler } from "./endpoint/message_handler";
 import { IncomingMessageEndpoint } from "./endpoint/incoming_message";
+import { UtilsMessageHandler } from "./utils/message_handler";
+import { IncomingMessageUtils } from "./utils/incoming_message";
 
 export class Client {
   public receiveEvents = false;
@@ -79,6 +81,8 @@ export class Client {
         message as IncomingMessageEndpoint,
         this.driver
       ),
+    [Instance.utils]: (message) =>
+      UtilsMessageHandler.handle(message as IncomingMessageUtils),
   };
 
   constructor(

--- a/src/lib/utils/command.ts
+++ b/src/lib/utils/command.ts
@@ -1,0 +1,3 @@
+export enum UtilCommand {
+  parseQRCodeString = "utils.parse_qr_code_string",
+}

--- a/src/lib/utils/command.ts
+++ b/src/lib/utils/command.ts
@@ -1,3 +1,3 @@
-export enum UtilCommand {
+export enum UtilsCommand {
   parseQRCodeString = "utils.parse_qr_code_string",
 }

--- a/src/lib/utils/incoming_message.ts
+++ b/src/lib/utils/incoming_message.ts
@@ -1,0 +1,12 @@
+import { IncomingCommandBase } from "../incoming_message_base";
+import { UtilsCommand } from "./command";
+
+export interface IncomingCommandUtilsBase extends IncomingCommandBase {}
+
+export interface IncomingCommandUtilsParseQRCodeString
+  extends IncomingCommandUtilsBase {
+  command: UtilsCommand.parseQRCodeString;
+  qr: string;
+}
+
+export type IncomingMessageUtils = IncomingCommandUtilsParseQRCodeString;

--- a/src/lib/utils/message_handler.ts
+++ b/src/lib/utils/message_handler.ts
@@ -1,0 +1,33 @@
+import { Driver } from "zwave-js";
+import {
+  CommandClasses,
+  ConfigurationMetadata,
+  extractFirmware,
+  Firmware,
+  guessFirmwareFileFormat,
+  parseQRCodeString,
+} from "@zwave-js/core";
+import { UtilsNotFoundError, UnknownCommandError } from "../error";
+import { Client } from "../server";
+import { dumpConfigurationMetadata, dumpMetadata } from "../state";
+import { UtilsCommand } from "./command";
+import { IncomingMessageUtils } from "./incoming_message";
+import { UtilsResultTypes } from "./outgoing_message";
+
+export class UtilsMessageHandler {
+  static async handle(
+    message: IncomingMessageUtils,
+    driver: Driver,
+    client: Client
+  ): Promise<UtilsResultTypes[UtilsCommand]> {
+    const { command } = message;
+
+    switch (message.command) {
+      case UtilsCommand.parseQRCodeString:
+        const qrProvisioningInformation = parseQRCodeString(message.qr);
+        return { qrProvisioningInformation };
+      default:
+        throw new UnknownCommandError(command);
+    }
+  }
+}

--- a/src/lib/utils/message_handler.ts
+++ b/src/lib/utils/message_handler.ts
@@ -1,24 +1,12 @@
-import { Driver } from "zwave-js";
-import {
-  CommandClasses,
-  ConfigurationMetadata,
-  extractFirmware,
-  Firmware,
-  guessFirmwareFileFormat,
-  parseQRCodeString,
-} from "@zwave-js/core";
-import { UtilsNotFoundError, UnknownCommandError } from "../error";
-import { Client } from "../server";
-import { dumpConfigurationMetadata, dumpMetadata } from "../state";
+import { parseQRCodeString } from "@zwave-js/core";
+import { UnknownCommandError } from "../error";
 import { UtilsCommand } from "./command";
 import { IncomingMessageUtils } from "./incoming_message";
 import { UtilsResultTypes } from "./outgoing_message";
 
 export class UtilsMessageHandler {
   static async handle(
-    message: IncomingMessageUtils,
-    driver: Driver,
-    client: Client
+    message: IncomingMessageUtils
   ): Promise<UtilsResultTypes[UtilsCommand]> {
     const { command } = message;
 

--- a/src/lib/utils/outgoing_message.ts
+++ b/src/lib/utils/outgoing_message.ts
@@ -1,0 +1,8 @@
+import { QRProvisioningInformation } from "@zwave-js/core";
+import { UtilsCommand } from "./command";
+
+export interface UtilsResultTypes {
+  [UtilsCommand.parseQRCodeString]: {
+    qrProvisioningInformation: QRProvisioningInformation;
+  };
+}


### PR DESCRIPTION
- Adds support for the new SmartStart provisioning workflows as well as using the S2 inclusion workflow using a QR code. 
- Adds a command to be able to call `parseQRCodeString`.
- Update `beginExclusion` command to include new option.

Note that the `provisionSmartStartNode` and `beginInclusion` commands deviate from the API slightly in that they will also accept the QR code string directly and will automatically use the `parseQRCodeString` helper function when necessary to convert the string. This will avoid requiring the client to make two server calls if the user does not want to pick security grants.