### PR TITLE
Bump zwave-js to 8.7.5 and bump zwave-js-server to 1.10.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.10.7",
+  "version": "1.10.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -685,12 +685,12 @@
       }
     },
     "@zwave-js/config": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.6.1.tgz",
-      "integrity": "sha512-/smkyuCz5mlbye+WTqdwsSqMKTZbw3RG94ufI5QnwwKu4iBUJFmLTzVO7FGfkllUHZnpOPn5sVeZOSMxfeoyIw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.7.0.tgz",
+      "integrity": "sha512-MyOVdoYz7eTekIQ6hGMMVbgp2CWcRDQzNvJq/Gh5NSzUxIzcDNcN342ZKhhQtfQ6mHpOvrwE4dScN/8PjwymlQ==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "8.6.1",
+        "@zwave-js/core": "8.7.0",
         "@zwave-js/shared": "8.6.0",
         "alcalzone-shared": "^4.0.0",
         "ansi-colors": "^4.1.1",
@@ -702,9 +702,9 @@
       }
     },
     "@zwave-js/core": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-8.6.1.tgz",
-      "integrity": "sha512-/s0PTJ1E09u+DslquSpoa4mkHaNj7Ce4LPIfVJHVoojxNDVPh0XELMWOZE2BbEFPjrb4F5YfrdNEpm2QjnSzhw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-8.7.0.tgz",
+      "integrity": "sha512-i1jVgH6mZHlCTg5DRG+oNebyNUc62u35D+Bb4xl7xRRmOhpR0sPoIl108jhVoDTTacggtSDfeM2AiR9Ncvz+Ww==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.2.0",
@@ -730,16 +730,16 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-8.6.1.tgz",
-      "integrity": "sha512-meA12dQbK3sMdEF4H4BZ4C/XEaelEjSqOTs1HXQ0lDZWwTb0+f5XcU3J8mX9nzZumXafq4Wevw/zhxXPmO2VYQ==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-8.7.0.tgz",
+      "integrity": "sha512-U2+W0fgqEBMhxQQfgHWkSO7zvLi2VyQ+xCtiSXxiuAZuaPSM1YqEMEJtOTQlYyWu6iNxAYkvxspb6zeNqRmb2g==",
       "dev": true,
       "requires": {
         "@sentry/node": "^6.13.3",
-        "@zwave-js/core": "8.6.1",
+        "@zwave-js/core": "8.7.0",
         "@zwave-js/shared": "8.6.0",
         "alcalzone-shared": "^4.0.0",
-        "serialport": "^9.2.4",
+        "serialport": "^9.2.5",
         "winston": "^3.3.3"
       }
     },
@@ -917,9 +917,9 @@
       "dev": true
     },
     "axios": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
-      "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "dev": true,
       "requires": {
         "follow-redirects": "^1.14.4"
@@ -3275,9 +3275,9 @@
       "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA=="
     },
     "xstate": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.25.0.tgz",
