### PR TITLE
Bump zwave-js to 8.8.2 and add new commands introduced

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ interface {
   messageId: string;
   command: "node.refresh_info";
   nodeId: number;
+  options?: RefreshInfoOptions;
 }
 ```
 
@@ -504,6 +505,48 @@ interface {
   messageId: string;
   nodeId: number;
   command: "node.get_highest_security_class";
+}
+```
+
+#### [Test Powerlevel](https://zwave-js.github.io/node-zwave-js/#/api/node?id=testpowerlevel)
+
+[compatible with schema version: 13+]
+
+```ts
+interface {
+  messageId: string;
+  nodeId: number;
+  command: "node.test_powerlevel";
+  testNodeId: number;
+  powerlevel: Powerlevel;
+  testFrameCount: number;
+}
+```
+
+#### [Check Lifeline Health](https://zwave-js.github.io/node-zwave-js/#/api/node?id=checklifelinehealth)
+
+[compatible with schema version: 13+]
+
+```ts
+interface {
+  messageId: string;
+  nodeId: number;
+  command: "node.check_lifeline_health";
+  rounds?: number;
+}
+```
+
+#### [Check Route Health](https://zwave-js.github.io/node-zwave-js/#/api/node?id=checkroutehealth)
+
+[compatible with schema version: 13+]
+
+```ts
+interface {
+  messageId: string;
+  nodeId: number;
+  command: "node.check_route_health";
+  targetNodeId: number;
+  rounds?: number;
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -685,14 +685,14 @@
       }
     },
     "@zwave-js/config": {
-      "version": "8.7.6",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.7.6.tgz",
-      "integrity": "sha512-NiFDkn7u+udZ05jqlAasASvpGckwj7yBSYcTEPNRiIQApgWjibAEmz1CPM6rV4jtfQoujFx0RzBzKcBcw6GxPA==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.8.1.tgz",
+      "integrity": "sha512-k8LlOAFoGoWn19gWvRxuhSkUJW6kWmLYBIdBB8jZNUE0sEWbDsxwX3GYYmGb8WangQWvZPXE+VG9KBPAXnSaSw==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "8.7.4",
-        "@zwave-js/shared": "8.7.3",
-        "alcalzone-shared": "^4.0.0",
+        "@zwave-js/core": "8.8.1",
+        "@zwave-js/shared": "8.8.0",
+        "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.1",
         "fs-extra": "^10.0.0",
         "json-logic-js": "^2.0.1",
@@ -702,15 +702,15 @@
       }
     },
     "@zwave-js/core": {
-      "version": "8.7.4",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-8.7.4.tgz",
-      "integrity": "sha512-jL32ZO2CvasuGTPGhiIg0ty8w7mgog0UOD6ITrgVmltwj933eSuA1W/Ydl48U3miNQbW1fIov9OcW3m3OxkIiQ==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-8.8.1.tgz",
+      "integrity": "sha512-hqoBD4ADDOImWe1dG5NVVSwf1PojcxeMArmQLniAq9O/CgYDU8JK3fNBgABRE+VEvHeMDS1MqtUv6iSciEjeKg==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.2.0",
-        "@zwave-js/shared": "8.7.3",
+        "@zwave-js/shared": "8.8.0",
         "@zwave-js/winston-daily-rotate-file": "^4.5.6-0",
-        "alcalzone-shared": "^4.0.0",
+        "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.1",
         "dayjs": "^1.10.7",
         "logform": "*",
@@ -730,26 +730,26 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "8.7.4",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-8.7.4.tgz",
-      "integrity": "sha512-v9Y2GeWUi8/1HxUhB7btXT9yk7KqJXkhv8u7xclLqP8dgNZ5jKM9LaPoysGAtZWU+XDq+vrrducUJnDrj7q38A==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-8.8.1.tgz",
+      "integrity": "sha512-lGKFCN628ljSMANlXdAq7XosMjKMlkjJCINWv8UhUXZybYwo5zqSDFgKBbZwURsAJtNtGmwRtFy9tHdXIpkcWQ==",
       "dev": true,
       "requires": {
-        "@sentry/node": "^6.13.3",
-        "@zwave-js/core": "8.7.4",
-        "@zwave-js/shared": "8.7.3",
-        "alcalzone-shared": "^4.0.0",
+        "@sentry/node": "^6.14.3",
+        "@zwave-js/core": "8.8.1",
+        "@zwave-js/shared": "8.8.0",
+        "alcalzone-shared": "^4.0.1",
         "serialport": "^9.2.5",
         "winston": "^3.3.3"
       }
     },
     "@zwave-js/shared": {
-      "version": "8.7.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-8.7.3.tgz",
-      "integrity": "sha512-ISuDhFaKY5uDxzfVH5Yo3JdgZdT//xxnLwIFsiLdClnGevnW74TTh82J90yU2fTOHnB4QIaGNH/ddxelglgiaA==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-8.8.0.tgz",
+      "integrity": "sha512-fx8wu508/+XX2IJmNn6tZgnRwL0nu4x5CB8damwGKfPjeC0d7C+yRuL3PkamIDMy94BscEweoBNV0YK4ycUkcQ==",
       "dev": true,
       "requires": {
-        "alcalzone-shared": "^4.0.0",
+        "alcalzone-shared": "^4.0.1",
         "fs-extra": "^10.0.0"
       }
     },
@@ -3366,20 +3366,20 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "8.7.7",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.7.7.tgz",
-      "integrity": "sha512-y7u5mGrR+8rsvyTKIc7U62b1BIYG0tzxtVRn1ZClC3ew76DSpr+49C3t0B4hgs/NjX2jFSCy0tBfWsO7qTDNbQ==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.8.1.tgz",
+      "integrity": "sha512-JU8poK/4bnPlGPUROVacQvvzllHZXprbTtfpeorJMUWuwVn4Be6HLf+fZ8iuPivrBeJpa3NcQOSYoTYbqQCvyA==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.2.0",
         "@alcalzone/pak": "^0.7.0",
-        "@sentry/integrations": "^6.13.3",
-        "@sentry/node": "^6.13.3",
-        "@zwave-js/config": "8.7.6",
-        "@zwave-js/core": "8.7.4",
-        "@zwave-js/serial": "8.7.4",
-        "@zwave-js/shared": "8.7.3",
-        "alcalzone-shared": "^4.0.0",
+        "@sentry/integrations": "^6.14.3",
+        "@sentry/node": "^6.14.3",
+        "@zwave-js/config": "8.8.1",
+        "@zwave-js/core": "8.8.1",
+        "@zwave-js/serial": "8.8.1",
+        "@zwave-js/shared": "8.8.0",
+        "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.1",
         "axios": "^0.24.0",
         "execa": "^5.1.1",
@@ -3390,7 +3390,7 @@
         "serialport": "^9.2.5",
         "source-map-support": "^0.5.20",
         "winston": "^3.3.3",
-        "xstate": "^4.25.0"
+        "xstate": "^4.26.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -348,9 +348,9 @@
       }
     },
     "@serialport/bindings": {
-      "version": "9.2.7",
-      "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.2.7.tgz",
-      "integrity": "sha512-glbCqpMYyyfxiUSgGt/ayf84nVDRer9bxvxRv8JDwTYo+Wp2JTofbW4gC5wDa8xNtxMhD90J6PJTJA8E9YhrBg==",
+      "version": "9.2.8",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.2.8.tgz",
+      "integrity": "sha512-hSLxTe0tADZ3LMMGwvEJWOC/TaFQTyPeFalUCsJ1lSQ0k6bPF04JwrtB/C81GetmDBTNRY0GlD0SNtKCc7Dr5g==",
       "dev": true,
       "requires": {
         "@serialport/binding-abstract": "9.2.3",
@@ -358,7 +358,7 @@
         "bindings": "^1.5.0",
         "debug": "^4.3.2",
         "nan": "^2.15.0",
-        "prebuild-install": "^6.1.4"
+        "prebuild-install": "^7.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1164,9 +1164,9 @@
       "dev": true
     },
     "color-string": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
-      "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.7.4.tgz",
+      "integrity": "sha512-nVdUvPVgZMpRQad5dcsCMOSB5BXLljklTiaxS6ehhKxDsAI5sD7k5VmFuBt1y3Rlym8uulc/ANUN/bMWtBu6Sg==",
       "dev": true,
       "requires": {
         "color-name": "^1.0.0",
@@ -1277,12 +1277,12 @@
       }
     },
     "decompress-response": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dev": true,
       "requires": {
-        "mimic-response": "^2.0.0"
+        "mimic-response": "^3.1.0"
       }
     },
     "deep-extend": {
@@ -2323,9 +2323,9 @@
       "dev": true
     },
     "mimic-response": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "dev": true
     },
     "minimatch": {
@@ -2379,20 +2379,12 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
-      "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.5.0.tgz",
+      "integrity": "sha512-LtHvNIBgOy5mO8mPEUtkCW/YCRWYEKshIvqhe1GHHyXEHEB5mgICyYnAcl4qan3uFeRROErKGzatFHPf6kDxWw==",
       "dev": true,
       "requires": {
-        "semver": "^5.4.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
+        "semver": "^7.3.5"
       }
     },
     "normalize-path": {
@@ -2596,9 +2588,9 @@
       }
     },
     "prebuild-install": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
-      "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.0.0.tgz",
+      "integrity": "sha512-IvSenf33K7JcgddNz2D5w521EgO+4aMMjFt73Uk9FRzQ7P+QZPKrp7qPsDydsSwjGt3T5xRNnM1bj1zMTD5fTA==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3",
@@ -2607,11 +2599,11 @@
         "minimist": "^1.2.3",
         "mkdirp-classic": "^0.5.3",
         "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.21.0",
+        "node-abi": "^3.3.0",
         "npmlog": "^4.0.1",
         "pump": "^3.0.0",
         "rc": "^1.2.7",
-        "simple-get": "^3.0.3",
+        "simple-get": "^4.0.0",
         "tar-fs": "^2.0.0",
         "tunnel-agent": "^0.6.0"
       }
@@ -2823,13 +2815,13 @@
       "dev": true
     },
     "serialport": {
-      "version": "9.2.7",
-      "resolved": "https://registry.npmjs.org/serialport/-/serialport-9.2.7.tgz",
-      "integrity": "sha512-jH5mC0CtmDcE5Z1UXSDrYpzNzCFTGGyaAN/1D38olDbgTKqTrJ1VSfP1LzcKpHCL8M6UEiL+hs3xKP9PWrFeKQ==",
+      "version": "9.2.8",
+      "resolved": "https://registry.npmjs.org/serialport/-/serialport-9.2.8.tgz",
+      "integrity": "sha512-FsWpMQgSJxi93JgWl5xM1f9/Z8IjRJuaUEoHqLf8FPBLw7gMhInuHOBhI2onQufWIYPGTz3H3oGcu1nCaK1EfA==",
       "dev": true,
       "requires": {
         "@serialport/binding-mock": "9.2.4",
-        "@serialport/bindings": "9.2.7",
+        "@serialport/bindings": "9.2.8",
         "@serialport/parser-byte-length": "9.2.4",
         "@serialport/parser-cctalk": "9.2.4",
         "@serialport/parser-delimiter": "9.2.4",
@@ -2886,12 +2878,12 @@
       "dev": true
     },
     "simple-get": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.0.tgz",
+      "integrity": "sha512-ZalZGexYr3TA0SwySsr5HlgOOinS4Jsa8YB2GJ6lUNAazyAu4KG/VmzMTwAt2YVXzzVj8QmefmAonZIK2BSGcQ==",
       "dev": true,
       "requires": {
-        "decompress-response": "^4.2.0",
+        "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
@@ -3366,9 +3358,9 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.8.1.tgz",
-      "integrity": "sha512-JU8poK/4bnPlGPUROVacQvvzllHZXprbTtfpeorJMUWuwVn4Be6HLf+fZ8iuPivrBeJpa3NcQOSYoTYbqQCvyA==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.8.2.tgz",
+      "integrity": "sha512-shFY1y9hqKzS7mZzNBNMnpsuSgVhpas0EYQdXupm/r8rglBBm5c3+MNkGT2X/ImYYv1VR0WtsAs+pEqBXYaY8w==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ws": "^8.0.0"
   },
   "peerDependencies": {
-    "zwave-js": "^8.7.7"
+    "zwave-js": "^8.8.1"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -50,7 +50,7 @@
     "prettier": "^2.3.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^8.7.7",
+    "zwave-js": "^8.8.1",
     "alcalzone-shared": "^4.0.0"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ws": "^8.0.0"
   },
   "peerDependencies": {
-    "zwave-js": "^8.8.1"
+    "zwave-js": "^8.8.2"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -50,7 +50,7 @@
     "prettier": "^2.3.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^8.8.1",
+    "zwave-js": "^8.8.2",
     "alcalzone-shared": "^4.0.0"
   },
   "husky": {

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -4,4 +4,4 @@ export const version = require("../../package.json").version;
 export const minSchemaVersion = 0;
 
 // maximal/current schema version the server supports
-export const maxSchemaVersion = 12;
+export const maxSchemaVersion = 13;

--- a/src/lib/node/command.ts
+++ b/src/lib/node/command.ts
@@ -13,4 +13,7 @@ export enum NodeCommand {
   getFirmwareUpdateCapabilities = "node.get_firmware_update_capabilities",
   hasSecurityClass = "node.has_security_class",
   getHighestSecurityClass = "node.get_highest_security_class",
+  testPowerlevel = "node.test_powerlevel",
+  checkLifelineHealth = "node.check_lifeline_health",
+  checkRouteHealth = "node.check_route_health",
 }

--- a/src/lib/node/incoming_message.ts
+++ b/src/lib/node/incoming_message.ts
@@ -1,4 +1,10 @@
-import { ConfigValue, SetValueAPIOptions, ValueID } from "zwave-js";
+import {
+  ConfigValue,
+  Powerlevel,
+  RefreshInfoOptions,
+  SetValueAPIOptions,
+  ValueID,
+} from "zwave-js";
 import {
   CommandClasses,
   FirmwareFileFormat,
@@ -21,6 +27,7 @@ export interface IncomingCommandNodeSetValue extends IncomingCommandNodeBase {
 export interface IncomingCommandNodeRefreshInfo
   extends IncomingCommandNodeBase {
   command: NodeCommand.refreshInfo;
+  options?: RefreshInfoOptions;
 }
 
 export interface IncomingCommandNodeGetDefinedValueIDs
@@ -91,6 +98,26 @@ export interface IncomingCommandGetHighestSecurityClass
   command: NodeCommand.getHighestSecurityClass;
 }
 
+export interface IncomingCommandTestPowerlevel extends IncomingCommandNodeBase {
+  command: NodeCommand.testPowerlevel;
+  testNodeId: number;
+  powerlevel: Powerlevel;
+  testFrameCount: number;
+}
+
+export interface IncomingCommandCheckLifelineHealth
+  extends IncomingCommandNodeBase {
+  command: NodeCommand.checkLifelineHealth;
+  rounds?: number;
+}
+
+export interface IncomingCommandCheckRouteHealth
+  extends IncomingCommandNodeBase {
+  command: NodeCommand.checkRouteHealth;
+  targetNodeId: number;
+  rounds?: number;
+}
+
 export type IncomingMessageNode =
   | IncomingCommandNodeSetValue
   | IncomingCommandNodeRefreshInfo
@@ -105,4 +132,7 @@ export type IncomingMessageNode =
   | IncomingCommandNodeRefreshCCValues
   | IncomingCommandNodePing
   | IncomingCommandHasSecurityClass
-  | IncomingCommandGetHighestSecurityClass;
+  | IncomingCommandGetHighestSecurityClass
+  | IncomingCommandTestPowerlevel
+  | IncomingCommandCheckLifelineHealth
+  | IncomingCommandCheckRouteHealth;

--- a/src/lib/node/outgoing_message.ts
+++ b/src/lib/node/outgoing_message.ts
@@ -1,5 +1,7 @@
 import {
   FirmwareUpdateCapabilities,
+  LifelineHealthCheckSummary,
+  RouteHealthCheckSummary,
   TranslatedValueID,
   ValueMetadata,
 } from "zwave-js";
@@ -25,4 +27,7 @@ export interface NodeResultTypes {
   [NodeCommand.getHighestSecurityClass]: {
     highestSecurityClass: SecurityClass | undefined;
   };
+  [NodeCommand.testPowerlevel]: { framesAcked: number };
+  [NodeCommand.checkLifelineHealth]: { summary: LifelineHealthCheckSummary };
+  [NodeCommand.checkRouteHealth]: { summary: RouteHealthCheckSummary };
 }

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -64,6 +64,7 @@ export class Client {
       NodeMessageHandler.handle(
         message as IncomingMessageNode,
         this.driver,
+        this.clientsController,
         this
       ),
     [Instance.multicast_group]: (message) =>


### PR DESCRIPTION
Introduced three new commands at the node level:
- `testPowerlevel`
- `checkLifelineHealth`
- `checkRouteHealth`

I added callbacks for all commands to receive updates. Note that the event names aren't standard because these aren't events coming from the driver but this is consistent with how the `heal network progress` event is named.

I also updated the `refreshInfo` command to accept an optional parameter that was introduced in this release.