### PR TITLE
Bump zwave-js to 10.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,10 +34,10 @@
         "semver": "^7.3.5",
         "ts-node": "^10.5.0",
         "typescript": "^4.1.3",
-        "zwave-js": "^10.4.0"
+        "zwave-js": "^10.5.3"
       },
       "peerDependencies": {
-        "zwave-js": "^10.4.0"
+        "zwave-js": "^10.5.3"
       }
     },
     "node_modules/@alcalzone/jsonl-db": {
@@ -520,13 +520,13 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.31.1.tgz",
-      "integrity": "sha512-quaNU6z8jabmatBTDi28Wpff2yzfWIp/IU4bbi2QOtEiCNT+TQJXqlRTRMu9xLrX7YzyKCL5X2gbit/85lyWUg==",
+      "version": "7.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.34.0.tgz",
+      "integrity": "sha512-J1oxsYZX1N0tkEcaHt/uuDqk6zOnaivyampp+EvBsUMCdemjg7rwKvawlRB0ZtBEQu3HAhi8zecm03mlpWfCDw==",
       "dev": true,
       "dependencies": {
-        "@sentry/types": "7.31.1",
-        "@sentry/utils": "7.31.1",
+        "@sentry/types": "7.34.0",
+        "@sentry/utils": "7.34.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -534,21 +534,21 @@
       }
     },
     "node_modules/@sentry/core/node_modules/@sentry/types": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.31.1.tgz",
-      "integrity": "sha512-1uzr2l0AxEnxUX/S0EdmXUQ15/kDsam8Nbdw4Gai8SU764XwQgA/TTjoewVP597CDI/AHKan67Y630/Ylmkx9w==",
+      "version": "7.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.34.0.tgz",
+      "integrity": "sha512-K+OeHIrl35PSYn6Zwqe4b8WWyAJQoI5NeWxHVkM7oQTGJ1YLG4BvLsR+UiUXnKdR5krE4EDtEA5jLsDlBEyPvw==",
       "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core/node_modules/@sentry/utils": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.31.1.tgz",
-      "integrity": "sha512-ZsIPq29aNdP9q3R7qIzJhZ9WW+4DzE9g5SfGwx3UjTIxoRRBfdUJUbf7S+LKEdvCkKbyoDt6FLt5MiSJV43xBA==",
+      "version": "7.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.34.0.tgz",
+      "integrity": "sha512-VIHHXEBw0htzqxnU8A7WkXKvmsG2pZVqHlAn0H9W/yyFQtXMuP1j1i0NsjADB/3JXUKK83kTNWGzScXvp0o+Jg==",
       "dev": true,
       "dependencies": {
-        "@sentry/types": "7.31.1",
+        "@sentry/types": "7.34.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -571,14 +571,14 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.31.1.tgz",
-      "integrity": "sha512-4VzfOU1YHeoGkBQmkVXlXoXITf+1NkZEREKhdzgpVAkVjb2Tk3sMoFov4wOKWnNTTj4ka50xyaw/ZmqApgQ4Pw==",
+      "version": "7.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.34.0.tgz",
+      "integrity": "sha512-VM4XeydRdgeaNTRe8kwqYg2oNPddVyY74PlCFEFnPEN1NccycNuwiFno68kNrApeqxxLlTTmzkJy0BWo16x2Yg==",
       "dev": true,
       "dependencies": {
-        "@sentry/core": "7.31.1",
-        "@sentry/types": "7.31.1",
-        "@sentry/utils": "7.31.1",
+        "@sentry/core": "7.34.0",
+        "@sentry/types": "7.34.0",
+        "@sentry/utils": "7.34.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -589,21 +589,21 @@
       }
     },
     "node_modules/@sentry/node/node_modules/@sentry/types": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.31.1.tgz",
-      "integrity": "sha512-1uzr2l0AxEnxUX/S0EdmXUQ15/kDsam8Nbdw4Gai8SU764XwQgA/TTjoewVP597CDI/AHKan67Y630/Ylmkx9w==",
+      "version": "7.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.34.0.tgz",
+      "integrity": "sha512-K+OeHIrl35PSYn6Zwqe4b8WWyAJQoI5NeWxHVkM7oQTGJ1YLG4BvLsR+UiUXnKdR5krE4EDtEA5jLsDlBEyPvw==",
       "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/node/node_modules/@sentry/utils": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.31.1.tgz",
