### PR TITLE
Bump zwave-js-server to 0.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zwave-js/server",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/ciao": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Full access to zwave-js driver through Websockets",
   "homepage": "https://github.com/zwave-js/zwave-js-server#readme",
   "repository": {


### PR DESCRIPTION
Bumps the server to support all the new features that have been added. Ideally the other two PRs get merged ahead of time of this merge