-      "integrity": "sha512-qP7lc/ypOuuWME4ArOBnzaCa90TfHkjiqYDmxpiCjPy6FcXstInA2vH6qRVAHbPXRK4KQIYfIEOk1X38P+TldQ==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.26.0.tgz",
+      "integrity": "sha512-l0tfRBhVYM17D6IWT4pVOzzN9kY/5lnPWCe4LXjJ3F9HCrJOPBn6tPRAb9mapSRBS8cOeByJFDCRSNopgaoC5w==",
       "dev": true
     },
     "yallist": {
@@ -3305,28 +3305,28 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.6.1.tgz",
-      "integrity": "sha512-r4aUnzfE4QKbxvQUhBE4uPfgFqZFSBDWw1rRUn48PJYt0PpazDmbzbzn0rruRfuFAimApNsteIKrr3B6ha0DJQ==",
+      "version": "8.7.2",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.7.2.tgz",
+      "integrity": "sha512-kNCwDC8nWlIlzKowg2Ht3M5tFCB6HhVgqhZlvKqfoa2ELnWSHYfYYq0bgrYnMfDdicK9tS0ndWEH1a6OyZJifg==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.2.0",
         "@alcalzone/pak": "^0.7.0",
         "@sentry/integrations": "^6.13.3",
         "@sentry/node": "^6.13.3",
-        "@zwave-js/config": "8.6.1",
-        "@zwave-js/core": "8.6.1",
-        "@zwave-js/serial": "8.6.1",
+        "@zwave-js/config": "8.7.0",
+        "@zwave-js/core": "8.7.0",
+        "@zwave-js/serial": "8.7.0",
         "@zwave-js/shared": "8.6.0",
         "alcalzone-shared": "^4.0.0",
         "ansi-colors": "^4.1.1",
-        "axios": "^0.23.0",
+        "axios": "^0.24.0",
         "execa": "^5.1.1",
         "fs-extra": "^10.0.0",
         "proper-lockfile": "^4.1.2",
         "reflect-metadata": "^0.1.13",
         "semver": "^7.3.5",
-        "serialport": "^9.2.4",
+        "serialport": "^9.2.5",
         "source-map-support": "^0.5.20",
         "winston": "^3.3.3",
         "xstate": "^4.25.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -685,12 +685,12 @@
       }
     },
     "@zwave-js/config": {
-      "version": "8.7.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.7.3.tgz",
-      "integrity": "sha512-dWU1C/qS3SD27PKsUXYS9u7Dcak+Yi6EfED3rntFtJsyD03wuIVb8aU+RVjvEq3dnJn/+76BUu0USiw6qWSblA==",
+      "version": "8.7.4",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.7.4.tgz",
+      "integrity": "sha512-5bHEYav900bkopvY4986zoegq5z/DpfvdhmG0xhJ+Z7VZY3ZkTEmM4nEbr6pcNdKiQfkL8HXAV6/o+WtmXJ48w==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "8.7.3",
+        "@zwave-js/core": "8.7.4",
         "@zwave-js/shared": "8.7.3",
         "alcalzone-shared": "^4.0.0",
         "ansi-colors": "^4.1.1",
@@ -702,9 +702,9 @@
       }
     },
     "@zwave-js/core": {
-      "version": "8.7.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-8.7.3.tgz",
-      "integrity": "sha512-7PrTLlb2TzYDlYcVjT8EsBo1wR/7Mcnj0hpxzw8jII1siesIhGTguv3m+0S1dEr94jxexFJHosEveMx62SeebQ==",
+      "version": "8.7.4",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-8.7.4.tgz",
+      "integrity": "sha512-jL32ZO2CvasuGTPGhiIg0ty8w7mgog0UOD6ITrgVmltwj933eSuA1W/Ydl48U3miNQbW1fIov9OcW3m3OxkIiQ==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.2.0",
@@ -730,13 +730,13 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "8.7.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-8.7.3.tgz",
-      "integrity": "sha512-lKafbYbFwxSL6pZVLIEm2QDV4ytaovSgJVCs9uDClULRW9ijiVKrXgXDdo/DS0ijrfJy0FvXXft/x+YmSiGAOw==",
+      "version": "8.7.4",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-8.7.4.tgz",
+      "integrity": "sha512-v9Y2GeWUi8/1HxUhB7btXT9yk7KqJXkhv8u7xclLqP8dgNZ5jKM9LaPoysGAtZWU+XDq+vrrducUJnDrj7q38A==",
       "dev": true,
       "requires": {
         "@sentry/node": "^6.13.3",
-        "@zwave-js/core": "8.7.3",
+        "@zwave-js/core": "8.7.4",
         "@zwave-js/shared": "8.7.3",
         "alcalzone-shared": "^4.0.0",
         "serialport": "^9.2.5",
@@ -3305,18 +3305,18 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "8.7.3",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.7.3.tgz",
-      "integrity": "sha512-3Ltxw32A35gTQX7K6imJmn5zsh3aMuK55aKvSJziHZLjKoArKdS8swaDyZ5kI7PEBRfRZrHxJWrHDFoFNebXUg==",
+      "version": "8.7.4",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.7.4.tgz",
+      "integrity": "sha512-5ftKys85JvACojSfj0OrO5Tb0tL7Dvn3STVX8nCiwmAooPqDbRxGRlP5FzoVjR2KPcP++Zzj++kAfaqsrdE0Mw==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.2.0",
         "@alcalzone/pak": "^0.7.0",
         "@sentry/integrations": "^6.13.3",
         "@sentry/node": "^6.13.3",
-        "@zwave-js/config": "8.7.3",
-        "@zwave-js/core": "8.7.3",
-        "@zwave-js/serial": "8.7.3",
+        "@zwave-js/config": "8.7.4",
+        "@zwave-js/core": "8.7.4",
+        "@zwave-js/serial": "8.7.4",
         "@zwave-js/shared": "8.7.3",
         "alcalzone-shared": "^4.0.0",
         "ansi-colors": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -214,63 +214,63 @@
       }
     },
     "@sentry/core": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.14.0.tgz",