-      "integrity": "sha512-ZsIPq29aNdP9q3R7qIzJhZ9WW+4DzE9g5SfGwx3UjTIxoRRBfdUJUbf7S+LKEdvCkKbyoDt6FLt5MiSJV43xBA==",
+      "version": "7.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.34.0.tgz",
+      "integrity": "sha512-VIHHXEBw0htzqxnU8A7WkXKvmsG2pZVqHlAn0H9W/yyFQtXMuP1j1i0NsjADB/3JXUKK83kTNWGzScXvp0o+Jg==",
       "dev": true,
       "dependencies": {
-        "@sentry/types": "7.31.1",
+        "@sentry/types": "7.34.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1180,14 +1180,14 @@
       }
     },
     "node_modules/@zwave-js/cc": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-10.4.0.tgz",
-      "integrity": "sha512-qKisjEz2fOCCNp8LREYyRZu0pib38lqO+pnJwZs5Gjni0EnEC3A1FW470AXPUVJw2cbGtFDaYnGfTW72xeJSpg==",
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-10.5.2.tgz",
+      "integrity": "sha512-RBuAJ6cWlhZTLDDppWx6ILmqXATN9L8lyIfjSbNIzdlJ6jzJK1sW7r+rvXlcubAOPdDBEQa2UYbCJ/PEdFdoBg==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "10.4.0",
-        "@zwave-js/host": "10.4.0",
-        "@zwave-js/serial": "10.4.0",
+        "@zwave-js/core": "10.5.0",
+        "@zwave-js/host": "10.5.2",
+        "@zwave-js/serial": "10.5.2",
         "@zwave-js/shared": "10.4.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
@@ -1201,12 +1201,12 @@
       }
     },
     "node_modules/@zwave-js/config": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-10.4.0.tgz",
-      "integrity": "sha512-Z3Gc8gmgUJUwP/on/EDgobksfazOxOxfxUGHDH/jfqxsF0adFSdhSeatF9cCfh5YM+UWFYEZLgVykbKtIW9XoA==",
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-10.5.2.tgz",
+      "integrity": "sha512-nnXehRQZlOSwvKOhDuLkjwkyR2dZVaNOqwxz9UKcovclIZyXV+1V2VhAxa0BeIyidDZYV/Ma2SzT4lGckW/3WQ==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "10.4.0",
+        "@zwave-js/core": "10.5.0",
         "@zwave-js/shared": "10.4.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
@@ -1224,9 +1224,9 @@
       }
     },
     "node_modules/@zwave-js/core": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-10.4.0.tgz",
-      "integrity": "sha512-/3gKj8dzxn1T3ymiMjNPN/ficAEti9cnCVxQvjjRyqNsBe6onsN+n4Te+Ed7LuSybGH+v9G8iH29YkjjgzU66g==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-10.5.0.tgz",
+      "integrity": "sha512-l5/YwSZMMg8MeUhi8bCnS2xu1EYFO9ocY9Zl2LWXF/8xMYKqZohgxjkUg4YzbIoTyE5vGuaxVoBHqQ4iQ7xj3g==",
       "dev": true,
       "dependencies": {
         "@alcalzone/jsonl-db": "^2.5.3",
@@ -1250,13 +1250,13 @@
       }
     },
     "node_modules/@zwave-js/host": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-10.4.0.tgz",
-      "integrity": "sha512-NLL18cmaXZcbT/rQ/vdVCvRo9GQF5xYWGDxgja6zjuAR5xrsYyfyvI1lJuiOD9i9iPmTiu1XFv1PfJl54Ird3A==",
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-10.5.2.tgz",
+      "integrity": "sha512-BTbIWobUI/YYlSe35U/hDkA/zyMFtktEyLis17r/FTYZR35zcmKO/jHpwwKii/EELsxTrCJnXMh017NrhJlpKA==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/config": "10.4.0",
-        "@zwave-js/core": "10.4.0",
+        "@zwave-js/config": "10.5.2",
+        "@zwave-js/core": "10.5.0",
         "@zwave-js/shared": "10.4.0",
         "alcalzone-shared": "^4.0.8"
       },
@@ -1268,12 +1268,12 @@
       }
     },
     "node_modules/@zwave-js/nvmedit": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-10.4.0.tgz",
