### PR TITLE
Bump zwave-js to 8.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -950,6 +950,54 @@ interface {
 }
 ```
 
+#### `nvm backup progress`
+
+This event is sent on progress updates to the NVM backup process when the [`controller.backup_nvm_raw`](https://zwave-js.github.io/node-zwave-js/#/api/controller?id=nvm-backup-and-restore) command is issued by a client to the server and a backup is in progress.
+
+```ts
+interface {
+  type: "event";
+  event: {
+    source: "controller";
+    event: "nvm backup progress";
+    bytesRead: number;
+    total: number;
+  }
+}
+```
+
+#### `nvm convert progress`
+
+This event is sent on progress updates to the NVM conversion process when the [`controller.restore_nvm`](https://zwave-js.github.io/node-zwave-js/#/api/controller?id=nvm-backup-and-restore) command is issued by a client to the server and the NVM file that was passed in is being converted to the right format.
+
+```ts
+interface {
+  type: "event";
+  event: {
+    source: "controller";
+    event: "nvm backup progress";
+    bytesRead: number;
+    total: number;
+  }
+}
+```
+
+#### `nvm restore progress`
+
+This event is sent on progress updates to the NVM restoration process when the [`controller.restore_nvm`](https://zwave-js.github.io/node-zwave-js/#/api/controller?id=nvm-backup-and-restore) command is issued by a client to the server and the NVM data is being restored to the controller.
+
+```ts
+interface {
+  type: "event";
+  event: {
+    source: "controller";
+    event: "nvm backup progress";
+    bytesWritten: number;
+    total: number;
+  }
+}
+```
+
 ## Schema Version
 
 In an attempt to keep compatibility between different server and client versions, we've introduced a (basic) API Schema Version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,19 +32,19 @@
         "prettier": "^2.3.0",
         "ts-node": "^10.0.0",
         "typescript": "^4.1.3",
-        "zwave-js": "^8.8.2"
+        "zwave-js": "^8.9.0"
       },
       "peerDependencies": {
-        "zwave-js": "^8.8.2"
+        "zwave-js": "^8.9.0"
       }
     },
     "node_modules/@alcalzone/jsonl-db": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@alcalzone/jsonl-db/-/jsonl-db-2.2.0.tgz",
-      "integrity": "sha512-cSHbPtClQOTeaTZTlZzOsMwUrf3PxMhusv2uC3IiisNYMKwLJBw3Zpw+f89SzHhimR8TsR3gFtD0jBK0AzU6bA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@alcalzone/jsonl-db/-/jsonl-db-2.3.0.tgz",
+      "integrity": "sha512-zSu2fVGifCkbJ+p1vRBIv459+iAZ+ivpv1wCWg3RCWVX2PXUr9R09xuOtIIL662Iy/Js8ssreIkaipz+GGbayw==",
       "dev": true,
       "dependencies": {
-        "alcalzone-shared": "^4.0.0",
+        "alcalzone-shared": "^4.0.1",
         "fs-extra": "^10.0.0",
         "proper-lockfile": "^4.1.2"
       },
@@ -283,15 +283,37 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.15.0.tgz",
-      "integrity": "sha512-mCbKyqvD1G3Re6gv6N8tRkBz84gvVWDfLtC6d1WBArIopzter6ktEbvq0cMT6EOvGI2OLXuJ6mtHA93/Q0gGpw==",
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.16.1.tgz",
+      "integrity": "sha512-UFI0264CPUc5cR1zJH+S2UPOANpm6dLJOnsvnIGTjsrwzR0h8Hdl6rC2R/GPq+WNbnipo9hkiIwDlqbqvIU5vw==",
       "dev": true,
       "dependencies": {
-        "@sentry/hub": "6.15.0",
-        "@sentry/minimal": "6.15.0",
-        "@sentry/types": "6.15.0",
-        "@sentry/utils": "6.15.0",
+        "@sentry/hub": "6.16.1",
+        "@sentry/minimal": "6.16.1",
+        "@sentry/types": "6.16.1",
+        "@sentry/utils": "6.16.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/core/node_modules/@sentry/types": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.16.1.tgz",
+      "integrity": "sha512-Wh354g30UsJ5kYJbercektGX4ZMc9MHU++1NjeN2bTMnbofEcpUDWIiKeulZEY65IC1iU+1zRQQgtYO+/hgCUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/core/node_modules/@sentry/utils": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.16.1.tgz",
+      "integrity": "sha512-7ngq/i4R8JZitJo9Sl8PDnjSbDehOxgr1vsoMmerIsyRZ651C/8B+jVkMhaAPgSdyJ0AlE3O7DKKTP1FXFw9qw==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/types": "6.16.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -299,13 +321,35 @@
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.15.0.tgz",
-      "integrity": "sha512-cUbHPeG6kKpGBaEMgbTWeU03Y1Up5T3urGF+cgtrn80PmPYYSUPvVvWlZQWPb8CJZ1yQ0gySWo5RUTatBFrEHA==",
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.16.1.tgz",
+      "integrity": "sha512-4PGtg6AfpqMkreTpL7ymDeQ/U1uXv03bKUuFdtsSTn/FRf9TLS4JB0KuTZCxfp1IRgAA+iFg6B784dDkT8R9eg==",
       "dev": true,
       "dependencies": {
-        "@sentry/types": "6.15.0",
-        "@sentry/utils": "6.15.0",
+        "@sentry/types": "6.16.1",
+        "@sentry/utils": "6.16.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/hub/node_modules/@sentry/types": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.16.1.tgz",
+      "integrity": "sha512-Wh354g30UsJ5kYJbercektGX4ZMc9MHU++1NjeN2bTMnbofEcpUDWIiKeulZEY65IC1iU+1zRQQgtYO+/hgCUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/hub/node_modules/@sentry/utils": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.16.1.tgz",
+      "integrity": "sha512-7ngq/i4R8JZitJo9Sl8PDnjSbDehOxgr1vsoMmerIsyRZ651C/8B+jVkMhaAPgSdyJ0AlE3O7DKKTP1FXFw9qw==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/types": "6.16.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -328,30 +372,39 @@
       }
     },
     "node_modules/@sentry/minimal": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.15.0.tgz",
-      "integrity": "sha512-7RJIvZsjBa1qFUfMrAzQsWdfZT6Gm4t6ZTYfkpsXPBA35hkzglKbBrhhsUvkxGIhUGw/PiCUqxBUjcmzQP0vfg==",
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.16.1.tgz",
+      "integrity": "sha512-dq+mI1EQIvUM+zJtGCVgH3/B3Sbx4hKlGf2Usovm9KoqWYA+QpfVBholYDe/H2RXgO7LFEefDLvOdHDkqeJoyA==",
       "dev": true,
       "dependencies": {
-        "@sentry/hub": "6.15.0",
-        "@sentry/types": "6.15.0",
+        "@sentry/hub": "6.16.1",
+        "@sentry/types": "6.16.1",
         "tslib": "^1.9.3"
       },
       "engines": {
         "node": ">=6"
       }
     },
+    "node_modules/@sentry/minimal/node_modules/@sentry/types": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.16.1.tgz",
+      "integrity": "sha512-Wh354g30UsJ5kYJbercektGX4ZMc9MHU++1NjeN2bTMnbofEcpUDWIiKeulZEY65IC1iU+1zRQQgtYO+/hgCUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@sentry/node": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.15.0.tgz",
-      "integrity": "sha512-V1GeupWi9ClmoMy5eBWdVTv3k+Yx/JpddT4zCzzYY9QfjYtEvQI7R3SWFtlgXuaQQaZNU0WUoE2UgJV2N/vS8g==",
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.16.1.tgz",
+      "integrity": "sha512-SeDDoug2kUxeF1D7JGPa3h5EXxKtmA01mITBPYx5xbJ0sMksnv5I5bC1SJ8arRRzq6+W1C4IEeDBQtrVCk6ixA==",
       "dev": true,
       "dependencies": {
-        "@sentry/core": "6.15.0",
-        "@sentry/hub": "6.15.0",
-        "@sentry/tracing": "6.15.0",
-        "@sentry/types": "6.15.0",
-        "@sentry/utils": "6.15.0",
+        "@sentry/core": "6.16.1",
+        "@sentry/hub": "6.16.1",
+        "@sentry/tracing": "6.16.1",
+        "@sentry/types": "6.16.1",
+        "@sentry/utils": "6.16.1",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -361,16 +414,60 @@
         "node": ">=6"
       }
     },
-    "node_modules/@sentry/tracing": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.15.0.tgz",
-      "integrity": "sha512-V5unvX8qNEfdawX+m2n0jKgmH/YR2ItWZLH+3UevBTptO+xyfvRtpgGXYWUCo3iGvFgWb1C+iIC7LViR9rTvBg==",
+    "node_modules/@sentry/node/node_modules/@sentry/types": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.16.1.tgz",
+      "integrity": "sha512-Wh354g30UsJ5kYJbercektGX4ZMc9MHU++1NjeN2bTMnbofEcpUDWIiKeulZEY65IC1iU+1zRQQgtYO+/hgCUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/utils": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.16.1.tgz",
+      "integrity": "sha512-7ngq/i4R8JZitJo9Sl8PDnjSbDehOxgr1vsoMmerIsyRZ651C/8B+jVkMhaAPgSdyJ0AlE3O7DKKTP1FXFw9qw==",
       "dev": true,
       "dependencies": {
-        "@sentry/hub": "6.15.0",
-        "@sentry/minimal": "6.15.0",
-        "@sentry/types": "6.15.0",
-        "@sentry/utils": "6.15.0",
+        "@sentry/types": "6.16.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/tracing": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.16.1.tgz",
+      "integrity": "sha512-MPSbqXX59P+OEeST+U2V/8Hu/8QjpTUxTNeNyTHWIbbchdcMMjDbXTS3etCgajZR6Ro+DHElOz5cdSxH6IBGlA==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/hub": "6.16.1",
+        "@sentry/minimal": "6.16.1",
+        "@sentry/types": "6.16.1",
+        "@sentry/utils": "6.16.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/@sentry/types": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.16.1.tgz",
+      "integrity": "sha512-Wh354g30UsJ5kYJbercektGX4ZMc9MHU++1NjeN2bTMnbofEcpUDWIiKeulZEY65IC1iU+1zRQQgtYO+/hgCUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/@sentry/utils": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.16.1.tgz",
+      "integrity": "sha512-7ngq/i4R8JZitJo9Sl8PDnjSbDehOxgr1vsoMmerIsyRZ651C/8B+jVkMhaAPgSdyJ0AlE3O7DKKTP1FXFw9qw==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/types": "6.16.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -414,23 +511,6 @@
         "url": "https://opencollective.com/serialport/donate"
       }
     },
-    "node_modules/@serialport/binding-abstract/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@serialport/binding-mock": {
       "version": "9.2.4",
       "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-9.2.4.tgz",
@@ -445,23 +525,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/@serialport/binding-mock/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/@serialport/bindings": {
@@ -483,23 +546,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/@serialport/bindings/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/@serialport/parser-byte-length": {
@@ -602,23 +648,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/@serialport/stream/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -1005,13 +1034,13 @@
       }
     },
     "node_modules/@zwave-js/config": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.8.1.tgz",
-      "integrity": "sha512-k8LlOAFoGoWn19gWvRxuhSkUJW6kWmLYBIdBB8jZNUE0sEWbDsxwX3GYYmGb8WangQWvZPXE+VG9KBPAXnSaSw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.9.0.tgz",
+      "integrity": "sha512-0z18/QArboNZS7S8Dr5R1o5vfNvkHNL+8Zi77cDRLvHAHU6G9r8cRBsmaqrLDOhl2HpbIRGHE9hcaj0L9cXlDg==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "8.8.1",
-        "@zwave-js/shared": "8.8.0",
+        "@zwave-js/core": "8.9.0",
+        "@zwave-js/shared": "8.9.0",
         "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.1",
         "fs-extra": "^10.0.0",
@@ -1021,20 +1050,20 @@
         "winston": "^3.3.3"
       },
       "engines": {
-        "node": ">=12.22.2 <16.9.0 || >16.9.0"
+        "node": ">=12.22.2 <13 || >=14.13.0 <15 || >= 16 <16.9.0 || >16.9.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/AlCalzone/"
       }
     },
     "node_modules/@zwave-js/core": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-8.8.1.tgz",
-      "integrity": "sha512-hqoBD4ADDOImWe1dG5NVVSwf1PojcxeMArmQLniAq9O/CgYDU8JK3fNBgABRE+VEvHeMDS1MqtUv6iSciEjeKg==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-8.9.0.tgz",
+      "integrity": "sha512-w9AdRs3k4a3KUTre6QSf1vh26KX9mPQMXiPKdZtJhjuXHRSig/3TSIhUcSskHbR+lNQ9+oofnJe5zrIz7pS+4Q==",
       "dev": true,
       "dependencies": {
         "@alcalzone/jsonl-db": "^2.2.0",
-        "@zwave-js/shared": "8.8.0",
+        "@zwave-js/shared": "8.9.0",
         "@zwave-js/winston-daily-rotate-file": "^4.5.6-0",
         "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.1",
@@ -1046,7 +1075,7 @@
         "winston-transport": "*"
       },
       "engines": {
-        "node": ">=12.22.2 <16.9.0 || >16.9.0"
+        "node": ">=12.22.2 <13 || >=14.13.0 <15 || >= 16 <16.9.0 || >16.9.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/AlCalzone/"
@@ -1061,37 +1090,61 @@
         "moment": "^2.11.2"
       }
     },
-    "node_modules/@zwave-js/serial": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-8.8.1.tgz",
-      "integrity": "sha512-lGKFCN628ljSMANlXdAq7XosMjKMlkjJCINWv8UhUXZybYwo5zqSDFgKBbZwURsAJtNtGmwRtFy9tHdXIpkcWQ==",
+    "node_modules/@zwave-js/nvmedit": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-8.9.0.tgz",
+      "integrity": "sha512-uEvYNgFz5eGoz5mLKDe/7mIcL0mvxqBYn2K0FahiYshmy0l1mlKkmBDQG8jLoMkv1ZrLRBky1Sf6dfAxqIvjgw==",
       "dev": true,
       "dependencies": {
-        "@sentry/node": "^6.14.3",
-        "@zwave-js/core": "8.8.1",
-        "@zwave-js/shared": "8.8.0",
+        "@zwave-js/core": "8.9.0",
+        "@zwave-js/shared": "8.9.0",
         "alcalzone-shared": "^4.0.1",
-        "serialport": "^9.2.5",
+        "fs-extra": "^10.0.0",
+        "reflect-metadata": "^0.1.13",
+        "semver": "^7.3.5",
+        "yargs": "^17.2.1"
+      },
+      "bin": {
+        "nvmedit": "bin/nvmedit.js"
+      },
+      "engines": {
+        "node": ">=v12.22.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone/"
+      }
+    },
+    "node_modules/@zwave-js/serial": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-8.9.0.tgz",
+      "integrity": "sha512-/AoV18hLL0gSG92aG7gljtre2Fnn8GsbbhVzX+TDtDnLfS07df6asCqjzMOULn3pNKRhllPut6tLw6goZxRENg==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/node": "^6.15.0",
+        "@zwave-js/core": "8.9.0",
+        "@zwave-js/shared": "8.9.0",
+        "alcalzone-shared": "^4.0.1",
+        "serialport": "^9.2.8",
         "winston": "^3.3.3"
       },
       "engines": {
-        "node": ">=12.22.2 <16.9.0 || >16.9.0"
+        "node": ">=12.22.2 <13 || >=14.13.0 <15 || >= 16 <16.9.0 || >16.9.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/AlCalzone/"
       }
     },
     "node_modules/@zwave-js/shared": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-8.8.0.tgz",
-      "integrity": "sha512-fx8wu508/+XX2IJmNn6tZgnRwL0nu4x5CB8damwGKfPjeC0d7C+yRuL3PkamIDMy94BscEweoBNV0YK4ycUkcQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-8.9.0.tgz",
+      "integrity": "sha512-7Q3cfpRHb0CQ5O632ScI8b3DvlnoV451wbEU5MaDbRUsJLK4mJwCBfGEbOF59itH0nfuPzPvkeI7Fwefqu65aQ==",
       "dev": true,
       "dependencies": {
         "alcalzone-shared": "^4.0.1",
         "fs-extra": "^10.0.0"
       },
       "engines": {
-        "node": ">=v12.22.2"
+        "node": ">=12.22.2 <13 || >=14.13.0 <15 || >= 16 <16.9.0 || >16.9.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/AlCalzone/"
@@ -1198,23 +1251,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/alcalzone-shared/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -1252,9 +1288,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -1596,6 +1632,17 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
     "node_modules/code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -1634,9 +1681,9 @@
       "dev": true
     },
     "node_modules/color-string": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.7.4.tgz",
-      "integrity": "sha512-nVdUvPVgZMpRQad5dcsCMOSB5BXLljklTiaxS6ehhKxDsAI5sD7k5VmFuBt1y3Rlym8uulc/ANUN/bMWtBu6Sg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
       "dev": true,
       "dependencies": {
         "color-name": "^1.0.0",
@@ -1768,9 +1815,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -1905,6 +1952,15 @@
       "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2422,6 +2478,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -2887,23 +2952,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/lint-staged"
-      }
-    },
-    "node_modules/lint-staged/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/lint-staged/node_modules/micromatch": {
@@ -3696,6 +3744,15 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3873,23 +3930,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/serialport/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/set-blocking": {
@@ -4087,26 +4127,26 @@
       }
     },
     "node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -4483,16 +4523,31 @@
       }
     },
     "node_modules/winston-transport": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
-      "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.1.tgz",
+      "integrity": "sha512-ciZRlU4CSjHqHe8RQG1iPxKMRVwv6ZJ0RC7DxStKWd0KjpAhPDy5gVYSCpIUq+5CUsP+IyNOTZy1X0tO2QZqjg==",
       "dev": true,
       "dependencies": {
-        "readable-stream": "^2.3.7",
+        "logform": "^2.2.0",
+        "readable-stream": "^3.4.0",
         "triple-beam": "^1.2.0"
       },
       "engines": {
         "node": ">= 6.4.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/winston/node_modules/readable-stream": {
@@ -4571,6 +4626,15 @@
         "url": "https://opencollective.com/xstate"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -4584,6 +4648,33 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
+      "integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yn": {
@@ -4608,19 +4699,20 @@
       }
     },
     "node_modules/zwave-js": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.8.2.tgz",
-      "integrity": "sha512-shFY1y9hqKzS7mZzNBNMnpsuSgVhpas0EYQdXupm/r8rglBBm5c3+MNkGT2X/ImYYv1VR0WtsAs+pEqBXYaY8w==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.9.0.tgz",
+      "integrity": "sha512-86fGETedph2zEjG62nS7HH8umjgn614YxG8izy4om/6pK+J1VNaeNXg297kDxajikH4slfgmFWTG8dofgJGQiQ==",
       "dev": true,
       "dependencies": {
         "@alcalzone/jsonl-db": "^2.2.0",
         "@alcalzone/pak": "^0.7.0",
-        "@sentry/integrations": "^6.14.3",
-        "@sentry/node": "^6.14.3",
-        "@zwave-js/config": "8.8.1",
-        "@zwave-js/core": "8.8.1",
-        "@zwave-js/serial": "8.8.1",
-        "@zwave-js/shared": "8.8.0",
+        "@sentry/integrations": "^6.15.0",
+        "@sentry/node": "^6.15.0",
+        "@zwave-js/config": "8.9.0",
+        "@zwave-js/core": "8.9.0",
+        "@zwave-js/nvmedit": "8.9.0",
+        "@zwave-js/serial": "8.9.0",
+        "@zwave-js/shared": "8.9.0",
         "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.1",
         "axios": "^0.24.0",
@@ -4629,13 +4721,13 @@
         "proper-lockfile": "^4.1.2",
         "reflect-metadata": "^0.1.13",
         "semver": "^7.3.5",
-        "serialport": "^9.2.5",
-        "source-map-support": "^0.5.20",
+        "serialport": "^9.2.8",
+        "source-map-support": "^0.5.21",
         "winston": "^3.3.3",
-        "xstate": "^4.26.0"
+        "xstate": "^4.26.1"
       },
       "engines": {
-        "node": ">=12.22.2 <16.9.0 || >16.9.0"
+        "node": ">=12.22.2 <13 || >=14.13.0 <15 || >= 16 <16.9.0 || >16.9.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/AlCalzone/"
@@ -4644,12 +4736,12 @@
   },
   "dependencies": {
     "@alcalzone/jsonl-db": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@alcalzone/jsonl-db/-/jsonl-db-2.2.0.tgz",
-      "integrity": "sha512-cSHbPtClQOTeaTZTlZzOsMwUrf3PxMhusv2uC3IiisNYMKwLJBw3Zpw+f89SzHhimR8TsR3gFtD0jBK0AzU6bA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@alcalzone/jsonl-db/-/jsonl-db-2.3.0.tgz",
+      "integrity": "sha512-zSu2fVGifCkbJ+p1vRBIv459+iAZ+ivpv1wCWg3RCWVX2PXUr9R09xuOtIIL662Iy/Js8ssreIkaipz+GGbayw==",
       "dev": true,
       "requires": {
-        "alcalzone-shared": "^4.0.0",
+        "alcalzone-shared": "^4.0.1",
         "fs-extra": "^10.0.0",
         "proper-lockfile": "^4.1.2"
       }
@@ -4853,27 +4945,63 @@
       }
     },
     "@sentry/core": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.15.0.tgz",
-      "integrity": "sha512-mCbKyqvD1G3Re6gv6N8tRkBz84gvVWDfLtC6d1WBArIopzter6ktEbvq0cMT6EOvGI2OLXuJ6mtHA93/Q0gGpw==",
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.16.1.tgz",
+      "integrity": "sha512-UFI0264CPUc5cR1zJH+S2UPOANpm6dLJOnsvnIGTjsrwzR0h8Hdl6rC2R/GPq+WNbnipo9hkiIwDlqbqvIU5vw==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.15.0",
-        "@sentry/minimal": "6.15.0",
-        "@sentry/types": "6.15.0",
-        "@sentry/utils": "6.15.0",
+        "@sentry/hub": "6.16.1",
+        "@sentry/minimal": "6.16.1",
+        "@sentry/types": "6.16.1",
+        "@sentry/utils": "6.16.1",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "6.16.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.16.1.tgz",
+          "integrity": "sha512-Wh354g30UsJ5kYJbercektGX4ZMc9MHU++1NjeN2bTMnbofEcpUDWIiKeulZEY65IC1iU+1zRQQgtYO+/hgCUQ==",
+          "dev": true
+        },
+        "@sentry/utils": {
+          "version": "6.16.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.16.1.tgz",
+          "integrity": "sha512-7ngq/i4R8JZitJo9Sl8PDnjSbDehOxgr1vsoMmerIsyRZ651C/8B+jVkMhaAPgSdyJ0AlE3O7DKKTP1FXFw9qw==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "6.16.1",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@sentry/hub": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.15.0.tgz",
-      "integrity": "sha512-cUbHPeG6kKpGBaEMgbTWeU03Y1Up5T3urGF+cgtrn80PmPYYSUPvVvWlZQWPb8CJZ1yQ0gySWo5RUTatBFrEHA==",
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.16.1.tgz",
+      "integrity": "sha512-4PGtg6AfpqMkreTpL7ymDeQ/U1uXv03bKUuFdtsSTn/FRf9TLS4JB0KuTZCxfp1IRgAA+iFg6B784dDkT8R9eg==",
       "dev": true,
       "requires": {
-        "@sentry/types": "6.15.0",
-        "@sentry/utils": "6.15.0",
+        "@sentry/types": "6.16.1",
+        "@sentry/utils": "6.16.1",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "6.16.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.16.1.tgz",
+          "integrity": "sha512-Wh354g30UsJ5kYJbercektGX4ZMc9MHU++1NjeN2bTMnbofEcpUDWIiKeulZEY65IC1iU+1zRQQgtYO+/hgCUQ==",
+          "dev": true
+        },
+        "@sentry/utils": {
+          "version": "6.16.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.16.1.tgz",
+          "integrity": "sha512-7ngq/i4R8JZitJo9Sl8PDnjSbDehOxgr1vsoMmerIsyRZ651C/8B+jVkMhaAPgSdyJ0AlE3O7DKKTP1FXFw9qw==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "6.16.1",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@sentry/integrations": {
@@ -4889,44 +5017,88 @@
       }
     },
     "@sentry/minimal": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.15.0.tgz",
-      "integrity": "sha512-7RJIvZsjBa1qFUfMrAzQsWdfZT6Gm4t6ZTYfkpsXPBA35hkzglKbBrhhsUvkxGIhUGw/PiCUqxBUjcmzQP0vfg==",
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.16.1.tgz",
+      "integrity": "sha512-dq+mI1EQIvUM+zJtGCVgH3/B3Sbx4hKlGf2Usovm9KoqWYA+QpfVBholYDe/H2RXgO7LFEefDLvOdHDkqeJoyA==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.15.0",
-        "@sentry/types": "6.15.0",
+        "@sentry/hub": "6.16.1",
+        "@sentry/types": "6.16.1",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "6.16.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.16.1.tgz",
+          "integrity": "sha512-Wh354g30UsJ5kYJbercektGX4ZMc9MHU++1NjeN2bTMnbofEcpUDWIiKeulZEY65IC1iU+1zRQQgtYO+/hgCUQ==",
+          "dev": true
+        }
       }
     },
     "@sentry/node": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.15.0.tgz",
-      "integrity": "sha512-V1GeupWi9ClmoMy5eBWdVTv3k+Yx/JpddT4zCzzYY9QfjYtEvQI7R3SWFtlgXuaQQaZNU0WUoE2UgJV2N/vS8g==",
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.16.1.tgz",
+      "integrity": "sha512-SeDDoug2kUxeF1D7JGPa3h5EXxKtmA01mITBPYx5xbJ0sMksnv5I5bC1SJ8arRRzq6+W1C4IEeDBQtrVCk6ixA==",
       "dev": true,
       "requires": {
-        "@sentry/core": "6.15.0",
-        "@sentry/hub": "6.15.0",
-        "@sentry/tracing": "6.15.0",
-        "@sentry/types": "6.15.0",
-        "@sentry/utils": "6.15.0",
+        "@sentry/core": "6.16.1",
+        "@sentry/hub": "6.16.1",
+        "@sentry/tracing": "6.16.1",
+        "@sentry/types": "6.16.1",
+        "@sentry/utils": "6.16.1",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "6.16.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.16.1.tgz",
+          "integrity": "sha512-Wh354g30UsJ5kYJbercektGX4ZMc9MHU++1NjeN2bTMnbofEcpUDWIiKeulZEY65IC1iU+1zRQQgtYO+/hgCUQ==",
+          "dev": true
+        },
+        "@sentry/utils": {
+          "version": "6.16.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.16.1.tgz",
+          "integrity": "sha512-7ngq/i4R8JZitJo9Sl8PDnjSbDehOxgr1vsoMmerIsyRZ651C/8B+jVkMhaAPgSdyJ0AlE3O7DKKTP1FXFw9qw==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "6.16.1",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@sentry/tracing": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.15.0.tgz",
-      "integrity": "sha512-V5unvX8qNEfdawX+m2n0jKgmH/YR2ItWZLH+3UevBTptO+xyfvRtpgGXYWUCo3iGvFgWb1C+iIC7LViR9rTvBg==",
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.16.1.tgz",
+      "integrity": "sha512-MPSbqXX59P+OEeST+U2V/8Hu/8QjpTUxTNeNyTHWIbbchdcMMjDbXTS3etCgajZR6Ro+DHElOz5cdSxH6IBGlA==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.15.0",
-        "@sentry/minimal": "6.15.0",
-        "@sentry/types": "6.15.0",
-        "@sentry/utils": "6.15.0",
+        "@sentry/hub": "6.16.1",
+        "@sentry/minimal": "6.16.1",
+        "@sentry/types": "6.16.1",
+        "@sentry/utils": "6.16.1",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "6.16.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.16.1.tgz",
+          "integrity": "sha512-Wh354g30UsJ5kYJbercektGX4ZMc9MHU++1NjeN2bTMnbofEcpUDWIiKeulZEY65IC1iU+1zRQQgtYO+/hgCUQ==",
+          "dev": true
+        },
+        "@sentry/utils": {
+          "version": "6.16.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.16.1.tgz",
+          "integrity": "sha512-7ngq/i4R8JZitJo9Sl8PDnjSbDehOxgr1vsoMmerIsyRZ651C/8B+jVkMhaAPgSdyJ0AlE3O7DKKTP1FXFw9qw==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "6.16.1",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@sentry/types": {
@@ -4952,17 +5124,6 @@
       "dev": true,
       "requires": {
         "debug": "^4.3.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
       }
     },
     "@serialport/binding-mock": {
@@ -4973,17 +5134,6 @@
       "requires": {
         "@serialport/binding-abstract": "9.2.3",
         "debug": "^4.3.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
       }
     },
     "@serialport/bindings": {
@@ -4998,17 +5148,6 @@
         "debug": "^4.3.2",
         "nan": "^2.15.0",
         "prebuild-install": "^7.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
       }
     },
     "@serialport/parser-byte-length": {
@@ -5063,17 +5202,6 @@
       "dev": true,
       "requires": {
         "debug": "^4.3.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
       }
     },
     "@tsconfig/node10": {
@@ -5324,13 +5452,13 @@
       }
     },
     "@zwave-js/config": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.8.1.tgz",
-      "integrity": "sha512-k8LlOAFoGoWn19gWvRxuhSkUJW6kWmLYBIdBB8jZNUE0sEWbDsxwX3GYYmGb8WangQWvZPXE+VG9KBPAXnSaSw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-8.9.0.tgz",
+      "integrity": "sha512-0z18/QArboNZS7S8Dr5R1o5vfNvkHNL+8Zi77cDRLvHAHU6G9r8cRBsmaqrLDOhl2HpbIRGHE9hcaj0L9cXlDg==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "8.8.1",
-        "@zwave-js/shared": "8.8.0",
+        "@zwave-js/core": "8.9.0",
+        "@zwave-js/shared": "8.9.0",
         "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.1",
         "fs-extra": "^10.0.0",
@@ -5341,13 +5469,13 @@
       }
     },
     "@zwave-js/core": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-8.8.1.tgz",
-      "integrity": "sha512-hqoBD4ADDOImWe1dG5NVVSwf1PojcxeMArmQLniAq9O/CgYDU8JK3fNBgABRE+VEvHeMDS1MqtUv6iSciEjeKg==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-8.9.0.tgz",
+      "integrity": "sha512-w9AdRs3k4a3KUTre6QSf1vh26KX9mPQMXiPKdZtJhjuXHRSig/3TSIhUcSskHbR+lNQ9+oofnJe5zrIz7pS+4Q==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.2.0",
-        "@zwave-js/shared": "8.8.0",
+        "@zwave-js/shared": "8.9.0",
         "@zwave-js/winston-daily-rotate-file": "^4.5.6-0",
         "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.1",
@@ -5368,24 +5496,39 @@
         "moment": "^2.11.2"
       }
     },
-    "@zwave-js/serial": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-8.8.1.tgz",
-      "integrity": "sha512-lGKFCN628ljSMANlXdAq7XosMjKMlkjJCINWv8UhUXZybYwo5zqSDFgKBbZwURsAJtNtGmwRtFy9tHdXIpkcWQ==",
+    "@zwave-js/nvmedit": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-8.9.0.tgz",
+      "integrity": "sha512-uEvYNgFz5eGoz5mLKDe/7mIcL0mvxqBYn2K0FahiYshmy0l1mlKkmBDQG8jLoMkv1ZrLRBky1Sf6dfAxqIvjgw==",
       "dev": true,
       "requires": {
-        "@sentry/node": "^6.14.3",
-        "@zwave-js/core": "8.8.1",
-        "@zwave-js/shared": "8.8.0",
+        "@zwave-js/core": "8.9.0",
+        "@zwave-js/shared": "8.9.0",
         "alcalzone-shared": "^4.0.1",
-        "serialport": "^9.2.5",
+        "fs-extra": "^10.0.0",
+        "reflect-metadata": "^0.1.13",
+        "semver": "^7.3.5",
+        "yargs": "^17.2.1"
+      }
+    },
+    "@zwave-js/serial": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-8.9.0.tgz",
+      "integrity": "sha512-/AoV18hLL0gSG92aG7gljtre2Fnn8GsbbhVzX+TDtDnLfS07df6asCqjzMOULn3pNKRhllPut6tLw6goZxRENg==",
+      "dev": true,
+      "requires": {
+        "@sentry/node": "^6.15.0",
+        "@zwave-js/core": "8.9.0",
+        "@zwave-js/shared": "8.9.0",
+        "alcalzone-shared": "^4.0.1",
+        "serialport": "^9.2.8",
         "winston": "^3.3.3"
       }
     },
     "@zwave-js/shared": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-8.8.0.tgz",
-      "integrity": "sha512-fx8wu508/+XX2IJmNn6tZgnRwL0nu4x5CB8damwGKfPjeC0d7C+yRuL3PkamIDMy94BscEweoBNV0YK4ycUkcQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-8.9.0.tgz",
+      "integrity": "sha512-7Q3cfpRHb0CQ5O632ScI8b3DvlnoV451wbEU5MaDbRUsJLK4mJwCBfGEbOF59itH0nfuPzPvkeI7Fwefqu65aQ==",
       "dev": true,
       "requires": {
         "alcalzone-shared": "^4.0.1",
@@ -5461,17 +5604,6 @@
       "dev": true,
       "requires": {
         "debug": "^4.3.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
       }
     },
     "ansi-colors": {
@@ -5498,9 +5630,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -5749,6 +5881,17 @@
         }
       }
     },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -5798,9 +5941,9 @@
       "dev": true
     },
     "color-string": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.7.4.tgz",
-      "integrity": "sha512-nVdUvPVgZMpRQad5dcsCMOSB5BXLljklTiaxS6ehhKxDsAI5sD7k5VmFuBt1y3Rlym8uulc/ANUN/bMWtBu6Sg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
       "dev": true,
       "requires": {
         "color-name": "^1.0.0",
@@ -5902,9 +6045,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -6005,6 +6148,12 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -6402,6 +6551,12 @@
         }
       }
     },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
     "get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -6750,15 +6905,6 @@
         "yaml": "^1.10.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
         "micromatch": {
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -7346,6 +7492,12 @@
       "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
       "dev": true
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -7471,17 +7623,6 @@
         "@serialport/parser-regex": "9.2.4",
         "@serialport/stream": "9.2.4",
         "debug": "^4.3.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
       }
     },
     "set-blocking": {
@@ -7619,23 +7760,23 @@
       "dev": true
     },
     "string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       }
     },
     "strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       }
     },
     "strip-final-newline": {
@@ -7930,13 +8071,27 @@
       }
     },
     "winston-transport": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
-      "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.1.tgz",
+      "integrity": "sha512-ciZRlU4CSjHqHe8RQG1iPxKMRVwv6ZJ0RC7DxStKWd0KjpAhPDy5gVYSCpIUq+5CUsP+IyNOTZy1X0tO2QZqjg==",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.3.7",
+        "logform": "^2.2.0",
+        "readable-stream": "^3.4.0",
         "triple-beam": "^1.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "word-wrap": {
@@ -7974,6 +8129,12 @@
       "integrity": "sha512-JLofAEnN26l/1vbODgsDa+Phqa61PwDlxWu8+2pK+YbXf+y9pQSDLRvcYH2H1kkeUBA5fGp+xFL/zfE8jNMw4g==",
       "dev": true
     },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -7984,6 +8145,27 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
+      "integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+      "dev": true,
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      }
+    },
+    "yargs-parser": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
       "dev": true
     },
     "yn": {
@@ -7999,19 +8181,20 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.8.2.tgz",
-      "integrity": "sha512-shFY1y9hqKzS7mZzNBNMnpsuSgVhpas0EYQdXupm/r8rglBBm5c3+MNkGT2X/ImYYv1VR0WtsAs+pEqBXYaY8w==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.9.0.tgz",
+      "integrity": "sha512-86fGETedph2zEjG62nS7HH8umjgn614YxG8izy4om/6pK+J1VNaeNXg297kDxajikH4slfgmFWTG8dofgJGQiQ==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.2.0",
         "@alcalzone/pak": "^0.7.0",
-        "@sentry/integrations": "^6.14.3",
-        "@sentry/node": "^6.14.3",
-        "@zwave-js/config": "8.8.1",
-        "@zwave-js/core": "8.8.1",
-        "@zwave-js/serial": "8.8.1",
-        "@zwave-js/shared": "8.8.0",
+        "@sentry/integrations": "^6.15.0",
+        "@sentry/node": "^6.15.0",
+        "@zwave-js/config": "8.9.0",
+        "@zwave-js/core": "8.9.0",
+        "@zwave-js/nvmedit": "8.9.0",
+        "@zwave-js/serial": "8.9.0",
+        "@zwave-js/shared": "8.9.0",
         "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.1",
         "axios": "^0.24.0",
@@ -8020,10 +8203,10 @@
         "proper-lockfile": "^4.1.2",
         "reflect-metadata": "^0.1.13",
         "semver": "^7.3.5",
-        "serialport": "^9.2.5",
-        "source-map-support": "^0.5.20",
+        "serialport": "^9.2.8",
+        "source-map-support": "^0.5.21",
         "winston": "^3.3.3",
-        "xstate": "^4.26.0"
+        "xstate": "^4.26.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ws": "^8.0.0"
   },
   "peerDependencies": {
-    "zwave-js": "^8.8.2"
+    "zwave-js": "^8.9.0"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -50,7 +50,7 @@
     "prettier": "^2.3.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^8.8.2",
+    "zwave-js": "^8.9.0",
     "alcalzone-shared": "^4.0.0"
   },
   "husky": {

--- a/src/lib/controller/command.ts
+++ b/src/lib/controller/command.ts
@@ -26,4 +26,10 @@ export enum ControllerCommand {
   getProvisioningEntry = "controller.get_provisioning_entry",
   getProvisioningEntries = "controller.get_provisioning_entries",
   supportsFeature = "controller.supports_feature",
+  backupNVMRaw = "controller.backup_nvm_raw",
+  restoreNVM = "controller.restore_nvm",
+  setRFRegion = "controller.set_rf_region",
+  getRFRegion = "controller.get_rf_region",
+  setPowerlevel = "controller.set_powerlevel",
+  getPowerlevel = "controller.get_powerlevel",
 }

--- a/src/lib/controller/incoming_message.ts
+++ b/src/lib/controller/incoming_message.ts
@@ -4,6 +4,7 @@ import {
   InclusionOptions,
   PlannedProvisioningEntry,
   ReplaceNodeOptions,
+  RFRegion,
   ZWaveFeature,
 } from "zwave-js";
 import type { QRProvisioningInformation } from "@zwave-js/core";
@@ -181,6 +182,40 @@ export interface IncomingCommandControllerSupportsFeature
   feature: ZWaveFeature;
 }
 
+export interface IncomingCommandControllerBackupNVMRaw
+  extends IncomingCommandControllerBase {
+  command: ControllerCommand.backupNVMRaw;
+}
+
+export interface IncomingCommandControllerRestoreNVM
+  extends IncomingCommandControllerBase {
+  command: ControllerCommand.restoreNVM;
+  nvmData: string;
+}
+
+export interface IncomingCommandControllerSetRFRegion
+  extends IncomingCommandControllerBase {
+  command: ControllerCommand.setRFRegion;
+  region: RFRegion;
+}
+
+export interface IncomingCommandControllerGetRFRegion
+  extends IncomingCommandControllerBase {
+  command: ControllerCommand.getRFRegion;
+}
+
+export interface IncomingCommandControllerSetPowerlevel
+  extends IncomingCommandControllerBase {
+  command: ControllerCommand.setPowerlevel;
+  powerlevel: number;
+  measured0dBm: number;
+}
+
+export interface IncomingCommandControllerGetPowerlevel
+  extends IncomingCommandControllerBase {
+  command: ControllerCommand.getPowerlevel;
+}
+
 export type IncomingMessageController =
   | IncomingCommandControllerBeginInclusion
   | IncomingCommandControllerBeginInclusionLegacy
@@ -207,4 +242,10 @@ export type IncomingMessageController =
   | IncomingCommandControllerUnprovisionSmartStartNode
   | IncomingCommandControllerGetProvisioningEntry
   | IncomingCommandControllerGetProvisioningEntries
-  | IncomingCommandControllerSupportsFeature;
+  | IncomingCommandControllerSupportsFeature
+  | IncomingCommandControllerBackupNVMRaw
+  | IncomingCommandControllerRestoreNVM
+  | IncomingCommandControllerSetRFRegion
+  | IncomingCommandControllerGetRFRegion
+  | IncomingCommandControllerSetPowerlevel
+  | IncomingCommandControllerGetPowerlevel;

--- a/src/lib/controller/message_handler.ts
+++ b/src/lib/controller/message_handler.ts
@@ -251,8 +251,7 @@ export class ControllerMessageHandler {
         return { success };
       }
       case ControllerCommand.getPowerlevel: {
-        const powerlevelResponse = await driver.controller.getPowerlevel();
-        return powerlevelResponse;
+        return await driver.controller.getPowerlevel();
       }
       default:
         throw new UnknownCommandError(command);

--- a/src/lib/controller/message_handler.ts
+++ b/src/lib/controller/message_handler.ts
@@ -13,7 +13,6 @@ import {
 import {
   InclusionAlreadyInProgressError,
   InclusionPhaseNotInProgressError,
-  InvalidParamsPassedToCommandError,
   UnknownCommandError,
 } from "../error";
 import { Client, ClientsController } from "../server";
@@ -184,14 +183,77 @@ export class ControllerMessageHandler {
         await driver.controller.removeNodeFromAllAssociations(message.nodeId);
         return {};
       }
-      case ControllerCommand.getNodeNeighbors:
+      case ControllerCommand.getNodeNeighbors: {
         const neighbors = await driver.controller.getNodeNeighbors(
           message.nodeId
         );
         return { neighbors };
-      case ControllerCommand.supportsFeature:
+      }
+      case ControllerCommand.supportsFeature: {
         const supported = driver.controller.supportsFeature(message.feature);
         return { supported };
+      }
+      case ControllerCommand.backupNVMRaw: {
+        const nvmDataRaw = await driver.controller.backupNVMRaw(
+          (bytesRead: number, total: number) => {
+            clientsController.clients.forEach((client) =>
+              client.sendEvent({
+                source: "controller",
+                event: "nvm backup progress",
+                bytesRead,
+                total,
+              })
+            );
+          }
+        );
+        return { nvmData: nvmDataRaw.toString("base64") };
+      }
+      case ControllerCommand.restoreNVM: {
+        const nvmData = Buffer.from(message.nvmData, "base64");
+        driver.controller.restoreNVM(
+          nvmData,
+          (bytesRead: number, total: number) => {
+            clientsController.clients.forEach((client) =>
+              client.sendEvent({
+                source: "controller",
+                event: "nvm convert progress",
+                bytesRead,
+                total,
+              })
+            );
+          },
+          (bytesWritten: number, total: number) => {
+            clientsController.clients.forEach((client) =>
+              client.sendEvent({
+                source: "controller",
+                event: "nvm restore progress",
+                bytesWritten,
+                total,
+              })
+            );
+          }
+        );
+        return {};
+      }
+      case ControllerCommand.setRFRegion: {
+        const success = await driver.controller.setRFRegion(message.region);
+        return { success };
+      }
+      case ControllerCommand.getRFRegion: {
+        const region = await driver.controller.getRFRegion();
+        return { region };
+      }
+      case ControllerCommand.setPowerlevel: {
+        const success = await driver.controller.setPowerlevel(
+          message.powerlevel,
+          message.measured0dBm
+        );
+        return { success };
+      }
+      case ControllerCommand.getPowerlevel: {
+        const powerlevelResponse = await driver.controller.getPowerlevel();
+        return powerlevelResponse;
+      }
       default:
         throw new UnknownCommandError(command);
     }

--- a/src/lib/controller/outgoing_message.ts
+++ b/src/lib/controller/outgoing_message.ts
@@ -1,6 +1,7 @@
 import {
   AssociationAddress,
   AssociationGroup,
+  RFRegion,
   SmartStartProvisioningEntry,
 } from "zwave-js";
 import { ControllerCommand } from "./command";
@@ -41,4 +42,13 @@ export interface ControllerResultTypes {
     entries: SmartStartProvisioningEntry[];
   };
   [ControllerCommand.supportsFeature]: { supported: boolean | undefined };
+  [ControllerCommand.backupNVMRaw]: { nvmData: string };
+  [ControllerCommand.restoreNVM]: Record<string, never>;
+  [ControllerCommand.setRFRegion]: { success: boolean };
+  [ControllerCommand.getRFRegion]: { region: RFRegion };
+  [ControllerCommand.setPowerlevel]: { success: boolean };
+  [ControllerCommand.getPowerlevel]: {
+    powerlevel: number;
+    measured0dBm: number;
+  };
 }


### PR DESCRIPTION
https://github.com/zwave-js/node-zwave-js/releases/tag/v8.9.0

Added some missing additional commands while I was reviewing the docs:
- `controller.backup_nvm_raw` (we emit one new controller event to broadcast backup progress events, and the NVM in the end will be returned in base64 to follow the pattern we use for firmware updates)
- `controller.restore_nvm` (we emit two new controller event to broadcast file conversion and writing progress, and the NVM is read in as base64 to follow the pattern we use for firmware updates)
- `controller.get_rf_region`
- `controller.set_rf_region`
- `controller.get_powerlevel`
- `controller.set_powerlevel`