-      "integrity": "sha512-GKs1A3yjcVB5ST4Mx9Eq4Z1yQaeq+AN1eJO1pnJhkOUnBXbmLGXvEp039W3Qn9iq9QuQmVRQz2C0+9GbrWmx9A==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.14.1.tgz",
+      "integrity": "sha512-x2MOax+adphal0ytBsvQukwN5mcxZzb5zsPZ1YWzewQk3BY+2T/DFo50iVpaWdUXsJL2FtoZVVgtpTmf+/3JPw==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.14.0",
-        "@sentry/minimal": "6.14.0",
-        "@sentry/types": "6.14.0",
-        "@sentry/utils": "6.14.0",
+        "@sentry/hub": "6.14.1",
+        "@sentry/minimal": "6.14.1",
+        "@sentry/types": "6.14.1",
+        "@sentry/utils": "6.14.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.14.0.tgz",
-      "integrity": "sha512-27ZN0YOxxy+2BV8VyelCejeeVJXy3Bs91bF6ICv3fekfL6cpyGswVMFltmSxraZOMxS4+Xz2HEgjlddgtd8yDQ==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.14.1.tgz",
+      "integrity": "sha512-IqANj5qKG1N+nqBsuYIwAZsXDMmO/Sc4H2zZ2MP7QvRyp0ptpJmu1oTE0r0fohIcGgIWbnIphJjw990Lp507eA==",
       "dev": true,
       "requires": {
-        "@sentry/types": "6.14.0",
-        "@sentry/utils": "6.14.0",
+        "@sentry/types": "6.14.1",
+        "@sentry/utils": "6.14.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/integrations": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.14.0.tgz",
-      "integrity": "sha512-Cr5bso8s+VjmruhAlIR4RcNyDZ2TCSvPSPIpUGe0ig0M4CWlfuixKYVgn+nN6Y6VBWCRHB1ceFWbDX4j0Tdz2g==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.14.1.tgz",
+      "integrity": "sha512-GZFp03w0c/o2iY1oxebsqpumsDQsoOWiUXpfPriG6UoXZdCDrSoiotaRHPAagsWKQ1XjbILph8Vdz5dSMIuQTg==",
       "dev": true,
       "requires": {
-        "@sentry/types": "6.14.0",
-        "@sentry/utils": "6.14.0",
+        "@sentry/types": "6.14.1",
+        "@sentry/utils": "6.14.1",
         "localforage": "^1.8.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.14.0.tgz",
-      "integrity": "sha512-LLw2xwCxfnVToYZQQYqVb5ZGYW5nzZWXT/HlnHObwy1IJLTuGsHzFNxwfrTDVe9bsmAFGTo+2yHF+1bdYIfiCQ==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.14.1.tgz",
+      "integrity": "sha512-rxS0YUggCSuA7EzS1ai5jU8XArk4FBHZ02gmSoSSLtwFXmeQIa9XBKY0OEFmG2LMQYNOpvcGsezDO51EB6/X9w==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.14.0",
-        "@sentry/types": "6.14.0",
+        "@sentry/hub": "6.14.1",
+        "@sentry/types": "6.14.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.14.0.tgz",
-      "integrity": "sha512-ZxTqzDwYoyyXCMRd8JGzFK/MXHf6ZTKbHhAYSzz6FVWWrRveihVS98xurKZeR5kTefqFtJhZNyQ+BCclIc1zzw==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.14.1.tgz",
+      "integrity": "sha512-tnEfcaF5Z7I4D619XL76sjRd7VMDitZZ7ydfA8sWGC1BPaPyyIJzVxE/a7qJBQGW7W0Oo7ctwOI1hpmfyOpPxg==",
       "dev": true,
       "requires": {
-        "@sentry/core": "6.14.0",
-        "@sentry/hub": "6.14.0",
-        "@sentry/tracing": "6.14.0",
-        "@sentry/types": "6.14.0",
-        "@sentry/utils": "6.14.0",
+        "@sentry/core": "6.14.1",
+        "@sentry/hub": "6.14.1",
+        "@sentry/tracing": "6.14.1",
+        "@sentry/types": "6.14.1",
+        "@sentry/utils": "6.14.1",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -278,31 +278,31 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.14.0.tgz",
-      "integrity": "sha512-tcnHaNsKwk7y5ggVTbCVYvRKk9mH1MXab2G+0Eg2UBtXB3KOH3iYqdIMjpldu/7Rn4YuCP9OWcSqN7jXTlfaiA==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.14.1.tgz",
+      "integrity": "sha512-Bv/+S5Wn9OPxP7sA9VYMV1wpmXWptFVIMFoG4BuyV4aFYdIAMxSNE/ktqXwmqn+nkBic04nP9rF6lMJBLIvIaA==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.14.0",
-        "@sentry/minimal": "6.14.0",
-        "@sentry/types": "6.14.0",
-        "@sentry/utils": "6.14.0",
+        "@sentry/hub": "6.14.1",
+        "@sentry/minimal": "6.14.1",
+        "@sentry/types": "6.14.1",
+        "@sentry/utils": "6.14.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.14.0.tgz",
-      "integrity": "sha512-7t1YyKO69lLru2WZVGWik6f59qf8J75wSg41Sk5SySvsd7hjcxbj1PWz61/5ndRStvbZmabiVcn76nI2JKyD5A==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.14.1.tgz",
+      "integrity": "sha512-RIk3ZwQKZnASrYWfV5i4wbzVveHz8xLFAS2ySIMqh+hICKnB0N4/r8a1Of/84j7pj+iAbf5vPS85639eIf+9qg==",
       "dev": true
     },
     "@sentry/utils": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.14.0.tgz",
-      "integrity": "sha512-uEpQ2sjvS2bSj/QNIRWbXFXgk2+rWmw+QXbvVCIiYB7LK7Y7kry6StTt42UumMHlVLFLgXVKlTa50XrIblr60g==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.14.1.tgz",
+      "integrity": "sha512-GVvf0z18L4DN0a6vIBdHSlrK/Dj8QFhuiiJ8NtccSoY8xiKXQNz9FKN5d52NUNqm59aopAxcVAcs57yQSdxrZQ==",
       "dev": true,
       "requires": {
-        "@sentry/types": "6.14.0",
+        "@sentry/types": "6.14.1",
         "tslib": "^1.9.3"
       }
     },
@@ -685,9 +685,9 @@
       }
     },
     "@zwave-js/config": {
-      "version": "8.7.4",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.7.4.tgz",
-      "integrity": "sha512-5bHEYav900bkopvY4986zoegq5z/DpfvdhmG0xhJ+Z7VZY3ZkTEmM4nEbr6pcNdKiQfkL8HXAV6/o+WtmXJ48w==",
+      "version": "8.7.5",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.7.5.tgz",
+      "integrity": "sha512-N2GbLur+4g+Pg5PU9tBqtgnYunJM+r5Erc4IxJF5J2WNlOmGdVO4C67pcL8CzJeh4EIXHF6BS2D6I2E8p9kyjA==",
       "dev": true,
       "requires": {
         "@zwave-js/core": "8.7.4",
@@ -3305,16 +3305,16 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "8.7.4",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.7.4.tgz",
-      "integrity": "sha512-5ftKys85JvACojSfj0OrO5Tb0tL7Dvn3STVX8nCiwmAooPqDbRxGRlP5FzoVjR2KPcP++Zzj++kAfaqsrdE0Mw==",
+      "version": "8.7.5",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.7.5.tgz",
+      "integrity": "sha512-fRF61gJwL8kCEJ+GZ5lgUs0Q+mhQ53cLwVOZQ5yxF+WzbyJHzO1V+MRnLFYTVhurOzqDJYyvgQSadrXnQCKH5Q==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.2.0",
         "@alcalzone/pak": "^0.7.0",
         "@sentry/integrations": "^6.13.3",
         "@sentry/node": "^6.13.3",
-        "@zwave-js/config": "8.7.4",
+        "@zwave-js/config": "8.7.5",
         "@zwave-js/core": "8.7.4",
         "@zwave-js/serial": "8.7.4",
         "@zwave-js/shared": "8.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -214,63 +214,63 @@
       }
     },
     "@sentry/core": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.13.3.tgz",