-      "integrity": "sha512-fxhIxRHBcDESafhdE6Qnil+IbQig+XncUMcVXm1m77/fT8Ee3QXLPbqte0O1+10KcnHdult3t9cB0hlBIk2OhA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-10.5.0.tgz",
+      "integrity": "sha512-kXTToCLTytqdLBCfVZN1HaB7F4SrW8TVO/xMmG9D3n3yMEMaSDHRXobym9kOOb5aVwVCplASQiHwY+pL4t5R9A==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "10.4.0",
+        "@zwave-js/core": "10.5.0",
         "@zwave-js/shared": "10.4.0",
         "alcalzone-shared": "^4.0.8",
         "fs-extra": "^10.1.0",
@@ -1292,15 +1292,15 @@
       }
     },
     "node_modules/@zwave-js/serial": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-10.4.0.tgz",
-      "integrity": "sha512-8NPH7MqjSpd8HeGTJYfw+bmCPpadMebpSlJsf2n/vAbMU6E8Sp1Gi3X347MzdMxDAQOzF3YaV9UBmGcRcxvfBQ==",
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-10.5.2.tgz",
+      "integrity": "sha512-IqAYBhNE+LsEVSRu2UDzoM3inV2dp3JMfIJXBN8iVa/revCXTjGWOPJkqhulj74cQX9brCuA919YQ33N9hlJwA==",
       "dev": true,
       "dependencies": {
         "@sentry/node": "^7.12.1",
         "@serialport/stream": "^10.3.0",
-        "@zwave-js/core": "10.4.0",
-        "@zwave-js/host": "10.4.0",
+        "@zwave-js/core": "10.5.0",
+        "@zwave-js/host": "10.5.2",
         "@zwave-js/shared": "10.4.0",
         "alcalzone-shared": "^4.0.8",
         "serialport": "^10.4.0",
@@ -1330,14 +1330,14 @@
       }
     },
     "node_modules/@zwave-js/testing": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-10.4.0.tgz",
-      "integrity": "sha512-5rCxp7EJXK6B8td4SdVyqmZL+4WL3p7blVLKjT3LpZXcMolOTeEEptggJ9yhmFm2pUhkOHSoE12FwroJbRObXw==",
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-10.5.2.tgz",
+      "integrity": "sha512-3Si/nerD7I9pPpgiipUZqrEJUTNeFAPnbgXG9P5mZb+uhHzbrwVVDASK9wPgjGqWx2AJffAMl2MPEknqcMEaRA==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "10.4.0",
-        "@zwave-js/host": "10.4.0",
-        "@zwave-js/serial": "10.4.0",
+        "@zwave-js/core": "10.5.0",
+        "@zwave-js/host": "10.5.2",
+        "@zwave-js/serial": "10.5.2",
         "@zwave-js/shared": "10.4.0",
         "ansi-colors": "^4.1.3"
       },
@@ -4479,9 +4479,9 @@
       }
     },
     "node_modules/zwave-js": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-10.4.0.tgz",
-      "integrity": "sha512-9eVe+7xli+KOvoyakXPMI1a5Mhkjlwi2t6Gniuyu+s6U8rOCd8NmhHvvzB2p+2KLRjuYjBRqPNA5c8qAsvC+ug==",
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-10.5.3.tgz",
+      "integrity": "sha512-Qz+5XFTYZsgYAF2KWNBsUne/Og0F8MrviASUIocRwKdhTSPoKRvj7yuSMbwPJTgNCNg01dC0mf4aQ8FvCLtPEQ==",
       "dev": true,
       "dependencies": {
         "@alcalzone/jsonl-db": "^2.5.3",
@@ -4490,14 +4490,14 @@
         "@esm2cjs/p-queue": "^7.3.0",
         "@sentry/integrations": "^7.12.1",
         "@sentry/node": "^7.12.1",
-        "@zwave-js/cc": "10.4.0",
-        "@zwave-js/config": "10.4.0",
-        "@zwave-js/core": "10.4.0",
-        "@zwave-js/host": "10.4.0",
-        "@zwave-js/nvmedit": "10.4.0",
-        "@zwave-js/serial": "10.4.0",
+        "@zwave-js/cc": "10.5.2",
+        "@zwave-js/config": "10.5.2",
+        "@zwave-js/core": "10.5.0",
+        "@zwave-js/host": "10.5.2",
+        "@zwave-js/nvmedit": "10.5.0",
+        "@zwave-js/serial": "10.5.2",
         "@zwave-js/shared": "10.4.0",
-        "@zwave-js/testing": "10.4.0",
+        "@zwave-js/testing": "10.5.2",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "execa": "^5.1.1",
@@ -4873,29 +4873,29 @@
       }
     },
     "@sentry/core": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.31.1.tgz",
