### PR TITLE
Add command class mapping to Endpoint dump

### DIFF
--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -4,4 +4,4 @@ export const version = require("../../package.json").version;
 export const minSchemaVersion = 0;
 
 // maximal/current schema version the server supports
-export const maxSchemaVersion = 14;
+export const maxSchemaVersion = 15;

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -261,6 +261,8 @@ interface NodeStateSchema14 extends NodeStateSchema13 {
   keepAwake: boolean;
 }
 
+type NodeStateSchema15 = Omit<NodeStateSchema14, "commandClasses">;
+
 export type NodeState =
   | NodeStateSchema0
   | NodeStateSchema1
@@ -276,7 +278,8 @@ export type NodeState =
   | NodeStateSchema11
   | NodeStateSchema12
   | NodeStateSchema13
-  | NodeStateSchema14;
+  | NodeStateSchema14
+  | NodeStateSchema15;
 
 function getNodeValues(node: ZWaveNode, schemaVersion: number): ValueState[] {
   if (!node.ready) {
@@ -524,9 +527,11 @@ export const dumpNode = (node: ZWaveNode, schemaVersion: number): NodeState => {
   node4.deviceClass = node.deviceClass
     ? dumpDeviceClass(node.deviceClass)
     : null;
-  node4.commandClasses = Array.from(node.getSupportedCCInstances(), (cc) =>
-    dumpCommandClass(node, cc)
-  );
+  if (schemaVersion <= 14) {
+    node4.commandClasses = Array.from(node.getSupportedCCInstances(), (cc) =>
+      dumpCommandClass(node, cc)
+    );
+  }
   node4.interviewStage = InterviewStage[node.interviewStage];
   if (schemaVersion == 4) {
     return node4;
@@ -553,7 +558,11 @@ export const dumpNode = (node: ZWaveNode, schemaVersion: number): NodeState => {
   const node14 = node10 as NodeStateSchema14;
   node14.isControllerNode = node.isControllerNode();
   node14.keepAwake = node.keepAwake;
-  return node14;
+  if (schemaVersion == 14) {
+    return node14;
+  }
+
+  return node14 as NodeStateSchema15;
 };
 
 export const dumpEndpoint = (


### PR DESCRIPTION
Supported Command Classes are specific to an `Endpoint` - I believe that the "node" commandClasses we currently dump are effectively for endpoint 0.

I checked HA and we use the node command classes property in device automations but we can get them from the endpoints instead