### PR TITLE
Add controller command to get inclusion state

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,19 @@ interface {
 
 > NOTE: For the most part, `controller` commands have the same inputs as documented in the Z-Wave JS documentation. The two exceptions are `controller.begin_inclusion` and `controller.provision_smart_start_node`; in addition to the input types that are documented, these commands will also accept the QR code string directly and will convert the string to a `QRProvisioningInformation` object automatically.
 
+Additional commands added to the server:
+
+#### [Get inclusion state](https://zwave-js.github.io/node-zwave-js/#/api/controller?id=inclusionstate)
+
+[compatible with schema version: 14+]
+
+```ts
+interface {
+  messageId: string;
+  command: "controller.inclusion_state";
+}
+```
+
 ### Node level commands
 
 #### [Set value on a node](https://zwave-js.github.io/node-zwave-js/#/api/node?id=setvalue)

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -4,4 +4,4 @@ export const version = require("../../package.json").version;
 export const minSchemaVersion = 0;
 
 // maximal/current schema version the server supports
-export const maxSchemaVersion = 13;
+export const maxSchemaVersion = 14;

--- a/src/lib/controller/command.ts
+++ b/src/lib/controller/command.ts
@@ -26,4 +26,5 @@ export enum ControllerCommand {
   getProvisioningEntry = "controller.get_provisioning_entry",
   getProvisioningEntries = "controller.get_provisioning_entries",
   supportsFeature = "controller.supports_feature",
+  getInclusionState = "controller.get_inclusion_state",
 }

--- a/src/lib/controller/command.ts
+++ b/src/lib/controller/command.ts
@@ -26,5 +26,5 @@ export enum ControllerCommand {
   getProvisioningEntry = "controller.get_provisioning_entry",
   getProvisioningEntries = "controller.get_provisioning_entries",
   supportsFeature = "controller.supports_feature",
-  getInclusionState = "controller.get_inclusion_state",
+  inclusionState = "controller.inclusion_state",
 }

--- a/src/lib/controller/incoming_message.ts
+++ b/src/lib/controller/incoming_message.ts
@@ -181,9 +181,9 @@ export interface IncomingCommandControllerSupportsFeature
   feature: ZWaveFeature;
 }
 
-export interface IncomingCommandControllerGetInclusionState
+export interface IncomingCommandControllerInclusionState
   extends IncomingCommandControllerBase {
-  command: ControllerCommand.getInclusionState;
+  command: ControllerCommand.inclusionState;
 }
 
 export type IncomingMessageController =
@@ -213,4 +213,4 @@ export type IncomingMessageController =
   | IncomingCommandControllerGetProvisioningEntry
   | IncomingCommandControllerGetProvisioningEntries
   | IncomingCommandControllerSupportsFeature
-  | IncomingCommandControllerGetInclusionState;
+  | IncomingCommandControllerInclusionState;

--- a/src/lib/controller/incoming_message.ts
+++ b/src/lib/controller/incoming_message.ts
@@ -181,6 +181,11 @@ export interface IncomingCommandControllerSupportsFeature
   feature: ZWaveFeature;
 }
 
+export interface IncomingCommandControllerGetInclusionState
+  extends IncomingCommandControllerBase {
+  command: ControllerCommand.getInclusionState;
+}
+
 export type IncomingMessageController =
   | IncomingCommandControllerBeginInclusion
   | IncomingCommandControllerBeginInclusionLegacy
@@ -207,4 +212,5 @@ export type IncomingMessageController =
   | IncomingCommandControllerUnprovisionSmartStartNode
   | IncomingCommandControllerGetProvisioningEntry
   | IncomingCommandControllerGetProvisioningEntries
-  | IncomingCommandControllerSupportsFeature;
+  | IncomingCommandControllerSupportsFeature
+  | IncomingCommandControllerGetInclusionState;

--- a/src/lib/controller/message_handler.ts
+++ b/src/lib/controller/message_handler.ts
@@ -192,7 +192,7 @@ export class ControllerMessageHandler {
       case ControllerCommand.supportsFeature:
         const supported = driver.controller.supportsFeature(message.feature);
         return { supported };
-      case ControllerCommand.getInclusionState:
+      case ControllerCommand.inclusionState:
         const inclusionState = driver.controller.inclusionState;
         return { inclusionState };
       default:

--- a/src/lib/controller/message_handler.ts
+++ b/src/lib/controller/message_handler.ts
@@ -192,6 +192,9 @@ export class ControllerMessageHandler {
       case ControllerCommand.supportsFeature:
         const supported = driver.controller.supportsFeature(message.feature);
         return { supported };
+      case ControllerCommand.getInclusionState:
+        const inclusionState = driver.controller.inclusionState;
+        return { inclusionState };
       default:
         throw new UnknownCommandError(command);
     }

--- a/src/lib/controller/outgoing_message.ts
+++ b/src/lib/controller/outgoing_message.ts
@@ -1,6 +1,7 @@
 import {
   AssociationAddress,
   AssociationGroup,
+  InclusionState,
   SmartStartProvisioningEntry,
 } from "zwave-js";
 import { ControllerCommand } from "./command";
@@ -41,4 +42,5 @@ export interface ControllerResultTypes {
     entries: SmartStartProvisioningEntry[];
   };
   [ControllerCommand.supportsFeature]: { supported: boolean | undefined };
+  [ControllerCommand.getInclusionState]: { inclusionState: InclusionState };
 }

--- a/src/lib/controller/outgoing_message.ts
+++ b/src/lib/controller/outgoing_message.ts
@@ -42,5 +42,5 @@ export interface ControllerResultTypes {
     entries: SmartStartProvisioningEntry[];
   };
   [ControllerCommand.supportsFeature]: { supported: boolean | undefined };
-  [ControllerCommand.getInclusionState]: { inclusionState: InclusionState };
+  [ControllerCommand.inclusionState]: { inclusionState: InclusionState };
 }


### PR DESCRIPTION
As discussed here: https://discord.com/channels/330944238910963714/800356888827002880/920458863080259615

The HA frontend does not handle an in progress inclusion well. Part of the problem is that the frontend doesn't know that the controller is already in an inclusion state and is not idle. This command would allow clients to check this property so they know to subscribe to events.