### PR TITLE
Fix throwing the wrong error when an S0_Legacy key is missing.

### DIFF
--- a/src/bin/server.ts
+++ b/src/bin/server.ts
@@ -91,7 +91,7 @@ interface Args {
             "the Z-Wave JS docs for more information"
         );
         delete options.networkKey;
-      } else if (!options.networkKey && !options.securityKeys.S0_Legacy)
+      } else if (!options.securityKeys?.S0_Legacy)
         throw new Error("Error: `securityKeys.S0_Legacy` key is missing.");
     } catch (err) {
       console.error(`Error: failed loading config file ${configPath}`);


### PR DESCRIPTION
If *no* securityKeys whatsoever have been provided in a config file,
e.g., if `securityKeys` is null, then the current code will throw a
null dereferencing error instead of the intended "S0_Legacy key is
missing" error.  A `?` in the right spot should take care of this.

Also, remove the `!options.networkKey` clause, which is redundant
(because this is the ELSE to `if (options.networkKey) ...`).