-      "integrity": "sha512-quaNU6z8jabmatBTDi28Wpff2yzfWIp/IU4bbi2QOtEiCNT+TQJXqlRTRMu9xLrX7YzyKCL5X2gbit/85lyWUg==",
+      "version": "7.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.34.0.tgz",
+      "integrity": "sha512-J1oxsYZX1N0tkEcaHt/uuDqk6zOnaivyampp+EvBsUMCdemjg7rwKvawlRB0ZtBEQu3HAhi8zecm03mlpWfCDw==",
       "dev": true,
       "requires": {
-        "@sentry/types": "7.31.1",
-        "@sentry/utils": "7.31.1",
+        "@sentry/types": "7.34.0",
+        "@sentry/utils": "7.34.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
         "@sentry/types": {
-          "version": "7.31.1",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.31.1.tgz",
-          "integrity": "sha512-1uzr2l0AxEnxUX/S0EdmXUQ15/kDsam8Nbdw4Gai8SU764XwQgA/TTjoewVP597CDI/AHKan67Y630/Ylmkx9w==",
+          "version": "7.34.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.34.0.tgz",
+          "integrity": "sha512-K+OeHIrl35PSYn6Zwqe4b8WWyAJQoI5NeWxHVkM7oQTGJ1YLG4BvLsR+UiUXnKdR5krE4EDtEA5jLsDlBEyPvw==",
           "dev": true
         },
         "@sentry/utils": {
-          "version": "7.31.1",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.31.1.tgz",
-          "integrity": "sha512-ZsIPq29aNdP9q3R7qIzJhZ9WW+4DzE9g5SfGwx3UjTIxoRRBfdUJUbf7S+LKEdvCkKbyoDt6FLt5MiSJV43xBA==",
+          "version": "7.34.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.34.0.tgz",
+          "integrity": "sha512-VIHHXEBw0htzqxnU8A7WkXKvmsG2pZVqHlAn0H9W/yyFQtXMuP1j1i0NsjADB/3JXUKK83kTNWGzScXvp0o+Jg==",
           "dev": true,
           "requires": {
-            "@sentry/types": "7.31.1",
+            "@sentry/types": "7.34.0",
             "tslib": "^1.9.3"
           }
         }
@@ -4914,14 +4914,14 @@
       }
     },
     "@sentry/node": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.31.1.tgz",
-      "integrity": "sha512-4VzfOU1YHeoGkBQmkVXlXoXITf+1NkZEREKhdzgpVAkVjb2Tk3sMoFov4wOKWnNTTj4ka50xyaw/ZmqApgQ4Pw==",
+      "version": "7.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.34.0.tgz",
+      "integrity": "sha512-VM4XeydRdgeaNTRe8kwqYg2oNPddVyY74PlCFEFnPEN1NccycNuwiFno68kNrApeqxxLlTTmzkJy0BWo16x2Yg==",
       "dev": true,
       "requires": {
-        "@sentry/core": "7.31.1",
-        "@sentry/types": "7.31.1",
-        "@sentry/utils": "7.31.1",
+        "@sentry/core": "7.34.0",
+        "@sentry/types": "7.34.0",
+        "@sentry/utils": "7.34.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -4929,18 +4929,18 @@
       },
       "dependencies": {
         "@sentry/types": {
-          "version": "7.31.1",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.31.1.tgz",
-          "integrity": "sha512-1uzr2l0AxEnxUX/S0EdmXUQ15/kDsam8Nbdw4Gai8SU764XwQgA/TTjoewVP597CDI/AHKan67Y630/Ylmkx9w==",
+          "version": "7.34.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.34.0.tgz",
+          "integrity": "sha512-K+OeHIrl35PSYn6Zwqe4b8WWyAJQoI5NeWxHVkM7oQTGJ1YLG4BvLsR+UiUXnKdR5krE4EDtEA5jLsDlBEyPvw==",
           "dev": true
         },
         "@sentry/utils": {
-          "version": "7.31.1",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.31.1.tgz",
-          "integrity": "sha512-ZsIPq29aNdP9q3R7qIzJhZ9WW+4DzE9g5SfGwx3UjTIxoRRBfdUJUbf7S+LKEdvCkKbyoDt6FLt5MiSJV43xBA==",
+          "version": "7.34.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.34.0.tgz",
+          "integrity": "sha512-VIHHXEBw0htzqxnU8A7WkXKvmsG2pZVqHlAn0H9W/yyFQtXMuP1j1i0NsjADB/3JXUKK83kTNWGzScXvp0o+Jg==",
           "dev": true,
           "requires": {
-            "@sentry/types": "7.31.1",
+            "@sentry/types": "7.34.0",
             "tslib": "^1.9.3"
           }
         }
@@ -5310,14 +5310,14 @@
       }
     },
     "@zwave-js/cc": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-10.4.0.tgz",