-      "integrity": "sha512-obm3SjgCk8A7nB37b2AU1eq1q7gMoJRrGMv9VRIyfcG0Wlz/5lJ9O3ohUk+YZaaVfZMxXn6hFtsBiOWmlv7IIA==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.14.0.tgz",
+      "integrity": "sha512-GKs1A3yjcVB5ST4Mx9Eq4Z1yQaeq+AN1eJO1pnJhkOUnBXbmLGXvEp039W3Qn9iq9QuQmVRQz2C0+9GbrWmx9A==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.13.3",
-        "@sentry/minimal": "6.13.3",
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/hub": "6.14.0",
+        "@sentry/minimal": "6.14.0",
+        "@sentry/types": "6.14.0",
+        "@sentry/utils": "6.14.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.13.3.tgz",
-      "integrity": "sha512-eYppBVqvhs5cvm33snW2sxfcw6G20/74RbBn+E4WDo15hozis89kU7ZCJDOPkXuag3v1h9igns/kM6PNBb41dw==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.14.0.tgz",
+      "integrity": "sha512-27ZN0YOxxy+2BV8VyelCejeeVJXy3Bs91bF6ICv3fekfL6cpyGswVMFltmSxraZOMxS4+Xz2HEgjlddgtd8yDQ==",
       "dev": true,
       "requires": {
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/types": "6.14.0",
+        "@sentry/utils": "6.14.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/integrations": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.13.3.tgz",
-      "integrity": "sha512-iC8LkbBTxlRo9FNxRqFfEm85FrELltc3E9gFsFSBkCnf7S/3nDCDW+mJX92KpRk97Wqid6/JwlXttKz8lsdF2A==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.14.0.tgz",
+      "integrity": "sha512-Cr5bso8s+VjmruhAlIR4RcNyDZ2TCSvPSPIpUGe0ig0M4CWlfuixKYVgn+nN6Y6VBWCRHB1ceFWbDX4j0Tdz2g==",
       "dev": true,
       "requires": {
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/types": "6.14.0",
+        "@sentry/utils": "6.14.0",
         "localforage": "^1.8.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.13.3.tgz",
-      "integrity": "sha512-63MlYYRni3fs5Bh8XBAfVZ+ctDdWg0fapSTP1ydIC37fKvbE+5zhyUqwrEKBIiclEApg1VKX7bkKxVdu/vsFdw==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.14.0.tgz",
+      "integrity": "sha512-LLw2xwCxfnVToYZQQYqVb5ZGYW5nzZWXT/HlnHObwy1IJLTuGsHzFNxwfrTDVe9bsmAFGTo+2yHF+1bdYIfiCQ==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.13.3",
-        "@sentry/types": "6.13.3",
+        "@sentry/hub": "6.14.0",
+        "@sentry/types": "6.14.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.13.3.tgz",
-      "integrity": "sha512-ZeZSw+TcPcf4e0j7iEqNMtoVmz+WFW/TEoGokXIwysZqSgchKdAXDHqn+CqUqFan7d76JcJmzztAUK2JruQ2Kg==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.14.0.tgz",
+      "integrity": "sha512-ZxTqzDwYoyyXCMRd8JGzFK/MXHf6ZTKbHhAYSzz6FVWWrRveihVS98xurKZeR5kTefqFtJhZNyQ+BCclIc1zzw==",
       "dev": true,
       "requires": {
-        "@sentry/core": "6.13.3",
-        "@sentry/hub": "6.13.3",
-        "@sentry/tracing": "6.13.3",
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/core": "6.14.0",
+        "@sentry/hub": "6.14.0",
+        "@sentry/tracing": "6.14.0",
+        "@sentry/types": "6.14.0",
+        "@sentry/utils": "6.14.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -278,31 +278,31 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.13.3.tgz",
-      "integrity": "sha512-yyOFIhqlprPM0g4f35Icear3eZk2mwyYcGEzljJfY2iU6pJwj1lzia5PfSwiCW7jFGMmlBJNhOAIpfhlliZi8Q==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.14.0.tgz",
+      "integrity": "sha512-tcnHaNsKwk7y5ggVTbCVYvRKk9mH1MXab2G+0Eg2UBtXB3KOH3iYqdIMjpldu/7Rn4YuCP9OWcSqN7jXTlfaiA==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.13.3",
-        "@sentry/minimal": "6.13.3",
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/hub": "6.14.0",
+        "@sentry/minimal": "6.14.0",
+        "@sentry/types": "6.14.0",
+        "@sentry/utils": "6.14.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.13.3.tgz",
-      "integrity": "sha512-Vrz5CdhaTRSvCQjSyIFIaV9PodjAVFkzJkTRxyY7P77RcegMsRSsG1yzlvCtA99zG9+e6MfoJOgbOCwuZids5A==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.14.0.tgz",
+      "integrity": "sha512-7t1YyKO69lLru2WZVGWik6f59qf8J75wSg41Sk5SySvsd7hjcxbj1PWz61/5ndRStvbZmabiVcn76nI2JKyD5A==",
       "dev": true
     },
     "@sentry/utils": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.13.3.tgz",
-      "integrity": "sha512-zYFuFH3MaYtBZTeJ4Yajg7pDf0pM3MWs3+9k5my9Fd+eqNcl7dYQYJbT9gyC0HXK1QI4CAMNNlHNl4YXhF91ag==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.14.0.tgz",
+      "integrity": "sha512-uEpQ2sjvS2bSj/QNIRWbXFXgk2+rWmw+QXbvVCIiYB7LK7Y7kry6StTt42UumMHlVLFLgXVKlTa50XrIblr60g==",
       "dev": true,
       "requires": {
-        "@sentry/types": "6.13.3",
+        "@sentry/types": "6.14.0",
         "tslib": "^1.9.3"
       }
     },
@@ -685,13 +685,13 @@
       }
     },
     "@zwave-js/config": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.7.0.tgz",
