### PR TITLE
Add missing endpoint commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,6 +806,75 @@ interface {
 }
 ```
 
+#### [Check whether endpoint supports a given Command Class](https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=supportscc)
+
+[compatible with schema version: 23+]
+
+```ts
+interface {
+  messageId: string;
+  command: "endpoint.supports_cc";
+  nodeId: number;
+  endpoint?: number;
+  commandClass: CommandClasses;
+}
+```
+
+#### [Check whether endpoint controls a given Command Class](https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=controlscc)
+
+[compatible with schema version: 23+]
+
+```ts
+interface {
+  messageId: string;
+  command: "endpoint.controls_cc";
+  nodeId: number;
+  endpoint?: number;
+  commandClass: CommandClasses;
+}
+```
+
+#### [Check whether a given Command Class is secure](https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=isccsecure)
+
+[compatible with schema version: 23+]
+
+```ts
+interface {
+  messageId: string;
+  command: "endpoint.is_cc_secure";
+  nodeId: number;
+  endpoint?: number;
+  commandClass: CommandClasses;
+}
+```
+
+#### [Check version of a given Command Class](https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=getccversion)
+
+[compatible with schema version: 23+]
+
+```ts
+interface {
+  messageId: string;
+  command: "endpoint.get_cc_version";
+  nodeId: number;
+  endpoint?: number;
+  commandClass: CommandClasses;
+}
+```
+
+#### [Get node from endpoint](https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=getnodeunsafe)
+
+[compatible with schema version: 23+]
+
+```ts
+interface {
+  messageId: string;
+  command: "endpoint.get_node_unsafe";
+  nodeId: number;
+  endpoint?: number;
+}
+```
+
 ### Multicasting
 
 There are several commands available that can be multicast to multiple nodes simultaneously. If you would like to broadcast to all nodes, use the `broadcast_node` prefix for the following commands. If you would like to multicast to a subset of nodes, use the `multicast_group` prefix for the following commands, adding a `nodeIDs` list as an input parameter:

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -4,6 +4,6 @@ export const version = require("../../package.json").version;
 export const minSchemaVersion = 0;
 
 // maximal/current schema version the server supports
-export const maxSchemaVersion = 22;
+export const maxSchemaVersion = 23;
 
 export const dnssdServiceType = "zwave-js-server";

--- a/src/lib/endpoint/command.ts
+++ b/src/lib/endpoint/command.ts
@@ -1,4 +1,9 @@
 export enum EndpointCommand {
   invokeCCAPI = "endpoint.invoke_cc_api",
   supportsCCAPI = "endpoint.supports_cc_api",
+  supportsCC = "endpoint.supports_cc",
+  controlsCC = "endpoint.controls_cc",
+  isCCSecure = "endpoint.is_cc_secure",
+  getCCVersion = "endpoint.get_cc_version",
+  getNodeUnsafe = "endpoint.get_node_unsafe",
 }

--- a/src/lib/endpoint/incoming_message.ts
+++ b/src/lib/endpoint/incoming_message.ts
@@ -21,6 +21,40 @@ export interface IncomingCommandEndpointSupportsCCAPI
   commandClass: CommandClasses;
 }
 
+export interface IncomingCommandEndpointSupportsCC
+  extends IncomingCommandEndpointBase {
+  command: EndpointCommand.supportsCC;
+  commandClass: CommandClasses;
+}
+
+export interface IncomingCommandEndpointControlsCC
+  extends IncomingCommandEndpointBase {
+  command: EndpointCommand.controlsCC;
+  commandClass: CommandClasses;
+}
+
+export interface IncomingCommandEndpointIsCCSecure
+  extends IncomingCommandEndpointBase {
+  command: EndpointCommand.isCCSecure;
+  commandClass: CommandClasses;
+}
+
+export interface IncomingCommandEndpointGetCCVersion
+  extends IncomingCommandEndpointBase {
+  command: EndpointCommand.getCCVersion;
+  commandClass: CommandClasses;
+}
+
+export interface IncomingCommandEndpointGetNodeUnsafe
+  extends IncomingCommandEndpointBase {
+  command: EndpointCommand.getNodeUnsafe;
+}
+
 export type IncomingMessageEndpoint =
   | IncomingCommandEndpointInvokeCCAPI
-  | IncomingCommandEndpointSupportsCCAPI;
+  | IncomingCommandEndpointSupportsCCAPI
+  | IncomingCommandEndpointSupportsCC
+  | IncomingCommandEndpointControlsCC
+  | IncomingCommandEndpointIsCCSecure
+  | IncomingCommandEndpointGetCCVersion
+  | IncomingCommandEndpointGetNodeUnsafe;

--- a/src/lib/endpoint/outgoing_message.ts
+++ b/src/lib/endpoint/outgoing_message.ts
@@ -1,6 +1,12 @@
 import { EndpointCommand } from "./command";
+import { NodeState } from "../state";
 
 export interface EndpointResultTypes {
   [EndpointCommand.invokeCCAPI]: { response: unknown };
   [EndpointCommand.supportsCCAPI]: { supported: boolean };
+  [EndpointCommand.supportsCC]: { supported: boolean };
+  [EndpointCommand.controlsCC]: { controlled: boolean };
+  [EndpointCommand.isCCSecure]: { secure: boolean };
+  [EndpointCommand.getCCVersion]: { version: number };
+  [EndpointCommand.getNodeUnsafe]: { node: NodeState | undefined };
 }

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -91,7 +91,8 @@ export class Client {
     [Instance.endpoint]: (message) =>
       EndpointMessageHandler.handle(
         message as IncomingMessageEndpoint,
-        this.driver
+        this.driver,
+        this
       ),
     [Instance.utils]: (message) =>
       UtilsMessageHandler.handle(message as IncomingMessageUtils),


### PR DESCRIPTION
Adds endpoint commands that are missing. Skips [createCCInstance](https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=createccinstance) and [createCCInstanceUnsafe](https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=createccinstanceunsafe) because I'm not sure why a client would need to use these

Fixes #737