### PR TITLE
Bump zwave-js-server to 1.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Full access to zwave-js driver through Websockets",
   "homepage": "https://github.com/zwave-js/zwave-js-server#readme",
   "repository": {


### PR DESCRIPTION
Necessary so we can bump to 9.0.7 in the add-on without creating build errors