### PR TITLE
Add ability to specify listening address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 config.json
 /dist/
 .vscode/*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ These instructions are for development only. These CLIs will be available as `zw
 ts-node src/bin/server.ts /dev/tty0
 ```
 
-Opens server on `ws://localhost:3000`.
+Opens server on `ws://0.0.0.0:3000`.
 
 You can specify a configuration file with `--config`. This can be a JSON file or a JS file that exports the config. It needs to follow the [Z-Wave JS config format](https://zwave-js.github.io/node-zwave-js/#/api/driver?id=zwaveoptions).
 
-You can specify a different port for the websocket server to listen on with `--port`, as well as the interface to attach to `--host`.
+You can specify a different port for the websocket server to listen on with `--port`, as well as the interface to attach to using `--host`, the default host is **0.0.0.0** i.e all interfaces.
 
 If you don't have a USB stick, you can add `--mock-driver` to use a fake stick.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Opens server on `ws://localhost:3000`.
 
 You can specify a configuration file with `--config`. This can be a JSON file or a JS file that exports the config. It needs to follow the [Z-Wave JS config format](https://zwave-js.github.io/node-zwave-js/#/api/driver?id=zwaveoptions).
 
-You can specify a different port for the websocket server to listen on with `--port`.
+You can specify a different port for the websocket server to listen on with `--port`, as well as the interface to attach to `--host`.
 
 If you don't have a USB stick, you can add `--mock-driver` to use a fake stick.
 

--- a/src/bin/server.ts
+++ b/src/bin/server.ts
@@ -26,16 +26,10 @@ interface Args {
 (async () => {
   const args = parseArgs<Args>(["_", "config", "mock-driver", "port", "host"]);
 
-  let wsPort = 3000;
-  if (args["port"]) {
+  if (args.port) {
     if (typeof args["port"] !== "number") {
       throw new Error("port must be a valid integer");
     }
-    wsPort = args["port"];
-  }
-  let wsHost = "0.0.0.0";
-  if (args["host"]) {
-    wsHost = args["host"];
   }
 
   if (args["mock-driver"]) {
@@ -134,10 +128,8 @@ interface Args {
 
   driver.on("driver ready", async () => {
     try {
-      server = new ZwavejsServer(driver, { port: wsPort, host: wsHost });
+      server = new ZwavejsServer(driver, { port: args.port, host: args.host });
       await server.start();
-      const localEndpoint = wsHost + ":" + wsPort;
-      console.info("Server listening on", localEndpoint);
     } catch (error) {
       console.error("Unable to start Server", error);
     }

--- a/src/bin/server.ts
+++ b/src/bin/server.ts
@@ -19,7 +19,7 @@ interface Args {
   _: Array<string>;
   config?: string;
   "mock-driver": boolean;
-  port: number;
+  port?: number;
   host?: string;
 }
 
@@ -32,6 +32,10 @@ interface Args {
       throw new Error("port must be a valid integer");
     }
     wsPort = args["port"];
+  }
+  let wsHost = "0.0.0.0";
+  if (args["host"]) {
+    wsHost = args["host"];
   }
 
   if (args["mock-driver"]) {
@@ -130,9 +134,10 @@ interface Args {
 
   driver.on("driver ready", async () => {
     try {
-      server = new ZwavejsServer(driver, { port: wsPort, host: args.host });
+      server = new ZwavejsServer(driver, { port: wsPort, host: wsHost });
       await server.start();
-      console.info("Server listening on port", wsPort);
+      const localEndpoint = wsHost + ":" + wsPort;
+      console.info("Server listening on", localEndpoint);
     } catch (error) {
       console.error("Unable to start Server", error);
     }

--- a/src/bin/server.ts
+++ b/src/bin/server.ts
@@ -20,10 +20,11 @@ interface Args {
   config?: string;
   "mock-driver": boolean;
   port: number;
+  host?: string;
 }
 
 (async () => {
-  const args = parseArgs<Args>(["_", "config", "mock-driver", "port"]);
+  const args = parseArgs<Args>(["_", "config", "mock-driver", "port", "host"]);
 
   let wsPort = 3000;
   if (args["port"]) {
@@ -129,7 +130,7 @@ interface Args {
 
   driver.on("driver ready", async () => {
     try {
-      server = new ZwavejsServer(driver, { port: wsPort });
+      server = new ZwavejsServer(driver, { port: wsPort, host: args.host });
       await server.start();
       console.info("Server listening on port", wsPort);
     } catch (error) {

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -403,13 +403,16 @@ export class ZwavejsServer extends EventEmitter {
     this.sockets = new ClientsController(this.driver, this.logger);
     this.wsServer.on("connection", (socket) => this.sockets!.addSocket(socket));
 
-    this.logger.debug(`Starting server on port ${this.options.port}`);
+    const localEndpoint =
+      (this.options.host || "0.0.0.0") + ":" + this.options.port;
+
+    this.logger.debug(`Starting server on ${localEndpoint}`);
 
     this.server.on("error", this.onError.bind(this));
     this.server.listen(this.options.port, this.options.host);
     await once(this.server, "listening");
     this.emit("listening");
-    this.logger.info(`ZwaveJS server listening on port ${this.options.port}`);
+    this.logger.info(`ZwaveJS server listening on ${localEndpoint}`);
   }
 
   private onError(error: Error) {

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -358,8 +358,14 @@ export class ClientsController {
     this.cleanupLoggingEventForwarder();
   }
 }
+
+interface HostConfig {
+  port: number,
+  host: string
+}
+
 interface ZwavejsServerOptions {
-  port: number;
+  port: number | HostConfig;
   logger?: Logger;
 }
 

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -408,17 +408,14 @@ export class ZwavejsServer extends EventEmitter {
     this.sockets = new ClientsController(this.driver, this.logger);
     this.wsServer.on("connection", (socket) => this.sockets!.addSocket(socket));
 
-    const localEndpointString = `${this.options.host || this.defaultHost}:${
-      this.options.port || this.defaultPort
-    }`;
+    const port = this.options.port || this.defaultPort;
+    const host = this.options.host || this.defaultHost;
+    const localEndpointString = `${host}:${port}`;
 
     this.logger.debug(`Starting server on ${localEndpointString}`);
 
     this.server.on("error", this.onError.bind(this));
-    this.server.listen(
-      this.options.port || this.defaultPort,
-      this.options.host || this.defaultHost
-    );
+    this.server.listen(port, host);
     await once(this.server, "listening");
     this.emit("listening");
     this.logger.info(`ZwaveJS server listening on ${localEndpointString}`);

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -360,7 +360,7 @@ export class ClientsController {
 }
 
 interface ZwavejsServerOptions {
-  port: number;
+  port?: number;
   host?: string;
   logger?: Logger;
 }
@@ -384,8 +384,13 @@ export class ZwavejsServer extends EventEmitter {
   private wsServer?: ws.Server;
   private sockets?: ClientsController;
   private logger: Logger;
+  private defaultPort: number = 3000;
+  private defaultHost: string = "0.0.0.0";
 
-  constructor(private driver: Driver, private options: ZwavejsServerOptions) {
+  constructor(
+    private driver: Driver,
+    private options: ZwavejsServerOptions = {}
+  ) {
     super();
     this.logger = options.logger ?? console;
   }
@@ -403,16 +408,20 @@ export class ZwavejsServer extends EventEmitter {
     this.sockets = new ClientsController(this.driver, this.logger);
     this.wsServer.on("connection", (socket) => this.sockets!.addSocket(socket));
 
-    const localEndpoint =
-      (this.options.host || "0.0.0.0") + ":" + this.options.port;
+    const localEndpointString = `${this.options.host || this.defaultHost}:${
+      this.options.port || this.defaultPort
+    }`;
 
-    this.logger.debug(`Starting server on ${localEndpoint}`);
+    this.logger.debug(`Starting server on ${localEndpointString}`);
 
     this.server.on("error", this.onError.bind(this));
-    this.server.listen(this.options.port, this.options.host);
+    this.server.listen(
+      this.options.port || this.defaultPort,
+      this.options.host || this.defaultHost
+    );
     await once(this.server, "listening");
     this.emit("listening");
-    this.logger.info(`ZwaveJS server listening on ${localEndpoint}`);
+    this.logger.info(`ZwaveJS server listening on ${localEndpointString}`);
   }
 
   private onError(error: Error) {

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -358,8 +358,14 @@ export class ClientsController {
     this.cleanupLoggingEventForwarder();
   }
 }
-interface ZwavejsServerOptions {
+
+interface HostConfig {
   port: number;
+  host: string;
+}
+
+interface ZwavejsServerOptions {
+  port: number | HostConfig;
   logger?: Logger;
 }
 

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -359,13 +359,9 @@ export class ClientsController {
   }
 }
 
-interface HostConfig {
-  port: number;
-  host: string;
-}
-
 interface ZwavejsServerOptions {
-  port: number | HostConfig;
+  port: number;
+  host?: string;
   logger?: Logger;
 }
 
@@ -410,7 +406,7 @@ export class ZwavejsServer extends EventEmitter {
     this.logger.debug(`Starting server on port ${this.options.port}`);
 
     this.server.on("error", this.onError.bind(this));
-    this.server.listen(this.options.port);
+    this.server.listen(this.options.port, this.options.host);
     await once(this.server, "listening");
     this.emit("listening");
     this.logger.info(`ZwaveJS server listening on port ${this.options.port}`);

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -358,14 +358,8 @@ export class ClientsController {
     this.cleanupLoggingEventForwarder();
   }
 }
-
-interface HostConfig {
-  port: number,
-  host: string
-}
-
 interface ZwavejsServerOptions {
-  port: number | HostConfig;
+  port: number;
   logger?: Logger;
 }
 


### PR DESCRIPTION
Consuming this library, I was concerned around the lack of protection with not being able to control network access. Using NGINX or another attempt to secure the socket might not always be possible.

for example, I am building a .Net wrapper - that utilises this server - allowing .Net Developers to consume zwave-js in their applications - where the server/zwave-js is embedded.

So,
With this PR, it makes it possible to at least isolate the server to localhost - I.e the server might only be used to bridge language barriers, without breaking current implementations.

This is done by providing the ability to specify an object as opposed to a number, where said object accepts a `host` parameter
https://nodejs.org/api/net.html#serverlistenoptions-callback

My typescript is not up to scratch - so if this causes problems, please disregard.