-      "integrity": "sha512-qKisjEz2fOCCNp8LREYyRZu0pib38lqO+pnJwZs5Gjni0EnEC3A1FW470AXPUVJw2cbGtFDaYnGfTW72xeJSpg==",
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-10.5.2.tgz",
+      "integrity": "sha512-RBuAJ6cWlhZTLDDppWx6ILmqXATN9L8lyIfjSbNIzdlJ6jzJK1sW7r+rvXlcubAOPdDBEQa2UYbCJ/PEdFdoBg==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "10.4.0",
-        "@zwave-js/host": "10.4.0",
-        "@zwave-js/serial": "10.4.0",
+        "@zwave-js/core": "10.5.0",
+        "@zwave-js/host": "10.5.2",
+        "@zwave-js/serial": "10.5.2",
         "@zwave-js/shared": "10.4.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
@@ -5325,12 +5325,12 @@
       }
     },
     "@zwave-js/config": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-10.4.0.tgz",
-      "integrity": "sha512-Z3Gc8gmgUJUwP/on/EDgobksfazOxOxfxUGHDH/jfqxsF0adFSdhSeatF9cCfh5YM+UWFYEZLgVykbKtIW9XoA==",
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-10.5.2.tgz",
+      "integrity": "sha512-nnXehRQZlOSwvKOhDuLkjwkyR2dZVaNOqwxz9UKcovclIZyXV+1V2VhAxa0BeIyidDZYV/Ma2SzT4lGckW/3WQ==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "10.4.0",
+        "@zwave-js/core": "10.5.0",
         "@zwave-js/shared": "10.4.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
@@ -5342,9 +5342,9 @@
       }
     },
     "@zwave-js/core": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-10.4.0.tgz",
-      "integrity": "sha512-/3gKj8dzxn1T3ymiMjNPN/ficAEti9cnCVxQvjjRyqNsBe6onsN+n4Te+Ed7LuSybGH+v9G8iH29YkjjgzU66g==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-10.5.0.tgz",
+      "integrity": "sha512-l5/YwSZMMg8MeUhi8bCnS2xu1EYFO9ocY9Zl2LWXF/8xMYKqZohgxjkUg4YzbIoTyE5vGuaxVoBHqQ4iQ7xj3g==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.5.3",
@@ -5362,24 +5362,24 @@
       }
     },
     "@zwave-js/host": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-10.4.0.tgz",
-      "integrity": "sha512-NLL18cmaXZcbT/rQ/vdVCvRo9GQF5xYWGDxgja6zjuAR5xrsYyfyvI1lJuiOD9i9iPmTiu1XFv1PfJl54Ird3A==",
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-10.5.2.tgz",
+      "integrity": "sha512-BTbIWobUI/YYlSe35U/hDkA/zyMFtktEyLis17r/FTYZR35zcmKO/jHpwwKii/EELsxTrCJnXMh017NrhJlpKA==",
       "dev": true,
       "requires": {
-        "@zwave-js/config": "10.4.0",
-        "@zwave-js/core": "10.4.0",
+        "@zwave-js/config": "10.5.2",
+        "@zwave-js/core": "10.5.0",
         "@zwave-js/shared": "10.4.0",
         "alcalzone-shared": "^4.0.8"
       }
     },
     "@zwave-js/nvmedit": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-10.4.0.tgz",
-      "integrity": "sha512-fxhIxRHBcDESafhdE6Qnil+IbQig+XncUMcVXm1m77/fT8Ee3QXLPbqte0O1+10KcnHdult3t9cB0hlBIk2OhA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-10.5.0.tgz",
+      "integrity": "sha512-kXTToCLTytqdLBCfVZN1HaB7F4SrW8TVO/xMmG9D3n3yMEMaSDHRXobym9kOOb5aVwVCplASQiHwY+pL4t5R9A==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "10.4.0",
+        "@zwave-js/core": "10.5.0",
         "@zwave-js/shared": "10.4.0",
         "alcalzone-shared": "^4.0.8",
         "fs-extra": "^10.1.0",
