### PR TITLE
Bump zwave-js-server to 1.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zwave-js/server",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "license": "Apache-2.0",
       "dependencies": {
         "minimist": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Full access to zwave-js driver through Websockets",
   "homepage": "https://github.com/zwave-js/zwave-js-server#readme",
   "repository": {


### PR DESCRIPTION
This is primarily so we can release this fix: https://github.com/zwave-js/zwave-js-server/pull/487