-      "integrity": "sha512-MyOVdoYz7eTekIQ6hGMMVbgp2CWcRDQzNvJq/Gh5NSzUxIzcDNcN342ZKhhQtfQ6mHpOvrwE4dScN/8PjwymlQ==",
+      "version": "8.7.3",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.7.3.tgz",
+      "integrity": "sha512-dWU1C/qS3SD27PKsUXYS9u7Dcak+Yi6EfED3rntFtJsyD03wuIVb8aU+RVjvEq3dnJn/+76BUu0USiw6qWSblA==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "8.7.0",
-        "@zwave-js/shared": "8.6.0",
+        "@zwave-js/core": "8.7.3",
+        "@zwave-js/shared": "8.7.3",
         "alcalzone-shared": "^4.0.0",
         "ansi-colors": "^4.1.1",
         "fs-extra": "^10.0.0",
@@ -702,13 +702,13 @@
       }
     },
     "@zwave-js/core": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-8.7.0.tgz",
-      "integrity": "sha512-i1jVgH6mZHlCTg5DRG+oNebyNUc62u35D+Bb4xl7xRRmOhpR0sPoIl108jhVoDTTacggtSDfeM2AiR9Ncvz+Ww==",
+      "version": "8.7.3",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-8.7.3.tgz",
+      "integrity": "sha512-7PrTLlb2TzYDlYcVjT8EsBo1wR/7Mcnj0hpxzw8jII1siesIhGTguv3m+0S1dEr94jxexFJHosEveMx62SeebQ==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.2.0",
-        "@zwave-js/shared": "8.6.0",
+        "@zwave-js/shared": "8.7.3",
         "@zwave-js/winston-daily-rotate-file": "^4.5.6-0",
         "alcalzone-shared": "^4.0.0",
         "ansi-colors": "^4.1.1",
