### PR TITLE
Bump zwave-js to 9.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,17 +692,15 @@ interface {
 }
 ```
 
-#### [Is Any Firmware Update In Progress](https://zwave-js.github.io/node-zwave-js/#/api/node?id=isfirmwareupdateinprogress)
+#### [Is Firmware Update In Progress](https://zwave-js.github.io/node-zwave-js/#/api/node?id=isfirmwareupdateinprogress)
 
-Indicates whether a firmware update is in progress for this node.
-
-[compatible with schema version: 19+]
+[compatible with schema version: 11+]
 
 ```ts
 interface {
   messageId: string;
   nodeId: number;
-  command: "node.is_any_firmware_update_in_progress";
+  command: "node.is_firmware_update_in_progress";
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -694,7 +694,7 @@ interface {
 
 #### [Is Firmware Update In Progress](https://zwave-js.github.io/node-zwave-js/#/api/node?id=isfirmwareupdateinprogress)
 
-[compatible with schema version: 11+]
+[compatible with schema version: 21+]
 
 ```ts
 interface {

--- a/README.md
+++ b/README.md
@@ -352,17 +352,6 @@ interface {
 }
 ```
 
-#### Get whether any firmware updates are in progress
-
-[compatible with schema version: 20+]
-
-```ts
-interface {
-  messageId: string;
-  command: "controller.get_any_firmware_update_progress";
-}
-```
-
 ### Node level commands
 
 #### [Set value on a node](https://zwave-js.github.io/node-zwave-js/#/api/node?id=setvalue)
@@ -703,17 +692,17 @@ interface {
 }
 ```
 
-#### Get Firmware Update Progress status
+#### [Is Any Firmware Update In Progress](https://zwave-js.github.io/node-zwave-js/#/api/node?id=isfirmwareupdateinprogress)
 
 Indicates whether a firmware update is in progress for this node.
 
-[compatible with schema version: 18+]
+[compatible with schema version: 19+]
 
 ```ts
 interface {
   messageId: string;
   nodeId: number;
-  command: "node.get_firmware_update_progress";
+  command: "node.is_any_firmware_update_in_progress";
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,10 +34,10 @@
         "semver": "^7.3.5",
         "ts-node": "^10.5.0",
         "typescript": "^4.1.3",
-        "zwave-js": "^9.4.0"
+        "zwave-js": "^9.6.0"
       },
       "peerDependencies": {
-        "zwave-js": "^9.4.0"
+        "zwave-js": "^9.6.0"
       }
     },
     "node_modules/@alcalzone/jsonl-db": {
@@ -872,13 +872,13 @@
       }
     },
     "node_modules/@zwave-js/config": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-9.4.0.tgz",
-      "integrity": "sha512-c2vSTO/tCBnqfe3ivcffEX4v8OX1oOo+/oGQ3pCzsbSEgcfbx9x2NMpO/9GHCiKIbKGPj4rubZqHaLn7z6ScLQ==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-9.6.0.tgz",
+      "integrity": "sha512-r1ju+eUBgDZabh1akfa++DvpYeK7vV1Wm5A3EJhaqXuWw3r11lPbNppf8igakJAykCzhtjD7f7Bpq1R1gTyRkQ==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "9.4.0",
-        "@zwave-js/shared": "9.4.0",
+        "@zwave-js/core": "9.6.0",
+        "@zwave-js/shared": "9.6.0",
         "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.3",
         "fs-extra": "^10.1.0",
@@ -895,17 +895,17 @@
       }
     },
     "node_modules/@zwave-js/core": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-9.4.0.tgz",
