### PR TITLE
Add missing controller cmd and tell driver to emit event after setValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ You can specify a different port for the websocket server to listen on with `--p
 
 If you don't have a USB stick, you can add `--mock-driver` to use a fake stick.
 
+> NOTE: Unless specificed in the configuration file, the [`emitValueUpdateAfterSetValue` configuration option](https://zwave-js.github.io/node-zwave-js/#/api/driver?id=zwaveoptions) will be set to `true`. This is recommended for multi-client setups and for cases where multiple applications are sharing access to the same driver, e.g. [zwavejs2mqtt](https://github.com/zwave-js/zwavejs2mqtt)
+
 ### Start client
 
 Requires server to be running.

--- a/package-lock.json
+++ b/package-lock.json
@@ -214,63 +214,63 @@
       }
     },
     "@sentry/core": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.14.1.tgz",
-      "integrity": "sha512-x2MOax+adphal0ytBsvQukwN5mcxZzb5zsPZ1YWzewQk3BY+2T/DFo50iVpaWdUXsJL2FtoZVVgtpTmf+/3JPw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.15.0.tgz",
+      "integrity": "sha512-mCbKyqvD1G3Re6gv6N8tRkBz84gvVWDfLtC6d1WBArIopzter6ktEbvq0cMT6EOvGI2OLXuJ6mtHA93/Q0gGpw==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.14.1",
-        "@sentry/minimal": "6.14.1",
-        "@sentry/types": "6.14.1",
-        "@sentry/utils": "6.14.1",
+        "@sentry/hub": "6.15.0",
+        "@sentry/minimal": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.14.1.tgz",
-      "integrity": "sha512-IqANj5qKG1N+nqBsuYIwAZsXDMmO/Sc4H2zZ2MP7QvRyp0ptpJmu1oTE0r0fohIcGgIWbnIphJjw990Lp507eA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.15.0.tgz",
+      "integrity": "sha512-cUbHPeG6kKpGBaEMgbTWeU03Y1Up5T3urGF+cgtrn80PmPYYSUPvVvWlZQWPb8CJZ1yQ0gySWo5RUTatBFrEHA==",
       "dev": true,
       "requires": {
-        "@sentry/types": "6.14.1",
-        "@sentry/utils": "6.14.1",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/integrations": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.14.1.tgz",
-      "integrity": "sha512-GZFp03w0c/o2iY1oxebsqpumsDQsoOWiUXpfPriG6UoXZdCDrSoiotaRHPAagsWKQ1XjbILph8Vdz5dSMIuQTg==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.15.0.tgz",
+      "integrity": "sha512-fSBAipas6zwyYo4U91pyQOnaTcRCfwvH6ZFwu0Fqmkm64nU9rYpbTNiKkwOWbbiXXT6+LEF6RzBpsyhm4QvgmQ==",
       "dev": true,
       "requires": {
-        "@sentry/types": "6.14.1",
-        "@sentry/utils": "6.14.1",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "localforage": "^1.8.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.14.1.tgz",
-      "integrity": "sha512-rxS0YUggCSuA7EzS1ai5jU8XArk4FBHZ02gmSoSSLtwFXmeQIa9XBKY0OEFmG2LMQYNOpvcGsezDO51EB6/X9w==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.15.0.tgz",
+      "integrity": "sha512-7RJIvZsjBa1qFUfMrAzQsWdfZT6Gm4t6ZTYfkpsXPBA35hkzglKbBrhhsUvkxGIhUGw/PiCUqxBUjcmzQP0vfg==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.14.1",
-        "@sentry/types": "6.14.1",
+        "@sentry/hub": "6.15.0",
+        "@sentry/types": "6.15.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.14.1.tgz",
-      "integrity": "sha512-tnEfcaF5Z7I4D619XL76sjRd7VMDitZZ7ydfA8sWGC1BPaPyyIJzVxE/a7qJBQGW7W0Oo7ctwOI1hpmfyOpPxg==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.15.0.tgz",
+      "integrity": "sha512-V1GeupWi9ClmoMy5eBWdVTv3k+Yx/JpddT4zCzzYY9QfjYtEvQI7R3SWFtlgXuaQQaZNU0WUoE2UgJV2N/vS8g==",
       "dev": true,
       "requires": {
-        "@sentry/core": "6.14.1",
-        "@sentry/hub": "6.14.1",
-        "@sentry/tracing": "6.14.1",
-        "@sentry/types": "6.14.1",
-        "@sentry/utils": "6.14.1",
+        "@sentry/core": "6.15.0",
+        "@sentry/hub": "6.15.0",
+        "@sentry/tracing": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -278,31 +278,31 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.14.1.tgz",
-      "integrity": "sha512-Bv/+S5Wn9OPxP7sA9VYMV1wpmXWptFVIMFoG4BuyV4aFYdIAMxSNE/ktqXwmqn+nkBic04nP9rF6lMJBLIvIaA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.15.0.tgz",
+      "integrity": "sha512-V5unvX8qNEfdawX+m2n0jKgmH/YR2ItWZLH+3UevBTptO+xyfvRtpgGXYWUCo3iGvFgWb1C+iIC7LViR9rTvBg==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.14.1",
-        "@sentry/minimal": "6.14.1",
-        "@sentry/types": "6.14.1",
-        "@sentry/utils": "6.14.1",
+        "@sentry/hub": "6.15.0",
+        "@sentry/minimal": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.14.1.tgz",
-      "integrity": "sha512-RIk3ZwQKZnASrYWfV5i4wbzVveHz8xLFAS2ySIMqh+hICKnB0N4/r8a1Of/84j7pj+iAbf5vPS85639eIf+9qg==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.15.0.tgz",
+      "integrity": "sha512-zBw5gPUsofXUSpS3ZAXqRNedLRBvirl3sqkj2Lez7X2EkKRgn5D8m9fQIrig/X3TsKcXUpijDW5Buk5zeCVzJA==",
       "dev": true
     },
     "@sentry/utils": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.14.1.tgz",
-      "integrity": "sha512-GVvf0z18L4DN0a6vIBdHSlrK/Dj8QFhuiiJ8NtccSoY8xiKXQNz9FKN5d52NUNqm59aopAxcVAcs57yQSdxrZQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.15.0.tgz",
+      "integrity": "sha512-gnhKKyFtnNmKWjDizo7VKD0/Vx8cgW1lCusM6WI7jy2jlO3bQA0+Dzgmr4mIReZ74mq4VpOd2Vfrx7ZldW1DMw==",
       "dev": true,
       "requires": {
-        "@sentry/types": "6.14.1",
+        "@sentry/types": "6.15.0",
         "tslib": "^1.9.3"
       }
     },
@@ -685,9 +685,9 @@
       }
     },
     "@zwave-js/config": {
-      "version": "8.7.5",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.7.5.tgz",
-      "integrity": "sha512-N2GbLur+4g+Pg5PU9tBqtgnYunJM+r5Erc4IxJF5J2WNlOmGdVO4C67pcL8CzJeh4EIXHF6BS2D6I2E8p9kyjA==",
+      "version": "8.7.6",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.7.6.tgz",
+      "integrity": "sha512-NiFDkn7u+udZ05jqlAasASvpGckwj7yBSYcTEPNRiIQApgWjibAEmz1CPM6rV4jtfQoujFx0RzBzKcBcw6GxPA==",
       "dev": true,
       "requires": {
         "@zwave-js/core": "8.7.4",
@@ -3369,16 +3369,16 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "8.7.5",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.7.5.tgz",
-      "integrity": "sha512-fRF61gJwL8kCEJ+GZ5lgUs0Q+mhQ53cLwVOZQ5yxF+WzbyJHzO1V+MRnLFYTVhurOzqDJYyvgQSadrXnQCKH5Q==",
+      "version": "8.7.7",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.7.7.tgz",
+      "integrity": "sha512-y7u5mGrR+8rsvyTKIc7U62b1BIYG0tzxtVRn1ZClC3ew76DSpr+49C3t0B4hgs/NjX2jFSCy0tBfWsO7qTDNbQ==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.2.0",
         "@alcalzone/pak": "^0.7.0",
         "@sentry/integrations": "^6.13.3",
         "@sentry/node": "^6.13.3",
-        "@zwave-js/config": "8.7.5",
+        "@zwave-js/config": "8.7.6",
         "@zwave-js/core": "8.7.4",
         "@zwave-js/serial": "8.7.4",
         "@zwave-js/shared": "8.7.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ws": "^8.0.0"
   },
   "peerDependencies": {
-    "zwave-js": "^8.7.5"
+    "zwave-js": "^8.7.7"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -50,7 +50,7 @@
     "prettier": "^2.3.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^8.7.5",
+    "zwave-js": "^8.7.7",
     "alcalzone-shared": "^4.0.0"
   },
   "husky": {

--- a/src/bin/server.ts
+++ b/src/bin/server.ts
@@ -101,6 +101,8 @@ interface Args {
     }
   }
 
+  options["emitValueUpdateAfterSetValue"] = true;
+
   const driver = args["mock-driver"]
     ? createMockDriver()
     : new Driver(serialPort, options);

--- a/src/bin/server.ts
+++ b/src/bin/server.ts
@@ -101,7 +101,8 @@ interface Args {
     }
   }
 
-  options["emitValueUpdateAfterSetValue"] = true;
+  if (!("emitValueUpdateAfterSetValue" in options))
+    options["emitValueUpdateAfterSetValue"] = true;
 
   const driver = args["mock-driver"]
     ? createMockDriver()

--- a/src/bin/server.ts
+++ b/src/bin/server.ts
@@ -101,8 +101,15 @@ interface Args {
     }
   }
 
-  if (!("emitValueUpdateAfterSetValue" in options))
+  if (!("emitValueUpdateAfterSetValue" in options)) {
     options["emitValueUpdateAfterSetValue"] = true;
+  } else if (!options["emitValueUpdateAfterSetValue"]) {
+    console.warn(
+      "Because `emitValueUpdateAfterSetValue` is set to false, multi-client setups will not work " +
+        "as expected. In particular, clients will not see value updates that are initiated by " +
+        "another client."
+    );
+  }
 
   const driver = args["mock-driver"]
     ? createMockDriver()

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -4,4 +4,4 @@ export const version = require("../../package.json").version;
 export const minSchemaVersion = 0;
 
 // maximal/current schema version the server supports
-export const maxSchemaVersion = 11;
+export const maxSchemaVersion = 12;

--- a/src/lib/controller/command.ts
+++ b/src/lib/controller/command.ts
@@ -25,4 +25,5 @@ export enum ControllerCommand {
   unprovisionSmartStartNode = "controller.unprovision_smart_start_node",
   getProvisioningEntry = "controller.get_provisioning_entry",
   getProvisioningEntries = "controller.get_provisioning_entries",
+  supportsFeature = "controller.supports_feature",
 }

--- a/src/lib/controller/incoming_message.ts
+++ b/src/lib/controller/incoming_message.ts
@@ -4,6 +4,7 @@ import {
   InclusionOptions,
   PlannedProvisioningEntry,
   ReplaceNodeOptions,
+  ZWaveFeature,
 } from "zwave-js";
 import type { QRProvisioningInformation } from "@zwave-js/core";
 import { IncomingCommandBase } from "../incoming_message_base";
@@ -174,6 +175,12 @@ export interface IncomingCommandControllerGetProvisioningEntries
   command: ControllerCommand.getProvisioningEntries;
 }
 
+export interface IncomingCommandControllerSupportsFeature
+  extends IncomingCommandControllerBase {
+  command: ControllerCommand.supportsFeature;
+  feature: ZWaveFeature;
+}
+
 export type IncomingMessageController =
   | IncomingCommandControllerBeginInclusion
   | IncomingCommandControllerBeginInclusionLegacy
@@ -199,4 +206,5 @@ export type IncomingMessageController =
   | IncomingCommandControllerProvisionSmartStartNode
   | IncomingCommandControllerUnprovisionSmartStartNode
   | IncomingCommandControllerGetProvisioningEntry
-  | IncomingCommandControllerGetProvisioningEntries;
+  | IncomingCommandControllerGetProvisioningEntries
+  | IncomingCommandControllerSupportsFeature;

--- a/src/lib/controller/message_handler.ts
+++ b/src/lib/controller/message_handler.ts
@@ -189,6 +189,9 @@ export class ControllerMessageHandler {
           message.nodeId
         );
         return { neighbors };
+      case ControllerCommand.supportsFeature:
+        const supported = driver.controller.supportsFeature(message.feature);
+        return { supported };
       default:
         throw new UnknownCommandError(command);
     }

--- a/src/lib/controller/outgoing_message.ts
+++ b/src/lib/controller/outgoing_message.ts
@@ -40,4 +40,5 @@ export interface ControllerResultTypes {
   [ControllerCommand.getProvisioningEntries]: {
     entries: SmartStartProvisioningEntry[];
   };
+  [ControllerCommand.supportsFeature]: { supported: boolean | undefined };
 }


### PR DESCRIPTION
As discussed in #devs_zwave a new option has been introduced to force the driver to emit an event after a `setValue` call. We want this to be `true` always so that clients can see value updates even if they didn't make the call.

Also added the `controller.supports_feature` command.