### PR TITLE
Add param for whether any node is currently upgrading firmware

### DIFF
--- a/src/lib/node/message_handler.ts
+++ b/src/lib/node/message_handler.ts
@@ -212,6 +212,9 @@ export class NodeMessageHandler {
         return {};
       case NodeCommand.getFirmwareUpdateProgress:
         return {
+          anyProgress: Object.values(this.firmwareUpdateProgress).includes(
+            true
+          ),
           progress: this.firmwareUpdateProgress[nodeId] === true,
         };
       case NodeCommand.waitForWakeup:

--- a/src/lib/node/outgoing_message.ts
+++ b/src/lib/node/outgoing_message.ts
@@ -38,6 +38,9 @@ export interface NodeResultTypes {
   [NodeCommand.setName]: Record<string, never>;
   [NodeCommand.setLocation]: Record<string, never>;
   [NodeCommand.setKeepAwake]: Record<string, never>;
-  [NodeCommand.getFirmwareUpdateProgress]: { progress: boolean };
+  [NodeCommand.getFirmwareUpdateProgress]: {
+    progress: boolean;
+    anyProgress: boolean;
+  };
   [NodeCommand.waitForWakeup]: Record<string, never>;
 }


### PR DESCRIPTION
Al has indicated that only one firmware update should happen at any given time, so this property allows a client to determine if any node is currently updating it's firmware along with the target node.