-      "integrity": "sha512-AplNBIwraO1ko99gUqkObAlsI/VXngnJlYhtG+FGlAF18Aok2bJQ+ZJhp+an0Yo0zM5s8CpOeuWhw6cTd71ycQ==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-9.6.0.tgz",
+      "integrity": "sha512-tqOnG/crHqNAFS8YY/NuEdaS39rA5Y63Yy0FWF3MhCCjCq4oITWHoLmMPs/AghlD0mskyCLoNcW3h2X1aMtxfQ==",
       "dev": true,
       "dependencies": {
         "@alcalzone/jsonl-db": "^2.5.2",
-        "@zwave-js/shared": "9.4.0",
+        "@zwave-js/shared": "9.6.0",
         "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.3",
-        "dayjs": "^1.11.2",
-        "logform": "^2.4.0",
+        "dayjs": "^1.11.3",
+        "logform": "^2.4.1",
         "nrf-intel-hex": "^1.3.0",
         "triple-beam": "*",
         "winston": "^3.7.2",
@@ -920,13 +920,13 @@
       }
     },
     "node_modules/@zwave-js/host": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-9.4.0.tgz",
-      "integrity": "sha512-Otk8zo86uPKYgbrze9l3BKMg2O5hv8wf1jwiTKR38TfBXfBo5sJg7LUvy9Cww2kgXqbiiqPrauhQlFerBrM13w==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-9.6.0.tgz",
+      "integrity": "sha512-YJtmhMc6JuQUl5yKNh0FZbcdth256hdmy84LtKlgIDXd0F3ph3DKV6oNQhDKIby+ZB+Uuwe7TG0DkWyLOHh4Zw==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "9.4.0",
-        "@zwave-js/shared": "9.4.0",
+        "@zwave-js/core": "9.6.0",
+        "@zwave-js/shared": "9.6.0",
         "alcalzone-shared": "^4.0.1"
       },
       "engines": {
@@ -937,13 +937,13 @@
       }
     },
     "node_modules/@zwave-js/nvmedit": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-9.4.0.tgz",
-      "integrity": "sha512-jFBxq+ROgDGXKhLrIUHn+lir0lKmYZ0H/A0xRnRVsAPYkMWRkMlNEHvwup99DF4HxR2+4FAF8ycsGwE8dISbdw==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-9.6.0.tgz",
+      "integrity": "sha512-Xqx0zJJ1ZLBtyhLOqhOqyXyIj0kYH12H4tcHK3rJpUYd50WhwXdMhb3fqOyfZEDWl0cHMaeEhwG6RksrMdxXdQ==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "9.4.0",
-        "@zwave-js/shared": "9.4.0",
+        "@zwave-js/core": "9.6.0",
+        "@zwave-js/shared": "9.6.0",
         "alcalzone-shared": "^4.0.1",
         "fs-extra": "^10.1.0",
         "reflect-metadata": "^0.1.13",
@@ -961,15 +961,15 @@
       }
     },
     "node_modules/@zwave-js/serial": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-9.4.0.tgz",
-      "integrity": "sha512-4AYwkfyjwUBjLU02zppTHIhjweNzHdR9+uRVPq+7JldB1cGYBZ8aVShIFoV73SIXQMxIcO7l9EswjgR2Uo1dgA==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-9.6.0.tgz",
+      "integrity": "sha512-M+q9jqb9+8IQK3HFrONFE6D8Ia8EkshtaQv17WrxvEfs6Gm0YjV7jPyGgQtKMx+3BxbN14FTuJDLeiESbdwJPA==",
       "dev": true,
       "dependencies": {
         "@sentry/node": "^6.19.7",
-        "@zwave-js/core": "9.4.0",
-        "@zwave-js/host": "9.4.0",
-        "@zwave-js/shared": "9.4.0",
+        "@zwave-js/core": "9.6.0",
+        "@zwave-js/host": "9.6.0",
+        "@zwave-js/shared": "9.6.0",
         "alcalzone-shared": "^4.0.1",
         "serialport": "^10.4.0",
         "winston": "^3.7.2"
@@ -982,9 +982,9 @@
       }
     },
     "node_modules/@zwave-js/shared": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-9.4.0.tgz",
