### PR TITLE
Make notification event backwards compatible with old schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,10 +34,10 @@
         "semver": "^7.3.5",
         "ts-node": "^10.5.0",
         "typescript": "^4.1.3",
-        "zwave-js": "^9.6.0"
+        "zwave-js": "^9.6.2"
       },
       "peerDependencies": {
-        "zwave-js": "^9.6.0"
+        "zwave-js": "^9.6.2"
       }
     },
     "node_modules/@alcalzone/jsonl-db": {
@@ -877,23 +877,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.30.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.30.5.tgz",
-      "integrity": "sha512-NJ6F+YHHFT/30isRe2UTmIGGAiXKckCyMnIV58cE3JkHmaD6e5zyEYm5hBDv0Wbin+IC0T1FWJpD3YqHUG/Ydg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.30.5",
-        "@typescript-eslint/visitor-keys": "5.30.5"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.30.6",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.30.6.tgz",
@@ -913,46 +896,6 @@
       },
       "peerDependencies": {
         "eslint": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "5.30.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.30.5.tgz",
-      "integrity": "sha512-kZ80w/M2AvsbRvOr3PjaNh6qEW1LFqs2pLdo2s5R38B2HYXG8Z0PP48/4+j1QHJFL3ssHIbJ4odPRS8PlHrFfw==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.30.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.5.tgz",
-      "integrity": "sha512-qGTc7QZC801kbYjAr4AgdOfnokpwStqyhSbiQvqGBLixniAKyH+ib2qXIVo4P9NgGzwyfD9I0nlJN7D91E1VpQ==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.30.5",
-        "@typescript-eslint/visitor-keys": "5.30.5",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -1067,36 +1010,10 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.30.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.5.tgz",
-      "integrity": "sha512-D+xtGo9HUMELzWIUqcQc0p2PO4NyvTrgIOK/VnSH083+8sq0tiLozNRKuLarwHYGRuA6TVBQSuuLwJUDWd3aaA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.30.5",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/@zwave-js/config": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-9.6.0.tgz",
-      "integrity": "sha512-r1ju+eUBgDZabh1akfa++DvpYeK7vV1Wm5A3EJhaqXuWw3r11lPbNppf8igakJAykCzhtjD7f7Bpq1R1gTyRkQ==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-9.6.1.tgz",
+      "integrity": "sha512-9bU3hkXCbOq1qPW7k5fJKCra6REKjMHG7nNQDqSjaYk0oYohRGTWfk0XtJS9vvvJb8jeLxDMtPC9t5iKtZBK8w==",
       "dev": true,
       "dependencies": {
         "@zwave-js/core": "9.6.0",
@@ -4262,16 +4179,16 @@
       }
     },
     "node_modules/zwave-js": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-9.6.0.tgz",
-      "integrity": "sha512-SZxfQbWmS1Q9D4siegD9T17MU3D6Ees02ZLWLbFxHxdw6md+lgQFibTms4G7aDmdfktA1cre3EpS4IkWFH4edA==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-9.6.2.tgz",
+      "integrity": "sha512-2+i6ArrnPk+im7zBrkdkCOqdyhWp0KY3TqL3JOw4Ve7937CrhpxRWaT60NbEWSfd/ljmrfDH+rNlljgtkH8QqA==",
       "dev": true,
       "dependencies": {
         "@alcalzone/jsonl-db": "^2.5.2",
         "@alcalzone/pak": "^0.8.1",
         "@sentry/integrations": "^6.19.7",
         "@sentry/node": "^6.19.7",
-        "@zwave-js/config": "9.6.0",
+        "@zwave-js/config": "9.6.1",
         "@zwave-js/core": "9.6.0",
         "@zwave-js/host": "9.6.0",
         "@zwave-js/nvmedit": "9.6.0",
@@ -4922,16 +4839,6 @@
         }
       }
     },
-    "@typescript-eslint/scope-manager": {
-      "version": "5.30.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.30.5.tgz",
-      "integrity": "sha512-NJ6F+YHHFT/30isRe2UTmIGGAiXKckCyMnIV58cE3JkHmaD6e5zyEYm5hBDv0Wbin+IC0T1FWJpD3YqHUG/Ydg==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.30.5",
-        "@typescript-eslint/visitor-keys": "5.30.5"
-      }
-    },
     "@typescript-eslint/type-utils": {
       "version": "5.30.6",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.30.6.tgz",
@@ -4940,27 +4847,6 @@
       "requires": {
         "@typescript-eslint/utils": "5.30.6",
         "debug": "^4.3.4",
-        "tsutils": "^3.21.0"
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "5.30.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.30.5.tgz",
-      "integrity": "sha512-kZ80w/M2AvsbRvOr3PjaNh6qEW1LFqs2pLdo2s5R38B2HYXG8Z0PP48/4+j1QHJFL3ssHIbJ4odPRS8PlHrFfw==",
-      "dev": true
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "5.30.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.5.tgz",
-      "integrity": "sha512-qGTc7QZC801kbYjAr4AgdOfnokpwStqyhSbiQvqGBLixniAKyH+ib2qXIVo4P9NgGzwyfD9I0nlJN7D91E1VpQ==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.30.5",
-        "@typescript-eslint/visitor-keys": "5.30.5",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       }
     },
