### PR TITLE
Only send node found event to schema 19+ clients

### DIFF
--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -51,13 +51,15 @@ export class EventForwarder {
 
     this.clientsController.driver.controller.on("node found", (node) => {
       // forward event to all connected clients, respecting schemaVersion it supports
-      this.clientsController.clients.forEach((client) =>
-        this.sendEvent(client, {
-          source: "controller",
-          event: "node found",
-          node: dumpFoundNode(node, client.schemaVersion),
-        })
-      );
+      this.clientsController.clients
+        .filter((client) => client.schemaVersion > 18)
+        .forEach((client) =>
+          this.sendEvent(client, {
+            source: "controller",
+            event: "node found",
+            node: dumpFoundNode(node, client.schemaVersion),
+          })
+        );
       this.setupNode(node);
     });
 


### PR DESCRIPTION
This event was introduced in schema 18 but the logic was broken. It only works properly in schema 19+ so we should only send it to clients that support that.