-      "integrity": "sha512-eZ4j6ERIzwT8Izp4W4Nj5Bk57/Sjcn7e7ItAioPkgh/a97xO/rXii6EuOZQK8AiyKhRubA7u2YvG1fmu3PLjqg==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-9.6.0.tgz",
+      "integrity": "sha512-HvP7gZsxAapOUW+pna23VZ4OQ7iJ4tPbZEMdV+Ik/kYyNumShc5VE7G2LLphopzBzHPW/Fwx4s54WbjcGcftNA==",
       "dev": true,
       "dependencies": {
         "alcalzone-shared": "^4.0.1",
@@ -2758,9 +2758,9 @@
       }
     },
     "node_modules/logform": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.4.0.tgz",
-      "integrity": "sha512-CPSJw4ftjf517EhXZGGvTHHkYobo7ZCc0kvwUoOYcjfR2UVrI66RHj8MCrfAdEitdmFqbu2BYdYs8FHHZSb6iw==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.4.2.tgz",
+      "integrity": "sha512-W4c9himeAwXEdZ05dQNerhFz2XG80P9Oj0loPUMV23VC2it0orMHQhJm4hdnnor3rd1HsGf6a2lPwBM1zeXHGw==",
       "dev": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
@@ -2896,9 +2896,9 @@
       "dev": true
     },
     "node_modules/node-gyp-build": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
       "dev": true,
       "bin": {
         "node-gyp-build": "bin.js",
@@ -3816,7 +3816,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
     "node_modules/v8-compile-cache": {
@@ -3853,9 +3853,9 @@
       "dev": true
     },
     "node_modules/winston": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.7.2.tgz",
-      "integrity": "sha512-QziIqtojHBoyzUOdQvQiar1DH0Xp9nF1A1y7NVy2DGEsz82SBDtOalS0ulTRGVT14xPX3WRWkCsdcJKqNflKng==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.1.tgz",
+      "integrity": "sha512-r+6YAiCR4uI3N8eQNOg8k3P3PqwAm20cLKlzVD9E66Ch39+LZC+VH1UKf9JemQj2B3QoUHfKD7Poewn0Pr3Y1w==",
       "dev": true,
       "dependencies": {
         "@dabh/diagnostics": "^2.0.2",
@@ -4040,21 +4040,21 @@
       }
     },
     "node_modules/zwave-js": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-9.4.0.tgz",
-      "integrity": "sha512-w/n6+tAkms0gURTll5CRt0HDvZxct5Z6sAIT+6L6OiZY54GhjOxxFgDkoWbKlH5oQmyXl5t/EA2AF3jIYyl/QQ==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-9.6.0.tgz",
+      "integrity": "sha512-SZxfQbWmS1Q9D4siegD9T17MU3D6Ees02ZLWLbFxHxdw6md+lgQFibTms4G7aDmdfktA1cre3EpS4IkWFH4edA==",
       "dev": true,
       "dependencies": {
         "@alcalzone/jsonl-db": "^2.5.2",
         "@alcalzone/pak": "^0.8.1",
         "@sentry/integrations": "^6.19.7",
         "@sentry/node": "^6.19.7",
-        "@zwave-js/config": "9.4.0",
-        "@zwave-js/core": "9.4.0",
-        "@zwave-js/host": "9.4.0",
-        "@zwave-js/nvmedit": "9.4.0",
-        "@zwave-js/serial": "9.4.0",
-        "@zwave-js/shared": "9.4.0",
+        "@zwave-js/config": "9.6.0",
+        "@zwave-js/core": "9.6.0",
+        "@zwave-js/host": "9.6.0",
+        "@zwave-js/nvmedit": "9.6.0",
+        "@zwave-js/serial": "9.6.0",
+        "@zwave-js/shared": "9.6.0",
         "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.3",
         "axios": "^0.27.2",
@@ -4692,13 +4692,13 @@
       }
     },
     "@zwave-js/config": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-9.4.0.tgz",
