### PR TITLE
Re-add optional firmware target to node.update_firmware command

### DIFF
--- a/src/lib/node/incoming_message.ts
+++ b/src/lib/node/incoming_message.ts
@@ -59,6 +59,7 @@ export interface IncomingCommandNodeUpdateFirmware
     filename: string;
     file: string; // use base64 encoding for the file
     fileFormat?: FirmwareFileFormat;
+    firmwareTarget?: number;
   }[];
 }
 

--- a/src/lib/node/message_handler.ts
+++ b/src/lib/node/message_handler.ts
@@ -69,7 +69,7 @@ export class NodeMessageHandler {
           message.firmwareFileFormat ??
             guessFirmwareFileFormat(message.firmwareFilename, firmwareFile)
         );
-        // Defer to the target provided in the message if provided
+        // Defer to the target provided in the messaage when available
         firmware.firmwareTarget = message.target ?? firmware.firmwareTarget;
         success = await node.updateFirmware([firmware]);
         return { success };
@@ -80,7 +80,7 @@ export class NodeMessageHandler {
             file,
             update.fileFormat ?? guessFirmwareFileFormat(update.filename, file)
           );
-          // Defer to the target provided in the message if provided
+          // Defer to the target provided in the messaage when available
           firmware.firmwareTarget =
             update.firmwareTarget ?? firmware.firmwareTarget;
           return firmware;

--- a/src/lib/node/message_handler.ts
+++ b/src/lib/node/message_handler.ts
@@ -75,10 +75,13 @@ export class NodeMessageHandler {
       case NodeCommand.updateFirmware:
         const updates = message.updates.map((update) => {
           const file = Buffer.from(update.file, "base64");
-          return extractFirmware(
+          let firmware = extractFirmware(
             file,
             update.fileFormat ?? guessFirmwareFileFormat(update.filename, file)
           );
+          firmware.firmwareTarget =
+            update.firmwareTarget ?? firmware.firmwareTarget;
+          return firmware;
         });
         success = await node.updateFirmware(updates);
         return { success };


### PR DESCRIPTION
From a conversation in #devs_zwave I learned that I shouldn't have removed the target option in https://github.com/zwave-js/zwave-js-server/pull/765 so I am re-adding it