### PR TITLE
Bump zwave-js-server to 1.16.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.15.0",
+  "version": "1.16.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zwave-js/server",
-      "version": "1.15.0",
+      "version": "1.16.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "minimist": "^1.2.5",
@@ -32,10 +32,10 @@
         "prettier": "^2.3.0",
         "ts-node": "^10.5.0",
         "typescript": "^4.1.3",
-        "zwave-js": "^9.0.0-beta.2"
+        "zwave-js": "^9.0.0-beta.6"
       },
       "peerDependencies": {
-        "zwave-js": "^9.0.0-beta.2"
+        "zwave-js": "^9.0.0-beta.6"
       }
     },
     "node_modules/@alcalzone/jsonl-db": {
@@ -268,15 +268,37 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "6.18.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.18.1.tgz",
-      "integrity": "sha512-9V8Q+3Asi+3RL67CSIMMZ9mjMsu2/hrpQszYStX7hPPpAZIlAKk2MT5B+na/r80iWKhy+3Ts6aDFF218QtnsVw==",
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.18.2.tgz",
+      "integrity": "sha512-r5ad/gq5S/JHc9sd5CUhZQT9ojQ+f+thk/AoGeGawX/8HURZYAgIqD565d6FK0VsZEDkdRMl58z1Qon20h3y1g==",
       "dev": true,
       "dependencies": {
-        "@sentry/hub": "6.18.1",
-        "@sentry/minimal": "6.18.1",
-        "@sentry/types": "6.18.1",
-        "@sentry/utils": "6.18.1",
+        "@sentry/hub": "6.18.2",
+        "@sentry/minimal": "6.18.2",
+        "@sentry/types": "6.18.2",
+        "@sentry/utils": "6.18.2",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/core/node_modules/@sentry/types": {
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.18.2.tgz",
+      "integrity": "sha512-WzpJf/Q5aORTzrSwer/As1NlO90dBAQpaHV2ikDDKqOyMWEgjKb5/4gh59p9gH8JMMnLetP1AvQel0fOj5UnUw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/core/node_modules/@sentry/utils": {
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.18.2.tgz",
+      "integrity": "sha512-EC619jesknyu4xpwud5WC/5odYLz6JUy7OSFy5405PpdGeh/m8XUvuJAx4zDx0Iz/Mlk0S1Md+ZcQwqkv39dkw==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/types": "6.18.2",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -284,13 +306,35 @@
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "6.18.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.18.1.tgz",
-      "integrity": "sha512-+zGzgc/xX3an/nKA3ELMn9YD9VmqbNaNwWZ5/SjNUvzsYHh2UNZ7YzT8WawQsRVOXLljyCKxkWpFB4EchiYGbw==",
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.18.2.tgz",
+      "integrity": "sha512-d0AugekMkbnN12b4EXMjseJxtLPc9S20DGobCPUb4oAQT6S2oDQEj1jwP6PQ5vtgyy+GMYWxBMgqAQ4pjVYISQ==",
       "dev": true,
       "dependencies": {
-        "@sentry/types": "6.18.1",
-        "@sentry/utils": "6.18.1",
+        "@sentry/types": "6.18.2",
+        "@sentry/utils": "6.18.2",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/hub/node_modules/@sentry/types": {
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.18.2.tgz",
+      "integrity": "sha512-WzpJf/Q5aORTzrSwer/As1NlO90dBAQpaHV2ikDDKqOyMWEgjKb5/4gh59p9gH8JMMnLetP1AvQel0fOj5UnUw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/hub/node_modules/@sentry/utils": {
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.18.2.tgz",
+      "integrity": "sha512-EC619jesknyu4xpwud5WC/5odYLz6JUy7OSFy5405PpdGeh/m8XUvuJAx4zDx0Iz/Mlk0S1Md+ZcQwqkv39dkw==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/types": "6.18.2",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -313,30 +357,38 @@
       }
     },
     "node_modules/@sentry/minimal": {
-      "version": "6.18.1",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.18.1.tgz",
-      "integrity": "sha512-dm+0MuasWNi/LASvHX+09oCo8IBZY5WpMK8qXvQMnwQ9FVfklrjcfEI3666WORDCmeUhDCSeL2MbjPDm+AmPLg==",
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.18.2.tgz",
+      "integrity": "sha512-n7KYuo34W2LxE+3dnZ47of7XHuORINCnXq66XH72eoj67tf0XeWbIhEJrYGmoLRyRfoCYYrBLWiDl/uTjLzrzQ==",
       "dev": true,
       "dependencies": {
-        "@sentry/hub": "6.18.1",
-        "@sentry/types": "6.18.1",
+        "@sentry/hub": "6.18.2",
+        "@sentry/types": "6.18.2",
         "tslib": "^1.9.3"
       },
       "engines": {
         "node": ">=6"
       }
     },
+    "node_modules/@sentry/minimal/node_modules/@sentry/types": {
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.18.2.tgz",
+      "integrity": "sha512-WzpJf/Q5aORTzrSwer/As1NlO90dBAQpaHV2ikDDKqOyMWEgjKb5/4gh59p9gH8JMMnLetP1AvQel0fOj5UnUw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@sentry/node": {
-      "version": "6.18.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.18.1.tgz",
-      "integrity": "sha512-aTb2gwfZUq0lGDRGH5zNOYDfFMOQZu6E0QcAsvH2ZBcEj3rUWZz3r25COFrHmfzHLUV1KcF2AmnWo1QU1jmm0g==",
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.18.2.tgz",
+      "integrity": "sha512-1S+44c09n3KVpCYjwOfnA9jKvnpPegpQWM81Nu5J6ToGx+ZiddMq6B9GRXUnFfZ7Z6fJHZzFtySasQC7KqkQoA==",
       "dev": true,
       "dependencies": {
-        "@sentry/core": "6.18.1",
-        "@sentry/hub": "6.18.1",
-        "@sentry/tracing": "6.18.1",
-        "@sentry/types": "6.18.1",
-        "@sentry/utils": "6.18.1",
+        "@sentry/core": "6.18.2",
+        "@sentry/hub": "6.18.2",
+        "@sentry/types": "6.18.2",
+        "@sentry/utils": "6.18.2",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -346,16 +398,22 @@
         "node": ">=6"
       }
     },
-    "node_modules/@sentry/tracing": {
-      "version": "6.18.1",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.18.1.tgz",
-      "integrity": "sha512-OxozmSfxGx246Ae1XhO01I7ZWxO3briwMBh55E5KyjQb8fuS9gVE7Uy8ZRs5hhNjDutFAU7nMtC0zipfVxP6fg==",
+    "node_modules/@sentry/node/node_modules/@sentry/types": {
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.18.2.tgz",
+      "integrity": "sha512-WzpJf/Q5aORTzrSwer/As1NlO90dBAQpaHV2ikDDKqOyMWEgjKb5/4gh59p9gH8JMMnLetP1AvQel0fOj5UnUw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/utils": {
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.18.2.tgz",
+      "integrity": "sha512-EC619jesknyu4xpwud5WC/5odYLz6JUy7OSFy5405PpdGeh/m8XUvuJAx4zDx0Iz/Mlk0S1Md+ZcQwqkv39dkw==",
       "dev": true,
       "dependencies": {
-        "@sentry/hub": "6.18.1",
-        "@sentry/minimal": "6.18.1",
-        "@sentry/types": "6.18.1",
-        "@sentry/utils": "6.18.1",
+        "@sentry/types": "6.18.2",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -834,13 +892,13 @@
       }
     },
     "node_modules/@zwave-js/config": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-9.0.0-beta.4.tgz",
-      "integrity": "sha512-Qg6xPvY+/AK235cIsr/LvGIA4VHAWWJLv9TZ00Pczbfd5KZr61eu8a2bpIF7Tyoumln3JFZIDCBOisRT4KvIiw==",
+      "version": "9.0.0-beta.6-pr-4372-2e2f5d3",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-9.0.0-beta.6-pr-4372-2e2f5d3.tgz",
+      "integrity": "sha512-3qbGEPbFTT1x/miN6X1Yyp1blNe4DsFkGdyDP4Mkh08Ug1y5qpzIIToAu2UO3Pa7HZh2u8q+e4DtPrdTuwnQ3Q==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "9.0.0-beta.3",
-        "@zwave-js/shared": "9.0.0-beta.2",
+        "@zwave-js/core": "9.0.0-beta.6-pr-4372-2e2f5d3",
+        "@zwave-js/shared": "9.0.0-beta.6-pr-4372-2e2f5d3",
         "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.1",
         "fs-extra": "^10.0.1",
@@ -857,13 +915,13 @@
       }
     },
     "node_modules/@zwave-js/core": {
-      "version": "9.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-9.0.0-beta.3.tgz",
-      "integrity": "sha512-b7DiQFwwzFwsUhOFC+6Awp36rTXL3Rjouu02PCa9Nmpf/tWKSg+7w6lu8SWZ+OTOnZb/Rsh7K1lu8Lh8G93XsA==",
+      "version": "9.0.0-beta.6-pr-4372-2e2f5d3",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-9.0.0-beta.6-pr-4372-2e2f5d3.tgz",
+      "integrity": "sha512-dwxRCiE+UhuJD09hxkZFPdOa1O+SNvQMbXcFl/1iqjg45ughLJDSKrrLlD1oXUsC+2YiLdazvWzP0xntRxEFaQ==",
       "dev": true,
       "dependencies": {
         "@alcalzone/jsonl-db": "^2.5.1",
-        "@zwave-js/shared": "9.0.0-beta.2",
+        "@zwave-js/shared": "9.0.0-beta.6-pr-4372-2e2f5d3",
         "@zwave-js/winston-daily-rotate-file": "^4.5.6-1",
         "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.1",
@@ -891,13 +949,13 @@
       }
     },
     "node_modules/@zwave-js/nvmedit": {
-      "version": "9.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-9.0.0-beta.3.tgz",
-      "integrity": "sha512-lSO3pe6pAvoPQtUyzIGIoHX//yo9mAf1FvTs6S7Wa/IeeGdk3tLqq4megcf2+8EV+IR7pu+E3gzi0QiJo/fCcQ==",
+      "version": "9.0.0-beta.6-pr-4372-2e2f5d3",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-9.0.0-beta.6-pr-4372-2e2f5d3.tgz",
+      "integrity": "sha512-GXpokENomvu13GPzMC3AMs3dHSVVM1SqkoyFznFsjBXziAIo/Ic2d4yT3jU57nHFvByrFp3MaSqucO42SNousQ==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "9.0.0-beta.3",
-        "@zwave-js/shared": "9.0.0-beta.2",
+        "@zwave-js/core": "9.0.0-beta.6-pr-4372-2e2f5d3",
+        "@zwave-js/shared": "9.0.0-beta.6-pr-4372-2e2f5d3",
         "alcalzone-shared": "^4.0.1",
         "fs-extra": "^10.0.1",
         "reflect-metadata": "^0.1.13",
@@ -915,14 +973,14 @@
       }
     },
     "node_modules/@zwave-js/serial": {
-      "version": "9.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-9.0.0-beta.3.tgz",
-      "integrity": "sha512-4pjR56xrKIIjXMkoUgSsHk3E8QORBTr36P6axpo6oJ+p1MYCm2Re7YjnSbvEfTNjwM+f+50JOd9uY/19izfS+A==",
+      "version": "9.0.0-beta.6-pr-4372-2e2f5d3",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-9.0.0-beta.6-pr-4372-2e2f5d3.tgz",
+      "integrity": "sha512-LAvv7Ike8G8s4cMo+kqgCI13TfIhDQHdQ+tp59Ykg5HO24vv0k502jvu8R89+jJOlaE1qTvyVAEpZCBxB3DnGA==",
       "dev": true,
       "dependencies": {
         "@sentry/node": "^6.18.1",
-        "@zwave-js/core": "9.0.0-beta.3",
-        "@zwave-js/shared": "9.0.0-beta.2",
+        "@zwave-js/core": "9.0.0-beta.6-pr-4372-2e2f5d3",
+        "@zwave-js/shared": "9.0.0-beta.6-pr-4372-2e2f5d3",
         "alcalzone-shared": "^4.0.1",
         "serialport": "^10.3.0",
         "winston": "^3.6.0"
@@ -935,9 +993,9 @@
       }
     },
     "node_modules/@zwave-js/shared": {
-      "version": "9.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-9.0.0-beta.2.tgz",
-      "integrity": "sha512-hPtnZMMbOdd6kOpryMbTfWGjJuyAI1rtsWEEz5cbK6qFzwaga/EU+QJw6HwIQ3iuUqpojOxFSdeTfifiYnQmCQ==",
+      "version": "9.0.0-beta.6-pr-4372-2e2f5d3",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-9.0.0-beta.6-pr-4372-2e2f5d3.tgz",
+      "integrity": "sha512-WBWnY+Hnd7YkpD0Vo9qCwAcgUyKjSi99/aCERpSkNmD9o4VPV2ZA6DZL5VFJAG4oGOIC84TtlY6vgFN8YQxlow==",
       "dev": true,
       "dependencies": {
         "alcalzone-shared": "^4.0.1",
@@ -1467,9 +1525,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.10.8",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.8.tgz",
-      "integrity": "sha512-wbNwDfBHHur9UOzNUjeKUOJ0fCb0a52Wx0xInmQ7Y8FstyajiV1NmK1e00cxsr9YrE9r7yAChE0VvpuY5Rnlow==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.0.tgz",
+      "integrity": "sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug==",
       "dev": true
     },
     "node_modules/debug": {
@@ -3809,20 +3867,20 @@
       }
     },
     "node_modules/zwave-js": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-9.0.0-beta.4.tgz",
-      "integrity": "sha512-zzGWop0gdBKrq02Bb9/kvR7OxFAu/SvAVi++4V/gMReTE8s293yxQzFeTEdupbX5+DkHQdXuUjKTJtdXCi50Ow==",
+      "version": "9.0.0-beta.6-pr-4372-2e2f5d3",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-9.0.0-beta.6-pr-4372-2e2f5d3.tgz",
+      "integrity": "sha512-+CsvVU5bHU/NTDhDi4YuZi8HU2Yu/7Ve5BvWSlofNKBJpD3L7AYCO5ra0+sAcW9GUliTHlSWGOV+/4UNlaH8JA==",
       "dev": true,
       "dependencies": {
         "@alcalzone/jsonl-db": "^2.5.1",
         "@alcalzone/pak": "^0.8.1",
         "@sentry/integrations": "^6.18.1",
         "@sentry/node": "^6.18.1",
-        "@zwave-js/config": "9.0.0-beta.4",
-        "@zwave-js/core": "9.0.0-beta.3",
-        "@zwave-js/nvmedit": "9.0.0-beta.3",
-        "@zwave-js/serial": "9.0.0-beta.3",
-        "@zwave-js/shared": "9.0.0-beta.2",
+        "@zwave-js/config": "9.0.0-beta.6-pr-4372-2e2f5d3",
+        "@zwave-js/core": "9.0.0-beta.6-pr-4372-2e2f5d3",
+        "@zwave-js/nvmedit": "9.0.0-beta.6-pr-4372-2e2f5d3",
+        "@zwave-js/serial": "9.0.0-beta.6-pr-4372-2e2f5d3",
+        "@zwave-js/shared": "9.0.0-beta.6-pr-4372-2e2f5d3",
         "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.1",
         "axios": "^0.26.0",
@@ -4038,27 +4096,63 @@
       }
     },
     "@sentry/core": {
-      "version": "6.18.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.18.1.tgz",
-      "integrity": "sha512-9V8Q+3Asi+3RL67CSIMMZ9mjMsu2/hrpQszYStX7hPPpAZIlAKk2MT5B+na/r80iWKhy+3Ts6aDFF218QtnsVw==",
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.18.2.tgz",
+      "integrity": "sha512-r5ad/gq5S/JHc9sd5CUhZQT9ojQ+f+thk/AoGeGawX/8HURZYAgIqD565d6FK0VsZEDkdRMl58z1Qon20h3y1g==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.18.1",
-        "@sentry/minimal": "6.18.1",
-        "@sentry/types": "6.18.1",
-        "@sentry/utils": "6.18.1",
+        "@sentry/hub": "6.18.2",
+        "@sentry/minimal": "6.18.2",
+        "@sentry/types": "6.18.2",
+        "@sentry/utils": "6.18.2",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "6.18.2",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.18.2.tgz",
+          "integrity": "sha512-WzpJf/Q5aORTzrSwer/As1NlO90dBAQpaHV2ikDDKqOyMWEgjKb5/4gh59p9gH8JMMnLetP1AvQel0fOj5UnUw==",
+          "dev": true
+        },
+        "@sentry/utils": {
+          "version": "6.18.2",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.18.2.tgz",
+          "integrity": "sha512-EC619jesknyu4xpwud5WC/5odYLz6JUy7OSFy5405PpdGeh/m8XUvuJAx4zDx0Iz/Mlk0S1Md+ZcQwqkv39dkw==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "6.18.2",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@sentry/hub": {
-      "version": "6.18.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.18.1.tgz",
-      "integrity": "sha512-+zGzgc/xX3an/nKA3ELMn9YD9VmqbNaNwWZ5/SjNUvzsYHh2UNZ7YzT8WawQsRVOXLljyCKxkWpFB4EchiYGbw==",
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.18.2.tgz",
+      "integrity": "sha512-d0AugekMkbnN12b4EXMjseJxtLPc9S20DGobCPUb4oAQT6S2oDQEj1jwP6PQ5vtgyy+GMYWxBMgqAQ4pjVYISQ==",
       "dev": true,
       "requires": {
-        "@sentry/types": "6.18.1",
-        "@sentry/utils": "6.18.1",
+        "@sentry/types": "6.18.2",
+        "@sentry/utils": "6.18.2",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "6.18.2",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.18.2.tgz",
+          "integrity": "sha512-WzpJf/Q5aORTzrSwer/As1NlO90dBAQpaHV2ikDDKqOyMWEgjKb5/4gh59p9gH8JMMnLetP1AvQel0fOj5UnUw==",
+          "dev": true
+        },
+        "@sentry/utils": {
+          "version": "6.18.2",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.18.2.tgz",
+          "integrity": "sha512-EC619jesknyu4xpwud5WC/5odYLz6JUy7OSFy5405PpdGeh/m8XUvuJAx4zDx0Iz/Mlk0S1Md+ZcQwqkv39dkw==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "6.18.2",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@sentry/integrations": {
@@ -4074,44 +4168,56 @@
       }
     },
     "@sentry/minimal": {
-      "version": "6.18.1",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.18.1.tgz",
-      "integrity": "sha512-dm+0MuasWNi/LASvHX+09oCo8IBZY5WpMK8qXvQMnwQ9FVfklrjcfEI3666WORDCmeUhDCSeL2MbjPDm+AmPLg==",
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.18.2.tgz",
+      "integrity": "sha512-n7KYuo34W2LxE+3dnZ47of7XHuORINCnXq66XH72eoj67tf0XeWbIhEJrYGmoLRyRfoCYYrBLWiDl/uTjLzrzQ==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "6.18.1",
-        "@sentry/types": "6.18.1",
+        "@sentry/hub": "6.18.2",
+        "@sentry/types": "6.18.2",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "6.18.2",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.18.2.tgz",
+          "integrity": "sha512-WzpJf/Q5aORTzrSwer/As1NlO90dBAQpaHV2ikDDKqOyMWEgjKb5/4gh59p9gH8JMMnLetP1AvQel0fOj5UnUw==",
+          "dev": true
+        }
       }
     },
     "@sentry/node": {
-      "version": "6.18.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.18.1.tgz",
-      "integrity": "sha512-aTb2gwfZUq0lGDRGH5zNOYDfFMOQZu6E0QcAsvH2ZBcEj3rUWZz3r25COFrHmfzHLUV1KcF2AmnWo1QU1jmm0g==",
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.18.2.tgz",
+      "integrity": "sha512-1S+44c09n3KVpCYjwOfnA9jKvnpPegpQWM81Nu5J6ToGx+ZiddMq6B9GRXUnFfZ7Z6fJHZzFtySasQC7KqkQoA==",
       "dev": true,
       "requires": {
-        "@sentry/core": "6.18.1",
-        "@sentry/hub": "6.18.1",
-        "@sentry/tracing": "6.18.1",
-        "@sentry/types": "6.18.1",
-        "@sentry/utils": "6.18.1",
+        "@sentry/core": "6.18.2",
+        "@sentry/hub": "6.18.2",
+        "@sentry/types": "6.18.2",
+        "@sentry/utils": "6.18.2",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/tracing": {
-      "version": "6.18.1",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.18.1.tgz",
-      "integrity": "sha512-OxozmSfxGx246Ae1XhO01I7ZWxO3briwMBh55E5KyjQb8fuS9gVE7Uy8ZRs5hhNjDutFAU7nMtC0zipfVxP6fg==",
-      "dev": true,
-      "requires": {
-        "@sentry/hub": "6.18.1",
-        "@sentry/minimal": "6.18.1",
-        "@sentry/types": "6.18.1",
-        "@sentry/utils": "6.18.1",
-        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "6.18.2",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.18.2.tgz",
+          "integrity": "sha512-WzpJf/Q5aORTzrSwer/As1NlO90dBAQpaHV2ikDDKqOyMWEgjKb5/4gh59p9gH8JMMnLetP1AvQel0fOj5UnUw==",
+          "dev": true
+        },
+        "@sentry/utils": {
+          "version": "6.18.2",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.18.2.tgz",
+          "integrity": "sha512-EC619jesknyu4xpwud5WC/5odYLz6JUy7OSFy5405PpdGeh/m8XUvuJAx4zDx0Iz/Mlk0S1Md+ZcQwqkv39dkw==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "6.18.2",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@sentry/types": {
@@ -4414,13 +4520,13 @@
       }
     },
     "@zwave-js/config": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-9.0.0-beta.4.tgz",
-      "integrity": "sha512-Qg6xPvY+/AK235cIsr/LvGIA4VHAWWJLv9TZ00Pczbfd5KZr61eu8a2bpIF7Tyoumln3JFZIDCBOisRT4KvIiw==",
+      "version": "9.0.0-beta.6-pr-4372-2e2f5d3",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-9.0.0-beta.6-pr-4372-2e2f5d3.tgz",
+      "integrity": "sha512-3qbGEPbFTT1x/miN6X1Yyp1blNe4DsFkGdyDP4Mkh08Ug1y5qpzIIToAu2UO3Pa7HZh2u8q+e4DtPrdTuwnQ3Q==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "9.0.0-beta.3",
-        "@zwave-js/shared": "9.0.0-beta.2",
+        "@zwave-js/core": "9.0.0-beta.6-pr-4372-2e2f5d3",
+        "@zwave-js/shared": "9.0.0-beta.6-pr-4372-2e2f5d3",
         "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.1",
         "fs-extra": "^10.0.1",
@@ -4431,13 +4537,13 @@
       }
     },
     "@zwave-js/core": {
-      "version": "9.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-9.0.0-beta.3.tgz",
-      "integrity": "sha512-b7DiQFwwzFwsUhOFC+6Awp36rTXL3Rjouu02PCa9Nmpf/tWKSg+7w6lu8SWZ+OTOnZb/Rsh7K1lu8Lh8G93XsA==",
+      "version": "9.0.0-beta.6-pr-4372-2e2f5d3",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-9.0.0-beta.6-pr-4372-2e2f5d3.tgz",
+      "integrity": "sha512-dwxRCiE+UhuJD09hxkZFPdOa1O+SNvQMbXcFl/1iqjg45ughLJDSKrrLlD1oXUsC+2YiLdazvWzP0xntRxEFaQ==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.5.1",
-        "@zwave-js/shared": "9.0.0-beta.2",
+        "@zwave-js/shared": "9.0.0-beta.6-pr-4372-2e2f5d3",
         "@zwave-js/winston-daily-rotate-file": "^4.5.6-1",
         "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.1",
@@ -4459,13 +4565,13 @@
       }
     },
     "@zwave-js/nvmedit": {
-      "version": "9.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-9.0.0-beta.3.tgz",
-      "integrity": "sha512-lSO3pe6pAvoPQtUyzIGIoHX//yo9mAf1FvTs6S7Wa/IeeGdk3tLqq4megcf2+8EV+IR7pu+E3gzi0QiJo/fCcQ==",
+      "version": "9.0.0-beta.6-pr-4372-2e2f5d3",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-9.0.0-beta.6-pr-4372-2e2f5d3.tgz",
+      "integrity": "sha512-GXpokENomvu13GPzMC3AMs3dHSVVM1SqkoyFznFsjBXziAIo/Ic2d4yT3jU57nHFvByrFp3MaSqucO42SNousQ==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "9.0.0-beta.3",
-        "@zwave-js/shared": "9.0.0-beta.2",
+        "@zwave-js/core": "9.0.0-beta.6-pr-4372-2e2f5d3",
+        "@zwave-js/shared": "9.0.0-beta.6-pr-4372-2e2f5d3",
         "alcalzone-shared": "^4.0.1",
         "fs-extra": "^10.0.1",
         "reflect-metadata": "^0.1.13",
@@ -4474,23 +4580,23 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "9.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-9.0.0-beta.3.tgz",
-      "integrity": "sha512-4pjR56xrKIIjXMkoUgSsHk3E8QORBTr36P6axpo6oJ+p1MYCm2Re7YjnSbvEfTNjwM+f+50JOd9uY/19izfS+A==",
+      "version": "9.0.0-beta.6-pr-4372-2e2f5d3",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-9.0.0-beta.6-pr-4372-2e2f5d3.tgz",
+      "integrity": "sha512-LAvv7Ike8G8s4cMo+kqgCI13TfIhDQHdQ+tp59Ykg5HO24vv0k502jvu8R89+jJOlaE1qTvyVAEpZCBxB3DnGA==",
       "dev": true,
       "requires": {
         "@sentry/node": "^6.18.1",
-        "@zwave-js/core": "9.0.0-beta.3",
-        "@zwave-js/shared": "9.0.0-beta.2",
+        "@zwave-js/core": "9.0.0-beta.6-pr-4372-2e2f5d3",
+        "@zwave-js/shared": "9.0.0-beta.6-pr-4372-2e2f5d3",
         "alcalzone-shared": "^4.0.1",
         "serialport": "^10.3.0",
         "winston": "^3.6.0"
       }
     },
     "@zwave-js/shared": {
-      "version": "9.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-9.0.0-beta.2.tgz",
-      "integrity": "sha512-hPtnZMMbOdd6kOpryMbTfWGjJuyAI1rtsWEEz5cbK6qFzwaga/EU+QJw6HwIQ3iuUqpojOxFSdeTfifiYnQmCQ==",
+      "version": "9.0.0-beta.6-pr-4372-2e2f5d3",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-9.0.0-beta.6-pr-4372-2e2f5d3.tgz",
+      "integrity": "sha512-WBWnY+Hnd7YkpD0Vo9qCwAcgUyKjSi99/aCERpSkNmD9o4VPV2ZA6DZL5VFJAG4oGOIC84TtlY6vgFN8YQxlow==",
       "dev": true,
       "requires": {
         "alcalzone-shared": "^4.0.1",
@@ -4897,9 +5003,9 @@
       }
     },
     "dayjs": {
-      "version": "1.10.8",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.8.tgz",
-      "integrity": "sha512-wbNwDfBHHur9UOzNUjeKUOJ0fCb0a52Wx0xInmQ7Y8FstyajiV1NmK1e00cxsr9YrE9r7yAChE0VvpuY5Rnlow==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.0.tgz",
+      "integrity": "sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug==",
       "dev": true
     },
     "debug": {
@@ -6596,20 +6702,20 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-9.0.0-beta.4.tgz",
-      "integrity": "sha512-zzGWop0gdBKrq02Bb9/kvR7OxFAu/SvAVi++4V/gMReTE8s293yxQzFeTEdupbX5+DkHQdXuUjKTJtdXCi50Ow==",
+      "version": "9.0.0-beta.6-pr-4372-2e2f5d3",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-9.0.0-beta.6-pr-4372-2e2f5d3.tgz",
+      "integrity": "sha512-+CsvVU5bHU/NTDhDi4YuZi8HU2Yu/7Ve5BvWSlofNKBJpD3L7AYCO5ra0+sAcW9GUliTHlSWGOV+/4UNlaH8JA==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.5.1",
         "@alcalzone/pak": "^0.8.1",
         "@sentry/integrations": "^6.18.1",
         "@sentry/node": "^6.18.1",
-        "@zwave-js/config": "9.0.0-beta.4",
-        "@zwave-js/core": "9.0.0-beta.3",
-        "@zwave-js/nvmedit": "9.0.0-beta.3",
-        "@zwave-js/serial": "9.0.0-beta.3",
-        "@zwave-js/shared": "9.0.0-beta.2",
+        "@zwave-js/config": "9.0.0-beta.6-pr-4372-2e2f5d3",
+        "@zwave-js/core": "9.0.0-beta.6-pr-4372-2e2f5d3",
+        "@zwave-js/nvmedit": "9.0.0-beta.6-pr-4372-2e2f5d3",
+        "@zwave-js/serial": "9.0.0-beta.6-pr-4372-2e2f5d3",
+        "@zwave-js/shared": "9.0.0-beta.6-pr-4372-2e2f5d3",
         "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.1",
         "axios": "^0.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.15.0",
+  "version": "1.16.0-beta.1",
   "description": "Full access to zwave-js driver through Websockets",
   "homepage": "https://github.com/zwave-js/zwave-js-server#readme",
   "repository": {
@@ -33,7 +33,7 @@
     "ws": "^8.0.0"
   },
   "peerDependencies": {
-    "zwave-js": "^9.0.0-beta.2"
+    "zwave-js": "^9.0.0-beta.6"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -50,7 +50,7 @@
     "prettier": "^2.3.0",
     "ts-node": "^10.5.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^9.0.0-beta.2",
+    "zwave-js": "^9.0.0-beta.6",
     "alcalzone-shared": "^4.0.0"
   },
   "husky": {


### PR DESCRIPTION
Pushing a beta release so that zwavejs2mqtt can publish a beta version for testing zwave-js 9