-      "integrity": "sha512-c2vSTO/tCBnqfe3ivcffEX4v8OX1oOo+/oGQ3pCzsbSEgcfbx9x2NMpO/9GHCiKIbKGPj4rubZqHaLn7z6ScLQ==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-9.6.0.tgz",
+      "integrity": "sha512-r1ju+eUBgDZabh1akfa++DvpYeK7vV1Wm5A3EJhaqXuWw3r11lPbNppf8igakJAykCzhtjD7f7Bpq1R1gTyRkQ==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "9.4.0",
-        "@zwave-js/shared": "9.4.0",
+        "@zwave-js/core": "9.6.0",
+        "@zwave-js/shared": "9.6.0",
         "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.3",
         "fs-extra": "^10.1.0",
@@ -4709,17 +4709,17 @@
       }
     },
     "@zwave-js/core": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-9.4.0.tgz",
-      "integrity": "sha512-AplNBIwraO1ko99gUqkObAlsI/VXngnJlYhtG+FGlAF18Aok2bJQ+ZJhp+an0Yo0zM5s8CpOeuWhw6cTd71ycQ==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-9.6.0.tgz",
+      "integrity": "sha512-tqOnG/crHqNAFS8YY/NuEdaS39rA5Y63Yy0FWF3MhCCjCq4oITWHoLmMPs/AghlD0mskyCLoNcW3h2X1aMtxfQ==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.5.2",
-        "@zwave-js/shared": "9.4.0",
+        "@zwave-js/shared": "9.6.0",
         "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.3",
-        "dayjs": "^1.11.2",
-        "logform": "^2.4.0",
+        "dayjs": "^1.11.3",
+        "logform": "^2.4.1",
         "nrf-intel-hex": "^1.3.0",
         "triple-beam": "*",
         "winston": "^3.7.2",
@@ -4728,24 +4728,24 @@
       }
     },
     "@zwave-js/host": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-9.4.0.tgz",
-      "integrity": "sha512-Otk8zo86uPKYgbrze9l3BKMg2O5hv8wf1jwiTKR38TfBXfBo5sJg7LUvy9Cww2kgXqbiiqPrauhQlFerBrM13w==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-9.6.0.tgz",
+      "integrity": "sha512-YJtmhMc6JuQUl5yKNh0FZbcdth256hdmy84LtKlgIDXd0F3ph3DKV6oNQhDKIby+ZB+Uuwe7TG0DkWyLOHh4Zw==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "9.4.0",
-        "@zwave-js/shared": "9.4.0",
+        "@zwave-js/core": "9.6.0",
+        "@zwave-js/shared": "9.6.0",
         "alcalzone-shared": "^4.0.1"
       }
     },
     "@zwave-js/nvmedit": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-9.4.0.tgz",
-      "integrity": "sha512-jFBxq+ROgDGXKhLrIUHn+lir0lKmYZ0H/A0xRnRVsAPYkMWRkMlNEHvwup99DF4HxR2+4FAF8ycsGwE8dISbdw==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-9.6.0.tgz",
+      "integrity": "sha512-Xqx0zJJ1ZLBtyhLOqhOqyXyIj0kYH12H4tcHK3rJpUYd50WhwXdMhb3fqOyfZEDWl0cHMaeEhwG6RksrMdxXdQ==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "9.4.0",
-        "@zwave-js/shared": "9.4.0",
+        "@zwave-js/core": "9.6.0",
+        "@zwave-js/shared": "9.6.0",
         "alcalzone-shared": "^4.0.1",
         "fs-extra": "^10.1.0",
         "reflect-metadata": "^0.1.13",