@@ -730,23 +730,23 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-8.7.0.tgz",
-      "integrity": "sha512-U2+W0fgqEBMhxQQfgHWkSO7zvLi2VyQ+xCtiSXxiuAZuaPSM1YqEMEJtOTQlYyWu6iNxAYkvxspb6zeNqRmb2g==",
+      "version": "8.7.3",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-8.7.3.tgz",
+      "integrity": "sha512-lKafbYbFwxSL6pZVLIEm2QDV4ytaovSgJVCs9uDClULRW9ijiVKrXgXDdo/DS0ijrfJy0FvXXft/x+YmSiGAOw==",
       "dev": true,
       "requires": {
         "@sentry/node": "^6.13.3",
-        "@zwave-js/core": "8.7.0",
-        "@zwave-js/shared": "8.6.0",
+        "@zwave-js/core": "8.7.3",
+        "@zwave-js/shared": "8.7.3",
         "alcalzone-shared": "^4.0.0",
         "serialport": "^9.2.5",
         "winston": "^3.3.3"
       }
     },
     "@zwave-js/shared": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-8.6.0.tgz",
-      "integrity": "sha512-u7+e/SZh6G3vX6xu+lc9tmCwS2rDB1S1WCk/Q3ZEEkY37Qsw7pFPBL3p8PzQSjmK97/8pKEoNhNbGP427ytl0Q==",
+      "version": "8.7.3",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-8.7.3.tgz",
+      "integrity": "sha512-ISuDhFaKY5uDxzfVH5Yo3JdgZdT//xxnLwIFsiLdClnGevnW74TTh82J90yU2fTOHnB4QIaGNH/ddxelglgiaA==",
       "dev": true,
       "requires": {
         "alcalzone-shared": "^4.0.0",
@@ -3305,19 +3305,19 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "8.7.2",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.7.2.tgz",
-      "integrity": "sha512-kNCwDC8nWlIlzKowg2Ht3M5tFCB6HhVgqhZlvKqfoa2ELnWSHYfYYq0bgrYnMfDdicK9tS0ndWEH1a6OyZJifg==",
+      "version": "8.7.3",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.7.3.tgz",
+      "integrity": "sha512-3Ltxw32A35gTQX7K6imJmn5zsh3aMuK55aKvSJziHZLjKoArKdS8swaDyZ5kI7PEBRfRZrHxJWrHDFoFNebXUg==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.2.0",
         "@alcalzone/pak": "^0.7.0",
         "@sentry/integrations": "^6.13.3",
         "@sentry/node": "^6.13.3",
-        "@zwave-js/config": "8.7.0",
-        "@zwave-js/core": "8.7.0",
-        "@zwave-js/serial": "8.7.0",
-        "@zwave-js/shared": "8.6.0",
+        "@zwave-js/config": "8.7.3",
+        "@zwave-js/core": "8.7.3",
+        "@zwave-js/serial": "8.7.3",
+        "@zwave-js/shared": "8.7.3",
         "alcalzone-shared": "^4.0.0",
         "ansi-colors": "^4.1.1",
         "axios": "^0.24.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ws": "^8.0.0"
   },
   "peerDependencies": {
-    "zwave-js": "^8.7.4"
+    "zwave-js": "^8.7.5"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -42,7 +42,7 @@
     "prettier": "^2.3.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^8.7.4",
+    "zwave-js": "^8.7.5",
     "alcalzone-shared": "^4.0.0"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.10.7",
+  "version": "1.10.8",
   "description": "Full access to zwave-js driver through Websockets",
   "main": "dist/lib/index.js",
   "bin": {
@@ -25,7 +25,7 @@
     "ws": "^8.0.0"
   },
   "peerDependencies": {
-    "zwave-js": "^8.5.0"
+    "zwave-js": "^8.7.2"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -42,7 +42,7 @@
     "prettier": "^2.3.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^8.5.0",
+    "zwave-js": "^8.7.2",
     "alcalzone-shared": "^4.0.0"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ws": "^8.0.0"
   },
   "peerDependencies": {
-    "zwave-js": "^8.7.3"
+    "zwave-js": "^8.7.4"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -42,7 +42,7 @@
     "prettier": "^2.3.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^8.7.3",
+    "zwave-js": "^8.7.4",
     "alcalzone-shared": "^4.0.0"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ws": "^8.0.0"
   },
   "peerDependencies": {
-    "zwave-js": "^8.7.2"
+    "zwave-js": "^8.7.3"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -42,7 +42,7 @@
     "prettier": "^2.3.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^8.7.2",
+    "zwave-js": "^8.7.3",
     "alcalzone-shared": "^4.0.0"
   },
   "husky": {

--- a/src/lib/controller/message_handler.ts
+++ b/src/lib/controller/message_handler.ts
@@ -191,55 +191,57 @@ function processInclusionOptions(
       let validateDSKAndEnterPinPromise:
         | DeferredPromise<string | false>
         | undefined;
-      options.userCallbacks = {
-        grantSecurityClasses: (
-          requested: InclusionGrant
-        ): Promise<InclusionGrant | false> => {
-          clientsController.grantSecurityClassesPromise =
-            grantSecurityClassesPromise = createDeferredPromise();
-          grantSecurityClassesPromise.finally(() => {
-            if (
-              clientsController.grantSecurityClassesPromise ===
-              grantSecurityClassesPromise
-            ) {
-              delete clientsController.grantSecurityClassesPromise;
-            }
-          });
-          client.sendEvent({
-            source: "controller",
-            event: "grant security classes",
-            requested: requested as any,
-          });
+      if (!("provisioning" in options)) {
+        options.userCallbacks = {
+          grantSecurityClasses: (
+            requested: InclusionGrant
+          ): Promise<InclusionGrant | false> => {
+            clientsController.grantSecurityClassesPromise =
+              grantSecurityClassesPromise = createDeferredPromise();
+            grantSecurityClassesPromise.finally(() => {
+              if (
+                clientsController.grantSecurityClassesPromise ===
+                grantSecurityClassesPromise
+              ) {
+                delete clientsController.grantSecurityClassesPromise;
+              }
+            });
+            client.sendEvent({
+              source: "controller",
+              event: "grant security classes",
+              requested: requested as any,
+            });
 
-          return clientsController.grantSecurityClassesPromise;
-        },
-        validateDSKAndEnterPIN: (dsk: string): Promise<string | false> => {
-          clientsController.validateDSKAndEnterPinPromise =
-            validateDSKAndEnterPinPromise = createDeferredPromise();
-          validateDSKAndEnterPinPromise.finally(() => {
-            if (
-              clientsController.validateDSKAndEnterPinPromise ===
-              validateDSKAndEnterPinPromise
-            ) {
-              delete clientsController.validateDSKAndEnterPinPromise;
-            }
-          });
-          client.sendEvent({
-            source: "controller",
-            event: "validate dsk and enter pin",
-            dsk,
-          });
-          return clientsController.validateDSKAndEnterPinPromise;
-        },
-        abort: (): void => {
-          grantSecurityClassesPromise?.reject("aborted");
-          validateDSKAndEnterPinPromise?.reject("aborted");
-          client.sendEvent({
-            source: "controller",
-            event: "inclusion aborted",
-          });
-        },
-      };
+            return clientsController.grantSecurityClassesPromise;
+          },
+          validateDSKAndEnterPIN: (dsk: string): Promise<string | false> => {
+            clientsController.validateDSKAndEnterPinPromise =
+              validateDSKAndEnterPinPromise = createDeferredPromise();
+            validateDSKAndEnterPinPromise.finally(() => {
+              if (
+                clientsController.validateDSKAndEnterPinPromise ===
+                validateDSKAndEnterPinPromise
+              ) {
+                delete clientsController.validateDSKAndEnterPinPromise;
+              }
+            });
+            client.sendEvent({
+              source: "controller",
+              event: "validate dsk and enter pin",
+              dsk,
+            });
+            return clientsController.validateDSKAndEnterPinPromise;
+          },
+          abort: (): void => {
+            grantSecurityClassesPromise?.reject("aborted");
+            validateDSKAndEnterPinPromise?.reject("aborted");
+            client.sendEvent({
+              source: "controller",
+              event: "inclusion aborted",
+            });
+          },
+        };
+      }
     }
     return options;
   }


### PR DESCRIPTION
We need to do this to release the bug that was fixed in https://github.com/zwave-js/zwave-js-server/pull/427 because we want to bump the addon to a version that has the `Driver_Failed` feature. We should not wait for #432 to merge this