### PR TITLE
Update controller.get_provisioning_entry to match new signature

### DIFF
--- a/src/lib/controller/incoming_message.ts
+++ b/src/lib/controller/incoming_message.ts
@@ -168,7 +168,10 @@ export interface IncomingCommandControllerUnprovisionSmartStartNode
 export interface IncomingCommandControllerGetProvisioningEntry
   extends IncomingCommandControllerBase {
   command: ControllerCommand.getProvisioningEntry;
-  dsk: string;
+  // schema version < 17
+  dsk?: string;
+  // schema version > 16
+  dskOrNodeId?: string | number;
 }
 
 export interface IncomingCommandControllerGetProvisioningEntries

--- a/src/lib/controller/message_handler.ts
+++ b/src/lib/controller/message_handler.ts
@@ -9,11 +9,13 @@ import {
   InclusionOptions,
   InclusionStrategy,
   ReplaceNodeOptions,
+  SmartStartProvisioningEntry,
 } from "zwave-js";
 import { dumpController } from "..";
 import {
   InclusionAlreadyInProgressError,
   InclusionPhaseNotInProgressError,
+  InvalidParamsPassedToCommandError,
   UnknownCommandError,
 } from "../error";
 import { Client, ClientsController } from "../server";
@@ -81,8 +83,17 @@ export class ControllerMessageHandler {
         return {};
       }
       case ControllerCommand.getProvisioningEntry: {
-        const entry = driver.controller.getProvisioningEntry(message.dsk);
-        return { entry };
+        if (message.dskOrNodeId) {
+          return {
+            entry: driver.controller.getProvisioningEntry(message.dskOrNodeId),
+          };
+        }
+        if (message.dsk) {
+          return { entry: driver.controller.getProvisioningEntry(message.dsk) };
+        }
+        throw new InvalidParamsPassedToCommandError(
+          "Must include one of dsk or dskOrNodeId in call to getProvisioningEntry"
+        );
       }
       case ControllerCommand.getProvisioningEntries: {
         const entries = driver.controller.getProvisioningEntries();


### PR DESCRIPTION
the driver method now accepts node ID as input as well. We will support both parameter names just in case