### PR TITLE
Bump zwave-js to 10.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@homebridge/ciao": "^1.1.3"
   },
   "peerDependencies": {
-    "zwave-js": "^10.7.0"
+    "zwave-js": "^10.10.0"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -53,7 +53,7 @@
     "semver": "^7.3.5",
     "ts-node": "^10.5.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^10.7.0"
+    "zwave-js": "^10.10.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Nothing major, just keeping up to date:
- https://github.com/zwave-js/node-zwave-js/releases/tag/v10.8.0
- https://github.com/zwave-js/node-zwave-js/releases/tag/v10.10.0