@@ -4754,24 +4754,24 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-9.4.0.tgz",
-      "integrity": "sha512-4AYwkfyjwUBjLU02zppTHIhjweNzHdR9+uRVPq+7JldB1cGYBZ8aVShIFoV73SIXQMxIcO7l9EswjgR2Uo1dgA==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-9.6.0.tgz",
+      "integrity": "sha512-M+q9jqb9+8IQK3HFrONFE6D8Ia8EkshtaQv17WrxvEfs6Gm0YjV7jPyGgQtKMx+3BxbN14FTuJDLeiESbdwJPA==",
       "dev": true,
       "requires": {
         "@sentry/node": "^6.19.7",
-        "@zwave-js/core": "9.4.0",
-        "@zwave-js/host": "9.4.0",
-        "@zwave-js/shared": "9.4.0",
+        "@zwave-js/core": "9.6.0",
+        "@zwave-js/host": "9.6.0",
+        "@zwave-js/shared": "9.6.0",
         "alcalzone-shared": "^4.0.1",
         "serialport": "^10.4.0",
         "winston": "^3.7.2"
       }
     },
     "@zwave-js/shared": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-9.4.0.tgz",
-      "integrity": "sha512-eZ4j6ERIzwT8Izp4W4Nj5Bk57/Sjcn7e7ItAioPkgh/a97xO/rXii6EuOZQK8AiyKhRubA7u2YvG1fmu3PLjqg==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-9.6.0.tgz",
+      "integrity": "sha512-HvP7gZsxAapOUW+pna23VZ4OQ7iJ4tPbZEMdV+Ik/kYyNumShc5VE7G2LLphopzBzHPW/Fwx4s54WbjcGcftNA==",
       "dev": true,
       "requires": {
         "alcalzone-shared": "^4.0.1",
@@ -6096,9 +6096,9 @@
       }
     },
     "logform": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.4.0.tgz",