@@ -5027,28 +4913,10 @@
         }
       }
     },
-    "@typescript-eslint/visitor-keys": {
-      "version": "5.30.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.5.tgz",
-      "integrity": "sha512-D+xtGo9HUMELzWIUqcQc0p2PO4NyvTrgIOK/VnSH083+8sq0tiLozNRKuLarwHYGRuA6TVBQSuuLwJUDWd3aaA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.30.5",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-          "dev": true
-        }
-      }
-    },
     "@zwave-js/config": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-9.6.0.tgz",
-      "integrity": "sha512-r1ju+eUBgDZabh1akfa++DvpYeK7vV1Wm5A3EJhaqXuWw3r11lPbNppf8igakJAykCzhtjD7f7Bpq1R1gTyRkQ==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-9.6.1.tgz",
+      "integrity": "sha512-9bU3hkXCbOq1qPW7k5fJKCra6REKjMHG7nNQDqSjaYk0oYohRGTWfk0XtJS9vvvJb8jeLxDMtPC9t5iKtZBK8w==",
       "dev": true,
       "requires": {
         "@zwave-js/core": "9.6.0",
@@ -7349,16 +7217,16 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-9.6.0.tgz",
-      "integrity": "sha512-SZxfQbWmS1Q9D4siegD9T17MU3D6Ees02ZLWLbFxHxdw6md+lgQFibTms4G7aDmdfktA1cre3EpS4IkWFH4edA==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-9.6.2.tgz",
+      "integrity": "sha512-2+i6ArrnPk+im7zBrkdkCOqdyhWp0KY3TqL3JOw4Ve7937CrhpxRWaT60NbEWSfd/ljmrfDH+rNlljgtkH8QqA==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.5.2",
         "@alcalzone/pak": "^0.8.1",
         "@sentry/integrations": "^6.19.7",
         "@sentry/node": "^6.19.7",
-        "@zwave-js/config": "9.6.0",
+        "@zwave-js/config": "9.6.1",
         "@zwave-js/core": "9.6.0",
         "@zwave-js/host": "9.6.0",
         "@zwave-js/nvmedit": "9.6.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@homebridge/ciao": "^1.1.3"
   },
   "peerDependencies": {
-    "zwave-js": "^9.6.0"
+    "zwave-js": "^9.6.2"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -53,7 +53,7 @@
     "semver": "^7.3.5",
     "ts-node": "^10.5.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^9.6.0"
+    "zwave-js": "^9.6.2"
   },
   "husky": {
     "hooks": {

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -260,7 +260,17 @@ export class EventForwarder {
               eventData["parameters"] = args.parameters;
             }
             this.sendEvent(client, eventData);
-          } else if (client.schemaVersion >= 3) {
+          } else if (client.schemaVersion >= 3 && client.schemaVersion < 21) {
+            delete args.eventTypeLabel;
+            delete args.dataTypeLabel;
+            this.sendEvent(client, {
+              source: "node",
+              event: "notification",
+              nodeId: changedNode.nodeId,
+              ccId,
+              args,
+            });
+          } else if (client.schemaVersion >= 21) {
             this.sendEvent(client, {
               source: "node",
               event: "notification",

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -260,17 +260,11 @@ export class EventForwarder {
               eventData["parameters"] = args.parameters;
             }
             this.sendEvent(client, eventData);
-          } else if (client.schemaVersion >= 3 && client.schemaVersion < 21) {
-            delete args.eventTypeLabel;
-            delete args.dataTypeLabel;
-            this.sendEvent(client, {
-              source: "node",
-              event: "notification",
-              nodeId: changedNode.nodeId,
-              ccId,
-              args,
-            });
-          } else if (client.schemaVersion >= 21) {
+          } else if (client.schemaVersion >= 3) {
+            if (client.schemaVersion < 21) {
+              delete args.eventTypeLabel;
+              delete args.dataTypeLabel;
+            }
             this.sendEvent(client, {
               source: "node",
               event: "notification",

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -262,8 +262,17 @@ export class EventForwarder {
             this.sendEvent(client, eventData);
           } else if (client.schemaVersion >= 3) {
             if (client.schemaVersion < 21) {
-              delete args.eventTypeLabel;
-              delete args.dataTypeLabel;
+              if (
+                [
+                  CommandClasses["Multilevel Switch"],
+                  CommandClasses["Entry Control"],
+                ].includes(ccId)
+              ) {
+                delete args.eventTypeLabel;
+              }
+              if (ccId == CommandClasses["Entry Control"]) {
+                delete args.dataTypeLabel;
+              }
             }
             this.sendEvent(client, {
               source: "node",


### PR DESCRIPTION
v9.6.0 introduced new parameters to the `notification` event. Because we introduced strict validation for events in the lib, we need to remove these parameters from older schema clients so that they don't break