### PR TITLE
Bump zwave-js to 8.11.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,10 +32,10 @@
         "prettier": "^2.3.0",
         "ts-node": "^10.0.0",
         "typescript": "^4.1.3",
-        "zwave-js": "^8.10.2"
+        "zwave-js": "^8.11.5"
       },
       "peerDependencies": {
-        "zwave-js": "^8.10.2"
+        "zwave-js": "^8.11.5"
       }
     },
     "node_modules/@alcalzone/jsonl-db": {
@@ -891,9 +891,9 @@
       }
     },
     "node_modules/@zwave-js/nvmedit": {
-      "version": "8.11.4",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-8.11.4.tgz",
-      "integrity": "sha512-b1lbY/Xx03Rykjzi2knixyX+aT+DOtsxbSobs4eaLBG3vXydURMwO/lOavj+PEUQQTGJkgieS0Z6PFoN3b5/NQ==",
+      "version": "8.11.5",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-8.11.5.tgz",
+      "integrity": "sha512-2dOVDGjT/ZaUcTMX92U/SUZPHbgtl1G02QxLx6GDBGNa1vZIeDTsAvcXdzr08XRl2wxjc8YrRCFxuR3ok3QiqA==",
       "dev": true,
       "dependencies": {
         "@zwave-js/core": "8.11.3",
@@ -2173,9 +2173,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
       "dev": true,
       "funding": [
         {
@@ -4388,9 +4388,9 @@
       }
     },
     "node_modules/zwave-js": {
-      "version": "8.11.4",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.11.4.tgz",
-      "integrity": "sha512-91PZtUM1CzUpkrKOxwU8b87L2W54ClUk0d+LcXpI0Lr6X6Au7/7Xoa5tppQv2kmfSZ3g9sTxBcPJhkIM0D9yyA==",
+      "version": "8.11.5",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.11.5.tgz",
+      "integrity": "sha512-3uK7nwUec6cyC2q6U0cTCXNHDKGWnZPVwkYr2yCn3/vBHm7qB1GLHnT+k65JM3fsNV8Y6j03rlxLq/E9WatSMg==",
       "dev": true,
       "dependencies": {
         "@alcalzone/jsonl-db": "^2.4.1",
@@ -4399,7 +4399,7 @@
         "@sentry/node": "^6.17.3",
         "@zwave-js/config": "8.11.4",
         "@zwave-js/core": "8.11.3",
-        "@zwave-js/nvmedit": "8.11.4",
+        "@zwave-js/nvmedit": "8.11.5",
         "@zwave-js/serial": "8.11.3",
         "@zwave-js/shared": "8.11.3",
         "alcalzone-shared": "^4.0.1",
@@ -5048,9 +5048,9 @@
       }
     },
     "@zwave-js/nvmedit": {
-      "version": "8.11.4",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-8.11.4.tgz",
-      "integrity": "sha512-b1lbY/Xx03Rykjzi2knixyX+aT+DOtsxbSobs4eaLBG3vXydURMwO/lOavj+PEUQQTGJkgieS0Z6PFoN3b5/NQ==",
+      "version": "8.11.5",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-8.11.5.tgz",
+      "integrity": "sha512-2dOVDGjT/ZaUcTMX92U/SUZPHbgtl1G02QxLx6GDBGNa1vZIeDTsAvcXdzr08XRl2wxjc8YrRCFxuR3ok3QiqA==",
       "dev": true,
       "requires": {
         "@zwave-js/core": "8.11.3",
@@ -6020,9 +6020,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
       "dev": true
     },
     "fs-constants": {
@@ -7644,9 +7644,9 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "8.11.4",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.11.4.tgz",
-      "integrity": "sha512-91PZtUM1CzUpkrKOxwU8b87L2W54ClUk0d+LcXpI0Lr6X6Au7/7Xoa5tppQv2kmfSZ3g9sTxBcPJhkIM0D9yyA==",
+      "version": "8.11.5",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-8.11.5.tgz",
+      "integrity": "sha512-3uK7nwUec6cyC2q6U0cTCXNHDKGWnZPVwkYr2yCn3/vBHm7qB1GLHnT+k65JM3fsNV8Y6j03rlxLq/E9WatSMg==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.4.1",
@@ -7655,7 +7655,7 @@
         "@sentry/node": "^6.17.3",
         "@zwave-js/config": "8.11.4",
         "@zwave-js/core": "8.11.3",
-        "@zwave-js/nvmedit": "8.11.4",
+        "@zwave-js/nvmedit": "8.11.5",
         "@zwave-js/serial": "8.11.3",
         "@zwave-js/shared": "8.11.3",
         "alcalzone-shared": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ws": "^8.0.0"
   },
   "peerDependencies": {
-    "zwave-js": "^8.10.2"
+    "zwave-js": "^8.11.5"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -50,7 +50,7 @@
     "prettier": "^2.3.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^8.10.2",
+    "zwave-js": "^8.11.5",
     "alcalzone-shared": "^4.0.0"
   },
   "husky": {


### PR DESCRIPTION
Did this mainly to confirm no changes in the API before I bump the HA addon. While I was there I also bumped `follow-redirects` because npm detected a high sev vulnerability