@@ -5389,15 +5389,15 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-10.4.0.tgz",
-      "integrity": "sha512-8NPH7MqjSpd8HeGTJYfw+bmCPpadMebpSlJsf2n/vAbMU6E8Sp1Gi3X347MzdMxDAQOzF3YaV9UBmGcRcxvfBQ==",
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-10.5.2.tgz",
+      "integrity": "sha512-IqAYBhNE+LsEVSRu2UDzoM3inV2dp3JMfIJXBN8iVa/revCXTjGWOPJkqhulj74cQX9brCuA919YQ33N9hlJwA==",
       "dev": true,
       "requires": {
         "@sentry/node": "^7.12.1",
         "@serialport/stream": "^10.3.0",
-        "@zwave-js/core": "10.4.0",
-        "@zwave-js/host": "10.4.0",
+        "@zwave-js/core": "10.5.0",
+        "@zwave-js/host": "10.5.2",
         "@zwave-js/shared": "10.4.0",
         "alcalzone-shared": "^4.0.8",
         "serialport": "^10.4.0",
@@ -5415,14 +5415,14 @@
       }
     },
     "@zwave-js/testing": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-10.4.0.tgz",
-      "integrity": "sha512-5rCxp7EJXK6B8td4SdVyqmZL+4WL3p7blVLKjT3LpZXcMolOTeEEptggJ9yhmFm2pUhkOHSoE12FwroJbRObXw==",
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-10.5.2.tgz",
+      "integrity": "sha512-3Si/nerD7I9pPpgiipUZqrEJUTNeFAPnbgXG9P5mZb+uhHzbrwVVDASK9wPgjGqWx2AJffAMl2MPEknqcMEaRA==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "10.4.0",
-        "@zwave-js/host": "10.4.0",
-        "@zwave-js/serial": "10.4.0",
+        "@zwave-js/core": "10.5.0",
+        "@zwave-js/host": "10.5.2",
+        "@zwave-js/serial": "10.5.2",
         "@zwave-js/shared": "10.4.0",
         "ansi-colors": "^4.1.3"
       }
@@ -7699,9 +7699,9 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-10.4.0.tgz",
-      "integrity": "sha512-9eVe+7xli+KOvoyakXPMI1a5Mhkjlwi2t6Gniuyu+s6U8rOCd8NmhHvvzB2p+2KLRjuYjBRqPNA5c8qAsvC+ug==",
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-10.5.3.tgz",
+      "integrity": "sha512-Qz+5XFTYZsgYAF2KWNBsUne/Og0F8MrviASUIocRwKdhTSPoKRvj7yuSMbwPJTgNCNg01dC0mf4aQ8FvCLtPEQ==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^2.5.3",
@@ -7710,14 +7710,14 @@
         "@esm2cjs/p-queue": "^7.3.0",
         "@sentry/integrations": "^7.12.1",
         "@sentry/node": "^7.12.1",
-        "@zwave-js/cc": "10.4.0",
-        "@zwave-js/config": "10.4.0",
-        "@zwave-js/core": "10.4.0",
-        "@zwave-js/host": "10.4.0",
-        "@zwave-js/nvmedit": "10.4.0",
-        "@zwave-js/serial": "10.4.0",
+        "@zwave-js/cc": "10.5.2",
+        "@zwave-js/config": "10.5.2",
+        "@zwave-js/core": "10.5.0",
+        "@zwave-js/host": "10.5.2",
+        "@zwave-js/nvmedit": "10.5.0",
+        "@zwave-js/serial": "10.5.2",
         "@zwave-js/shared": "10.4.0",
-        "@zwave-js/testing": "10.4.0",
+        "@zwave-js/testing": "10.5.2",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "execa": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@homebridge/ciao": "^1.1.3"
   },
   "peerDependencies": {
-    "zwave-js": "^10.4.0"
+    "zwave-js": "^10.5.3"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -53,7 +53,7 @@
     "semver": "^7.3.5",
     "ts-node": "^10.5.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^10.4.0"
+    "zwave-js": "^10.5.3"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
- https://github.com/zwave-js/node-zwave-js/releases/tag/v10.5.0
- https://github.com/zwave-js/node-zwave-js/releases/tag/v10.5.1
- https://github.com/zwave-js/node-zwave-js/releases/tag/v10.5.2
- https://github.com/zwave-js/node-zwave-js/releases/tag/v10.5.3

No new features that matter, just the addition of a new utility for flashing via CLI (and bugfixes and config updates)