-      "integrity": "sha512-CPSJw4ftjf517EhXZGGvTHHkYobo7ZCc0kvwUoOYcjfR2UVrI66RHj8MCrfAdEitdmFqbu2BYdYs8FHHZSb6iw==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.4.2.tgz",
+      "integrity": "sha512-W4c9himeAwXEdZ05dQNerhFz2XG80P9Oj0loPUMV23VC2it0orMHQhJm4hdnnor3rd1HsGf6a2lPwBM1zeXHGw==",
       "dev": true,
       "requires": {
         "@colors/colors": "1.5.0",
@@ -6210,9 +6210,9 @@
       "dev": true
     },
     "node-gyp-build": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
       "dev": true
     },
     "normalize-path": {
@@ -6837,7 +6837,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
     "v8-compile-cache": {
@@ -6868,9 +6868,9 @@
       "dev": true
     },
     "winston": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.7.2.tgz",
-      "integrity": "sha512-QziIqtojHBoyzUOdQvQiar1DH0Xp9nF1A1y7NVy2DGEsz82SBDtOalS0ulTRGVT14xPX3WRWkCsdcJKqNflKng==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.1.tgz",
+      "integrity": "sha512-r+6YAiCR4uI3N8eQNOg8k3P3PqwAm20cLKlzVD9E66Ch39+LZC+VH1UKf9JemQj2B3QoUHfKD7Poewn0Pr3Y1w==",
       "dev": true,
       "requires": {
         "@dabh/diagnostics": "^2.0.2",
@@ -6995,21 +6995,21 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-9.4.0.tgz",
-      "integrity": "sha512-w/n6+tAkms0gURTll5CRt0HDvZxct5Z6sAIT+6L6OiZY54GhjOxxFgDkoWbKlH5oQmyXl5t/EA2AF3jIYyl/QQ==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-9.6.0.tgz",
+      "integrity": "sha512-SZxfQbWmS1Q9D4siegD9T17MU3D6Ees02ZLWLbFxHxdw6md+lgQFibTms4G7aDmdfktA1cre3EpS4IkWFH4edA==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.5.2",
         "@alcalzone/pak": "^0.8.1",
         "@sentry/integrations": "^6.19.7",
         "@sentry/node": "^6.19.7",
-        "@zwave-js/config": "9.4.0",
-        "@zwave-js/core": "9.4.0",
-        "@zwave-js/host": "9.4.0",
-        "@zwave-js/nvmedit": "9.4.0",
-        "@zwave-js/serial": "9.4.0",
-        "@zwave-js/shared": "9.4.0",
+        "@zwave-js/config": "9.6.0",
+        "@zwave-js/core": "9.6.0",
+        "@zwave-js/host": "9.6.0",
+        "@zwave-js/nvmedit": "9.6.0",
+        "@zwave-js/serial": "9.6.0",
+        "@zwave-js/shared": "9.6.0",
         "alcalzone-shared": "^4.0.1",
         "ansi-colors": "^4.1.3",
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@homebridge/ciao": "^1.1.3"
   },
   "peerDependencies": {
-    "zwave-js": "^9.4.0"
+    "zwave-js": "^9.6.0"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -53,7 +53,7 @@
     "semver": "^7.3.5",
     "ts-node": "^10.5.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^9.4.0"
+    "zwave-js": "^9.6.0"
   },
   "husky": {
     "hooks": {

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -4,6 +4,6 @@ export const version = require("../../package.json").version;
 export const minSchemaVersion = 0;
 
 // maximal/current schema version the server supports
-export const maxSchemaVersion = 20;
+export const maxSchemaVersion = 21;
 
 export const dnssdServiceType = "zwave-js-server";

--- a/src/lib/controller/command.ts
+++ b/src/lib/controller/command.ts
@@ -35,4 +35,5 @@ export enum ControllerCommand {
   getState = "controller.get_state",
   getKnownLifelineRoutes = "controller.get_known_lifeline_routes",
   getAnyFirmwareUpdateProgress = "controller.get_any_firmware_update_progress",
+  isAnyOTAFirmwareUpdateInProgress = "controller.is_any_ota_firmware_update_in_progress",
 }

--- a/src/lib/controller/command.ts
+++ b/src/lib/controller/command.ts
@@ -36,4 +36,6 @@ export enum ControllerCommand {
   getKnownLifelineRoutes = "controller.get_known_lifeline_routes",
   getAnyFirmwareUpdateProgress = "controller.get_any_firmware_update_progress",
   isAnyOTAFirmwareUpdateInProgress = "controller.is_any_ota_firmware_update_in_progress",
+  getAvailableFirmwareUpdates = "controller.get_available_firmware_updates",
+  beginOTAFirmwareUpdate = "controller.begin_ota_firmware_update",
 }

--- a/src/lib/controller/incoming_message.ts
+++ b/src/lib/controller/incoming_message.ts
@@ -231,6 +231,10 @@ export interface IncomingCommandControllerGetAnyFirmwareUpdateProgress
   extends IncomingCommandControllerBase {
   command: ControllerCommand.getAnyFirmwareUpdateProgress;
 }
+export interface IncomingCommandControllerIsAnyOTAFirmwareUpdateInProgress
+  extends IncomingCommandControllerBase {
+  command: ControllerCommand.isAnyOTAFirmwareUpdateInProgress;
+}
 
 export type IncomingMessageController =
   | IncomingCommandControllerBeginInclusion
@@ -267,4 +271,5 @@ export type IncomingMessageController =
   | IncomingCommandControllerGetPowerlevel
   | IncomingCommandControllerGetState
   | IncomingCommandControllerGetKnownLifelineRoutes
-  | IncomingCommandControllerGetAnyFirmwareUpdateProgress;
+  | IncomingCommandControllerGetAnyFirmwareUpdateProgress
+  | IncomingCommandControllerIsAnyOTAFirmwareUpdateInProgress;

--- a/src/lib/controller/incoming_message.ts
+++ b/src/lib/controller/incoming_message.ts
@@ -1,5 +1,6 @@
 import {
   AssociationAddress,
+  FirmwareUpdateFileInfo,
   InclusionGrant,
   InclusionOptions,
   PlannedProvisioningEntry,
@@ -227,13 +228,25 @@ export interface IncomingCommandControllerGetKnownLifelineRoutes
   extends IncomingCommandControllerBase {
   command: ControllerCommand.getKnownLifelineRoutes;
 }
-export interface IncomingCommandControllerGetAnyFirmwareUpdateProgress
-  extends IncomingCommandControllerBase {
-  command: ControllerCommand.getAnyFirmwareUpdateProgress;
-}
+
 export interface IncomingCommandControllerIsAnyOTAFirmwareUpdateInProgress
   extends IncomingCommandControllerBase {
-  command: ControllerCommand.isAnyOTAFirmwareUpdateInProgress;
+  command:
+    | ControllerCommand.isAnyOTAFirmwareUpdateInProgress
+    | ControllerCommand.getAnyFirmwareUpdateProgress;
+}
+
+export interface IncomingCommandControllerGetAvailableFirmwareUpdates
+  extends IncomingCommandControllerBase {
+  command: ControllerCommand.getAvailableFirmwareUpdates;
+  nodeId: number;
+}
+
+export interface IncomingCommandControllerBeginOTAFirmwareUpdate
+  extends IncomingCommandControllerBase {
+  command: ControllerCommand.beginOTAFirmwareUpdate;
+  nodeId: number;
+  update: FirmwareUpdateFileInfo;
 }
 
 export type IncomingMessageController =
@@ -271,5 +284,6 @@ export type IncomingMessageController =
   | IncomingCommandControllerGetPowerlevel
   | IncomingCommandControllerGetState
   | IncomingCommandControllerGetKnownLifelineRoutes
-  | IncomingCommandControllerGetAnyFirmwareUpdateProgress
-  | IncomingCommandControllerIsAnyOTAFirmwareUpdateInProgress;
+  | IncomingCommandControllerIsAnyOTAFirmwareUpdateInProgress
+  | IncomingCommandControllerGetAvailableFirmwareUpdates
+  | IncomingCommandControllerBeginOTAFirmwareUpdate;

--- a/src/lib/controller/message_handler.ts
+++ b/src/lib/controller/message_handler.ts
@@ -269,10 +269,11 @@ export class ControllerMessageHandler {
         const routes = driver.controller.getKnownLifelineRoutes();
         return { routes };
       }
-      case ControllerCommand.getAnyFirmwareUpdateProgress: {
-        const progress =
-          clientsController.nodeMessageHandler.anyFirmwareUpdateProgress;
-        return { progress };
+      case ControllerCommand.getAnyFirmwareUpdateProgress:
+      case ControllerCommand.isAnyOTAFirmwareUpdateInProgress: {
+        return {
+          progress: driver.controller.isAnyOTAFirmwareUpdateInProgress(),
+        };
       }
       default:
         throw new UnknownCommandError(command);

--- a/src/lib/controller/message_handler.ts
+++ b/src/lib/controller/message_handler.ts
@@ -275,6 +275,20 @@ export class ControllerMessageHandler {
           progress: driver.controller.isAnyOTAFirmwareUpdateInProgress(),
         };
       }
+      case ControllerCommand.getAvailableFirmwareUpdates: {
+        return {
+          updates: await driver.controller.getAvailableFirmwareUpdates(
+            message.nodeId
+          ),
+        };
+      }
+      case ControllerCommand.beginOTAFirmwareUpdate: {
+        await driver.controller.beginOTAFirmwareUpdate(
+          message.nodeId,
+          message.update
+        );
+        return {};
+      }
       default:
         throw new UnknownCommandError(command);
     }

--- a/src/lib/controller/outgoing_message.ts
+++ b/src/lib/controller/outgoing_message.ts
@@ -1,6 +1,7 @@
 import {
   AssociationAddress,
   AssociationGroup,
+  FirmwareUpdateInfo,
   LifelineRoutes,
   RFRegion,
   SmartStartProvisioningEntry,
@@ -63,4 +64,8 @@ export interface ControllerResultTypes {
   [ControllerCommand.isAnyOTAFirmwareUpdateInProgress]: {
     progress: boolean;
   };
+  [ControllerCommand.getAvailableFirmwareUpdates]: {
+    updates: FirmwareUpdateInfo[];
+  };
+  [ControllerCommand.beginOTAFirmwareUpdate]: Record<string, never>;
 }

--- a/src/lib/controller/outgoing_message.ts
+++ b/src/lib/controller/outgoing_message.ts
@@ -60,4 +60,7 @@ export interface ControllerResultTypes {
   [ControllerCommand.getAnyFirmwareUpdateProgress]: {
     progress: boolean;
   };
+  [ControllerCommand.isAnyOTAFirmwareUpdateInProgress]: {
+    progress: boolean;
+  };
 }

--- a/src/lib/node/command.ts
+++ b/src/lib/node/command.ts
@@ -24,5 +24,6 @@ export enum NodeCommand {
   setLocation = "node.set_location",
   setKeepAwake = "node.set_keep_awake",
   getFirmwareUpdateProgress = "node.get_firmware_update_progress",
+  isFirmwareUpdateInProgress = "node.is_firmware_update_in_progress",
   waitForWakeup = "node.wait_for_wakeup",
 }

--- a/src/lib/node/incoming_message.ts
+++ b/src/lib/node/incoming_message.ts
@@ -155,14 +155,11 @@ export interface IncomingCommandSetKeepAwake extends IncomingCommandNodeBase {
   keepAwake: boolean;
 }
 
-export interface IncomingCommandGetFirmwareUpdateInProgress
-  extends IncomingCommandNodeBase {
-  command: NodeCommand.getFirmwareUpdateProgress;
-}
-
 export interface IncomingCommandIsFirmwareUpdateInProgress
   extends IncomingCommandNodeBase {
-  command: NodeCommand.isFirmwareUpdateInProgress;
+  command:
+    | NodeCommand.isFirmwareUpdateInProgress
+    | NodeCommand.getFirmwareUpdateProgress;
 }
 
 export interface IncomingCommandWaitForWakeup extends IncomingCommandNodeBase {
@@ -194,6 +191,5 @@ export type IncomingMessageNode =
   | IncomingCommandSetName
   | IncomingCommandSetLocation
   | IncomingCommandSetKeepAwake
-  | IncomingCommandGetFirmwareUpdateInProgress
   | IncomingCommandIsFirmwareUpdateInProgress
   | IncomingCommandWaitForWakeup;

--- a/src/lib/node/incoming_message.ts
+++ b/src/lib/node/incoming_message.ts
@@ -160,6 +160,11 @@ export interface IncomingCommandGetFirmwareUpdateInProgress
   command: NodeCommand.getFirmwareUpdateProgress;
 }
 
+export interface IncomingCommandIsFirmwareUpdateInProgress
+  extends IncomingCommandNodeBase {
+  command: NodeCommand.isFirmwareUpdateInProgress;
+}
+
 export interface IncomingCommandWaitForWakeup extends IncomingCommandNodeBase {
   command: NodeCommand.waitForWakeup;
 }
@@ -190,4 +195,5 @@ export type IncomingMessageNode =
   | IncomingCommandSetLocation
   | IncomingCommandSetKeepAwake
   | IncomingCommandGetFirmwareUpdateInProgress
+  | IncomingCommandIsFirmwareUpdateInProgress
   | IncomingCommandWaitForWakeup;

--- a/src/lib/node/outgoing_message.ts
+++ b/src/lib/node/outgoing_message.ts
@@ -39,5 +39,6 @@ export interface NodeResultTypes {
   [NodeCommand.setLocation]: Record<string, never>;
   [NodeCommand.setKeepAwake]: Record<string, never>;
   [NodeCommand.getFirmwareUpdateProgress]: { progress: boolean };
+  [NodeCommand.isFirmwareUpdateInProgress]: { progress: boolean };
   [NodeCommand.waitForWakeup]: Record<string, never>;
 }


### PR DESCRIPTION
in 9.5.0 the driver added commands to check whether firmware updates are in progress. We no longer need to track that in the server.

In 9.6.0 the driver added support for automatic updates so we added the corresponding commands