### PR TITLE
Remove ZwavejsServer interface

### DIFF
--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -387,13 +387,6 @@ export interface Logger {
   debug(message: string): void;
 }
 
-export interface ZwavejsServer {
-  start(): Promise<void>;
-  destroy(): Promise<void>;
-  on(event: "listening", listener: () => void): this;
-  on(event: "error", listener: (error: Error) => void): this;
-}
-
 export class ZwavejsServer extends EventEmitter {
   private server?: HttpServer;
   private wsServer?: ws.Server;


### PR DESCRIPTION
Apparently if you define multiple interfaces with the same name or multiple interfaces and classes with the same name, the interface becomes a merged version of all of them. Anyway, I think this is redundant so let's just remove it