### PR TITLE
Hide dependencies in release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,8 @@
+categories:
+  - title: "⬆️ Dependencies"
+      collapse-after: 1
+      labels:
+        - "dependencies"
 template: |
   ## What's Changed
 


### PR DESCRIPTION
This was a nice change for the lib: https://github.com/home-assistant-libs/zwave-js-server-python/pull/390

Adopting the same mechanism here