### PR TITLE
Update node.beginFirmwareUpdate command to accept a target

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ interface {
   firmwareFilename: string;
   firmwareFile: string; // use base64 encoding for the file
   firmwareFileFormat?: FileFormat;
+  target?: number;
 }
 ```
 

--- a/src/lib/node/incoming_message.ts
+++ b/src/lib/node/incoming_message.ts
@@ -47,6 +47,7 @@ export interface IncomingCommandNodeBeginFirmwareUpdate
   firmwareFilename: string;
   firmwareFile: string; // use base64 encoding for the file
   firmwareFileFormat?: FirmwareFileFormat;
+  target?: number;
 }
 
 export interface IncomingCommandNodeAbortFirmwareUpdate

--- a/src/lib/node/message_handler.ts
+++ b/src/lib/node/message_handler.ts
@@ -76,7 +76,7 @@ export class NodeMessageHandler {
         actualFirmware = extractFirmware(firmwareFile, format);
         await node.beginFirmwareUpdate(
           actualFirmware.data,
-          actualFirmware.firmwareTarget
+          message.target ?? actualFirmware.firmwareTarget
         );
         if (!(nodeId in this.firmwareUpdateProgress)) {
           node.on(


### PR DESCRIPTION
Per Al we can't rely on `extractFirmware` to get the target and should always let the user specify it.