### PR TITLE
Bump zwave-js to 10.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,24 +34,24 @@
         "semver": "^7.3.5",
         "ts-node": "^10.5.0",
         "typescript": "^4.1.3",
-        "zwave-js": "^10.10.0"
+        "zwave-js": "^10.11.0"
       },
       "peerDependencies": {
-        "zwave-js": "^10.10.0"
+        "zwave-js": "^10.11.0"
       }
     },
     "node_modules/@alcalzone/jsonl-db": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@alcalzone/jsonl-db/-/jsonl-db-2.5.3.tgz",
-      "integrity": "sha512-CuQ6aoBusGex0AJWEgwXfgApdUD9YsxM9JCnim8S6Z1icO5AxecxWEiBm1a2/m2vfwA7roqg+LEHbwon9EkgRw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@alcalzone/jsonl-db/-/jsonl-db-3.1.0.tgz",
+      "integrity": "sha512-Wc1nxOyJVBF0NWrG1X7SQcb6mWWtr2i9e1cOSHQsjmnHlBYlFoj82fsP1NCZrHdXBhqQyYpdXP8ZQ8zz0iddFQ==",
       "dev": true,
       "dependencies": {
         "@alcalzone/proper-lockfile": "^4.1.3-0",
-        "alcalzone-shared": "^4.0.3",
+        "alcalzone-shared": "^4.0.8",
         "fs-extra": "^10.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@alcalzone/pak": {
@@ -529,13 +529,13 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.37.0.tgz",
-      "integrity": "sha512-2M6aZKIG/1HgfE0hobQ9tKSo6ZsyBrSQqjtQhMVFwVzZJyFw3m1AqcrB+f0myi+1ay2MMPbJ+HhYtBPR3e4EvA==",
+      "version": "7.43.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.43.0.tgz",
+      "integrity": "sha512-zvMZgEi7ptLBwDnd+xR/u4zdSe5UzS4S3ZhoemdQrn1PxsaVySD/ptyzLoGSZEABqlRxGHnQrZ78MU1hUDvKuQ==",
       "dev": true,
       "dependencies": {
-        "@sentry/types": "7.37.0",
-        "@sentry/utils": "7.37.0",
+        "@sentry/types": "7.43.0",
+        "@sentry/utils": "7.43.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -543,21 +543,21 @@
       }
     },
     "node_modules/@sentry/core/node_modules/@sentry/types": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.37.0.tgz",
-      "integrity": "sha512-p8iw5oGvWLIk7osMgXhxshUpebJD0riiuT3ihBP0DV+Gs8r0qdQ5gtcStl7Cn0D4013p4j/f3T5q85Z9ENE6fA==",
+      "version": "7.43.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.43.0.tgz",
+      "integrity": "sha512-5XxCWqYWJNoS+P6Ie2ZpUDxLRCt7FTEzmlQkCdjW6MFWOX26hAbF/wEuOTYAFKZXMIXOz0Egofik1e8v1Cg6/A==",
       "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core/node_modules/@sentry/utils": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.37.0.tgz",
-      "integrity": "sha512-CN86EKQ07+SgqfgGehMJsgrCEjc0sl1YDcj2xf9dA0Bn3ma2MTDkCyutxVcRfc2IVWfqAN1rn/L8/BH2v2+eqA==",
+      "version": "7.43.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.43.0.tgz",
+      "integrity": "sha512-f78YfMLcgNU7+suyWFCuQhQlneXXMS+egb0EFZh7iU7kANUPRX5T4b+0C+fwaPm5gA6XfGYskr4ZnzQJLOlSqg==",
       "dev": true,
       "dependencies": {
-        "@sentry/types": "7.37.0",
+        "@sentry/types": "7.43.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -580,14 +580,14 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.37.0.tgz",
-      "integrity": "sha512-ohkk5K7V3+lK1MtVVpTzqu09xcGNu9IeGK2VjjMD68deojdYrxWXINuO4ta0aE1hmg1rwAlpPebQkmXspo9zOw==",
+      "version": "7.43.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.43.0.tgz",
+      "integrity": "sha512-oXaTBq6Bk8Qwsd46hhRU2MLEnjYqWI41nPJmXyAWkDSYQTP7sUe1qM8bCUdsRpPwQh955Vq9qCRfgMbN4lEoAQ==",
       "dev": true,
       "dependencies": {
-        "@sentry/core": "7.37.0",
-        "@sentry/types": "7.37.0",
-        "@sentry/utils": "7.37.0",
+        "@sentry/core": "7.43.0",
+        "@sentry/types": "7.43.0",
+        "@sentry/utils": "7.43.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -598,21 +598,21 @@
       }
     },
     "node_modules/@sentry/node/node_modules/@sentry/types": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.37.0.tgz",
-      "integrity": "sha512-p8iw5oGvWLIk7osMgXhxshUpebJD0riiuT3ihBP0DV+Gs8r0qdQ5gtcStl7Cn0D4013p4j/f3T5q85Z9ENE6fA==",
+      "version": "7.43.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.43.0.tgz",
+      "integrity": "sha512-5XxCWqYWJNoS+P6Ie2ZpUDxLRCt7FTEzmlQkCdjW6MFWOX26hAbF/wEuOTYAFKZXMIXOz0Egofik1e8v1Cg6/A==",
       "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/node/node_modules/@sentry/utils": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.37.0.tgz",
-      "integrity": "sha512-CN86EKQ07+SgqfgGehMJsgrCEjc0sl1YDcj2xf9dA0Bn3ma2MTDkCyutxVcRfc2IVWfqAN1rn/L8/BH2v2+eqA==",
+      "version": "7.43.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.43.0.tgz",
+      "integrity": "sha512-f78YfMLcgNU7+suyWFCuQhQlneXXMS+egb0EFZh7iU7kANUPRX5T4b+0C+fwaPm5gA6XfGYskr4ZnzQJLOlSqg==",
       "dev": true,
       "dependencies": {
-        "@sentry/types": "7.37.0",
+        "@sentry/types": "7.43.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1190,15 +1190,15 @@
       }
     },
     "node_modules/@zwave-js/cc": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-10.10.0.tgz",
-      "integrity": "sha512-ZT+V5+llCZknSe5CwaVom5PpEFbFfm6pXbzS6nJ2Nt5m7//G4qExK+356qOfE7vsEz9KgIDEbDGfEtfhq/heUQ==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-10.12.0.tgz",
+      "integrity": "sha512-So6QJZ18fTcYrZcrQNYn9K1Jaq2HEV63U/XhcrSizv/wIKunGToSKuSt96Hs0JR/NwkxMZXeEtxkN0/lnLmh+w==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/host": "10.10.0",
-        "@zwave-js/serial": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/host": "10.12.0",
+        "@zwave-js/serial": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "reflect-metadata": "^0.1.13"
@@ -1211,13 +1211,13 @@
       }
     },
     "node_modules/@zwave-js/config": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-10.10.0.tgz",
-      "integrity": "sha512-nlCYS8SZol0IM66OFgOF2eFC0NRc4qreVrC2NfUTdxy3plClSOhsQeZsREyvXyxEtrhMaW5G93M6Ad7+YbIh7Q==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-10.12.0.tgz",
+      "integrity": "sha512-xJqX2alrQ+BT4f2SYuFxfkZ5/iyboz5cBI45nrXZFGXfq9Elu45xQyWsjayvPbItnltYPYH29UtVq1V7s/hHJw==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "fs-extra": "^10.1.0",
@@ -1234,13 +1234,13 @@
       }
     },
     "node_modules/@zwave-js/core": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-10.10.0.tgz",
-      "integrity": "sha512-jwejHy/HEAHTCIJJkAF+4b8F1mTK2xVLdZzdPNh4t9RBRpFH+cxuKS4DP7iEHAyDROvyOmzW//QOxZMHEmbqwg==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-10.12.0.tgz",
+      "integrity": "sha512-xonkV4fUjKFfdrZU2sp/atL5hQC7uEJs7OIfGXMzaLp8KYqgN1a5BB2G/e8GhCSLj3bQHub4PSKGi9JfrDc83A==",
       "dev": true,
       "dependencies": {
-        "@alcalzone/jsonl-db": "^2.5.3",
-        "@zwave-js/shared": "10.10.0",
+        "@alcalzone/jsonl-db": "^3.0.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "dayjs": "^1.11.5",
@@ -1260,14 +1260,14 @@
       }
     },
     "node_modules/@zwave-js/host": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-10.10.0.tgz",
-      "integrity": "sha512-SrbfE3um8S1lFhW9WaZcbIIzqCirB0ej6U64azhxSQLRWDj0mbkqso1FZvbqzOgT67HTFejiICDe6MqVnl2beA==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-10.12.0.tgz",
+      "integrity": "sha512-tCSStxymrFNNmjgUk905uzrBZ7xvC+eSJ0yztxYgIgeNNfRQ0mQADJJEO+FYbyWMdwx1FkByQP87EPDLIchWdg==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/config": "10.10.0",
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/config": "10.12.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8"
       },
       "engines": {
@@ -1278,13 +1278,13 @@
       }
     },
     "node_modules/@zwave-js/nvmedit": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-10.10.0.tgz",
-      "integrity": "sha512-EGSXNUptfwQPONtrZPkYkV3wefaKrheEx2GheH11L9v4Bg1KfxVMLJh92p9c0/sGZTayZnAR0q5Pt41BeuMhBA==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-10.12.0.tgz",
+      "integrity": "sha512-mqq8dBKe3ZLUaMzI/4t78w3/wKWwjpfSDs02c4bVbhJvKn3WuX1xgSgpY99qA1LSqCMG3VE3wQeQk/jwArKxqw==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "fs-extra": "^10.1.0",
         "reflect-metadata": "^0.1.13",
@@ -1302,16 +1302,16 @@
       }
     },
     "node_modules/@zwave-js/serial": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-10.10.0.tgz",
-      "integrity": "sha512-3Bp9lR3uojiEyZV6wtj8RDijRDhcGPhK3xu0wQZ2OEYZOKuGyGB1XNpVaRhowj26UQ2e6ztcz8S/tr8poNRDXA==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-10.12.0.tgz",
+      "integrity": "sha512-FackmvPXNfLX/0eePyCYvud4p9r+6aP2E9EJDzWwg4CuCquW9R/HSPY1d/7Hfh/qAv2n6U9vN3xVPqdCR6YqEQ==",
       "dev": true,
       "dependencies": {
         "@sentry/node": "^7.12.1",
         "@serialport/stream": "^10.3.0",
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/host": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/host": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "serialport": "^10.4.0",
         "winston": "^3.8.2"
@@ -1324,9 +1324,9 @@
       }
     },
     "node_modules/@zwave-js/shared": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-10.10.0.tgz",
-      "integrity": "sha512-UOEyaQ60nRO9zWlsOyK3prYZCUtjfbXNPd/mZSzWrWeZcNzKcU5VdZGHHJnbCDf3wS0zyOhB66afBlY7O0RpuQ==",
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-10.11.1.tgz",
+      "integrity": "sha512-lAxZ1qPkZB4Kl4lMAUVIqMcdTLW5ZAdKUKYOVGXpdfOdXkavhtLYbjdW5kdsjU7R9fwB7lO1BRooGsC8m2L/gQ==",
       "dev": true,
       "dependencies": {
         "alcalzone-shared": "^4.0.8",
@@ -1340,15 +1340,15 @@
       }
     },
     "node_modules/@zwave-js/testing": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-10.10.0.tgz",
-      "integrity": "sha512-VylUNmdrGMVaUFOvFqZuQGa9fLmZ6HPhrgLHcECbn7YBjgk7kz2Ha+irrsfny73zYT0t/BtYlZl3M54I2S5ahQ==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-10.12.0.tgz",
+      "integrity": "sha512-BCKuGJVahBsmVfXuuE+ujs0ATL7ZUuGtjWcGVF+BJj/8RDrCn68kuG6SNV5VuFWTF8e+IZ51VHcYo/dDXbuHNQ==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/host": "10.10.0",
-        "@zwave-js/serial": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/host": "10.12.0",
+        "@zwave-js/serial": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "ansi-colors": "^4.1.3"
       },
       "engines": {
@@ -3681,9 +3681,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
@@ -4455,9 +4455,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
@@ -4503,25 +4503,25 @@
       }
     },
     "node_modules/zwave-js": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-10.10.0.tgz",
-      "integrity": "sha512-mirnbCz9egAZebFDgycnkxnqAPeZRlWE0t0sH23DxkXWsQMZI+L1qHWHZJUm3+1SDLmOS7pCZk+9cwNSEWGhrA==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-10.12.0.tgz",
+      "integrity": "sha512-50kbN1P5YQUutaMCXL0UJd73diRfhlIV2gFX46les8qnyrHH23C1MQcG1Zmadk820gcx4qgoZhNnDSSFx1cYdw==",
       "dev": true,
       "dependencies": {
-        "@alcalzone/jsonl-db": "^2.5.3",
+        "@alcalzone/jsonl-db": "^3.0.0",
         "@alcalzone/pak": "^0.8.1",
         "@esm2cjs/got": "^12.5.3",
         "@esm2cjs/p-queue": "^7.3.0",
         "@sentry/integrations": "^7.12.1",
         "@sentry/node": "^7.12.1",
-        "@zwave-js/cc": "10.10.0",
-        "@zwave-js/config": "10.10.0",
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/host": "10.10.0",
-        "@zwave-js/nvmedit": "10.10.0",
-        "@zwave-js/serial": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
-        "@zwave-js/testing": "10.10.0",
+        "@zwave-js/cc": "10.12.0",
+        "@zwave-js/config": "10.12.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/host": "10.12.0",
+        "@zwave-js/nvmedit": "10.12.0",
+        "@zwave-js/serial": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
+        "@zwave-js/testing": "10.12.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "execa": "^5.1.1",
@@ -4544,13 +4544,13 @@
   },
   "dependencies": {
     "@alcalzone/jsonl-db": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@alcalzone/jsonl-db/-/jsonl-db-2.5.3.tgz",
-      "integrity": "sha512-CuQ6aoBusGex0AJWEgwXfgApdUD9YsxM9JCnim8S6Z1icO5AxecxWEiBm1a2/m2vfwA7roqg+LEHbwon9EkgRw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@alcalzone/jsonl-db/-/jsonl-db-3.1.0.tgz",
+      "integrity": "sha512-Wc1nxOyJVBF0NWrG1X7SQcb6mWWtr2i9e1cOSHQsjmnHlBYlFoj82fsP1NCZrHdXBhqQyYpdXP8ZQ8zz0iddFQ==",
       "dev": true,
       "requires": {
         "@alcalzone/proper-lockfile": "^4.1.3-0",
-        "alcalzone-shared": "^4.0.3",
+        "alcalzone-shared": "^4.0.8",
         "fs-extra": "^10.1.0"
       }
     },
@@ -4903,29 +4903,29 @@
       }
     },
     "@sentry/core": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.37.0.tgz",
-      "integrity": "sha512-2M6aZKIG/1HgfE0hobQ9tKSo6ZsyBrSQqjtQhMVFwVzZJyFw3m1AqcrB+f0myi+1ay2MMPbJ+HhYtBPR3e4EvA==",
+      "version": "7.43.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.43.0.tgz",
+      "integrity": "sha512-zvMZgEi7ptLBwDnd+xR/u4zdSe5UzS4S3ZhoemdQrn1PxsaVySD/ptyzLoGSZEABqlRxGHnQrZ78MU1hUDvKuQ==",
       "dev": true,
       "requires": {
-        "@sentry/types": "7.37.0",
-        "@sentry/utils": "7.37.0",
+        "@sentry/types": "7.43.0",
+        "@sentry/utils": "7.43.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
         "@sentry/types": {
-          "version": "7.37.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.37.0.tgz",
-          "integrity": "sha512-p8iw5oGvWLIk7osMgXhxshUpebJD0riiuT3ihBP0DV+Gs8r0qdQ5gtcStl7Cn0D4013p4j/f3T5q85Z9ENE6fA==",
+          "version": "7.43.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.43.0.tgz",
+          "integrity": "sha512-5XxCWqYWJNoS+P6Ie2ZpUDxLRCt7FTEzmlQkCdjW6MFWOX26hAbF/wEuOTYAFKZXMIXOz0Egofik1e8v1Cg6/A==",
           "dev": true
         },
         "@sentry/utils": {
-          "version": "7.37.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.37.0.tgz",
-          "integrity": "sha512-CN86EKQ07+SgqfgGehMJsgrCEjc0sl1YDcj2xf9dA0Bn3ma2MTDkCyutxVcRfc2IVWfqAN1rn/L8/BH2v2+eqA==",
+          "version": "7.43.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.43.0.tgz",
+          "integrity": "sha512-f78YfMLcgNU7+suyWFCuQhQlneXXMS+egb0EFZh7iU7kANUPRX5T4b+0C+fwaPm5gA6XfGYskr4ZnzQJLOlSqg==",
           "dev": true,
           "requires": {
-            "@sentry/types": "7.37.0",
+            "@sentry/types": "7.43.0",
             "tslib": "^1.9.3"
           }
         }
@@ -4944,14 +4944,14 @@
       }
     },
     "@sentry/node": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.37.0.tgz",
-      "integrity": "sha512-ohkk5K7V3+lK1MtVVpTzqu09xcGNu9IeGK2VjjMD68deojdYrxWXINuO4ta0aE1hmg1rwAlpPebQkmXspo9zOw==",
+      "version": "7.43.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.43.0.tgz",
+      "integrity": "sha512-oXaTBq6Bk8Qwsd46hhRU2MLEnjYqWI41nPJmXyAWkDSYQTP7sUe1qM8bCUdsRpPwQh955Vq9qCRfgMbN4lEoAQ==",
       "dev": true,
       "requires": {
-        "@sentry/core": "7.37.0",
-        "@sentry/types": "7.37.0",
-        "@sentry/utils": "7.37.0",
+        "@sentry/core": "7.43.0",
+        "@sentry/types": "7.43.0",
+        "@sentry/utils": "7.43.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -4959,18 +4959,18 @@
       },
       "dependencies": {
         "@sentry/types": {
-          "version": "7.37.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.37.0.tgz",
-          "integrity": "sha512-p8iw5oGvWLIk7osMgXhxshUpebJD0riiuT3ihBP0DV+Gs8r0qdQ5gtcStl7Cn0D4013p4j/f3T5q85Z9ENE6fA==",
+          "version": "7.43.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.43.0.tgz",
+          "integrity": "sha512-5XxCWqYWJNoS+P6Ie2ZpUDxLRCt7FTEzmlQkCdjW6MFWOX26hAbF/wEuOTYAFKZXMIXOz0Egofik1e8v1Cg6/A==",
           "dev": true
         },
         "@sentry/utils": {
-          "version": "7.37.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.37.0.tgz",
-          "integrity": "sha512-CN86EKQ07+SgqfgGehMJsgrCEjc0sl1YDcj2xf9dA0Bn3ma2MTDkCyutxVcRfc2IVWfqAN1rn/L8/BH2v2+eqA==",
+          "version": "7.43.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.43.0.tgz",
+          "integrity": "sha512-f78YfMLcgNU7+suyWFCuQhQlneXXMS+egb0EFZh7iU7kANUPRX5T4b+0C+fwaPm5gA6XfGYskr4ZnzQJLOlSqg==",
           "dev": true,
           "requires": {
-            "@sentry/types": "7.37.0",
+            "@sentry/types": "7.43.0",
             "tslib": "^1.9.3"
           }
         }
@@ -5341,28 +5341,28 @@
       }
     },
     "@zwave-js/cc": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-10.10.0.tgz",
-      "integrity": "sha512-ZT+V5+llCZknSe5CwaVom5PpEFbFfm6pXbzS6nJ2Nt5m7//G4qExK+356qOfE7vsEz9KgIDEbDGfEtfhq/heUQ==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-10.12.0.tgz",
+      "integrity": "sha512-So6QJZ18fTcYrZcrQNYn9K1Jaq2HEV63U/XhcrSizv/wIKunGToSKuSt96Hs0JR/NwkxMZXeEtxkN0/lnLmh+w==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/host": "10.10.0",
-        "@zwave-js/serial": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/host": "10.12.0",
+        "@zwave-js/serial": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "reflect-metadata": "^0.1.13"
       }
     },
     "@zwave-js/config": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-10.10.0.tgz",
-      "integrity": "sha512-nlCYS8SZol0IM66OFgOF2eFC0NRc4qreVrC2NfUTdxy3plClSOhsQeZsREyvXyxEtrhMaW5G93M6Ad7+YbIh7Q==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-10.12.0.tgz",
+      "integrity": "sha512-xJqX2alrQ+BT4f2SYuFxfkZ5/iyboz5cBI45nrXZFGXfq9Elu45xQyWsjayvPbItnltYPYH29UtVq1V7s/hHJw==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "fs-extra": "^10.1.0",
@@ -5373,13 +5373,13 @@
       }
     },
     "@zwave-js/core": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-10.10.0.tgz",
-      "integrity": "sha512-jwejHy/HEAHTCIJJkAF+4b8F1mTK2xVLdZzdPNh4t9RBRpFH+cxuKS4DP7iEHAyDROvyOmzW//QOxZMHEmbqwg==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-10.12.0.tgz",
+      "integrity": "sha512-xonkV4fUjKFfdrZU2sp/atL5hQC7uEJs7OIfGXMzaLp8KYqgN1a5BB2G/e8GhCSLj3bQHub4PSKGi9JfrDc83A==",
       "dev": true,
       "requires": {
-        "@alcalzone/jsonl-db": "^2.5.3",
-        "@zwave-js/shared": "10.10.0",
+        "@alcalzone/jsonl-db": "^3.0.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "dayjs": "^1.11.5",
@@ -5393,25 +5393,25 @@
       }
     },
     "@zwave-js/host": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-10.10.0.tgz",
-      "integrity": "sha512-SrbfE3um8S1lFhW9WaZcbIIzqCirB0ej6U64azhxSQLRWDj0mbkqso1FZvbqzOgT67HTFejiICDe6MqVnl2beA==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-10.12.0.tgz",
+      "integrity": "sha512-tCSStxymrFNNmjgUk905uzrBZ7xvC+eSJ0yztxYgIgeNNfRQ0mQADJJEO+FYbyWMdwx1FkByQP87EPDLIchWdg==",
       "dev": true,
       "requires": {
-        "@zwave-js/config": "10.10.0",
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/config": "10.12.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8"
       }
     },
     "@zwave-js/nvmedit": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-10.10.0.tgz",
-      "integrity": "sha512-EGSXNUptfwQPONtrZPkYkV3wefaKrheEx2GheH11L9v4Bg1KfxVMLJh92p9c0/sGZTayZnAR0q5Pt41BeuMhBA==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-10.12.0.tgz",
+      "integrity": "sha512-mqq8dBKe3ZLUaMzI/4t78w3/wKWwjpfSDs02c4bVbhJvKn3WuX1xgSgpY99qA1LSqCMG3VE3wQeQk/jwArKxqw==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "fs-extra": "^10.1.0",
         "reflect-metadata": "^0.1.13",
@@ -5420,25 +5420,25 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-10.10.0.tgz",
-      "integrity": "sha512-3Bp9lR3uojiEyZV6wtj8RDijRDhcGPhK3xu0wQZ2OEYZOKuGyGB1XNpVaRhowj26UQ2e6ztcz8S/tr8poNRDXA==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-10.12.0.tgz",
+      "integrity": "sha512-FackmvPXNfLX/0eePyCYvud4p9r+6aP2E9EJDzWwg4CuCquW9R/HSPY1d/7Hfh/qAv2n6U9vN3xVPqdCR6YqEQ==",
       "dev": true,
       "requires": {
         "@sentry/node": "^7.12.1",
         "@serialport/stream": "^10.3.0",
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/host": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/host": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "serialport": "^10.4.0",
         "winston": "^3.8.2"
       }
     },
     "@zwave-js/shared": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-10.10.0.tgz",
-      "integrity": "sha512-UOEyaQ60nRO9zWlsOyK3prYZCUtjfbXNPd/mZSzWrWeZcNzKcU5VdZGHHJnbCDf3wS0zyOhB66afBlY7O0RpuQ==",
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-10.11.1.tgz",
+      "integrity": "sha512-lAxZ1qPkZB4Kl4lMAUVIqMcdTLW5ZAdKUKYOVGXpdfOdXkavhtLYbjdW5kdsjU7R9fwB7lO1BRooGsC8m2L/gQ==",
       "dev": true,
       "requires": {
         "alcalzone-shared": "^4.0.8",
@@ -5446,15 +5446,15 @@
       }
     },
     "@zwave-js/testing": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-10.10.0.tgz",
-      "integrity": "sha512-VylUNmdrGMVaUFOvFqZuQGa9fLmZ6HPhrgLHcECbn7YBjgk7kz2Ha+irrsfny73zYT0t/BtYlZl3M54I2S5ahQ==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-10.12.0.tgz",
+      "integrity": "sha512-BCKuGJVahBsmVfXuuE+ujs0ATL7ZUuGtjWcGVF+BJj/8RDrCn68kuG6SNV5VuFWTF8e+IZ51VHcYo/dDXbuHNQ==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/host": "10.10.0",
-        "@zwave-js/serial": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/host": "10.12.0",
+        "@zwave-js/serial": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "ansi-colors": "^4.1.3"
       }
     },
@@ -7166,9 +7166,9 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -7705,9 +7705,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
       "requires": {
         "cliui": "^8.0.1",
@@ -7738,25 +7738,25 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-10.10.0.tgz",
-      "integrity": "sha512-mirnbCz9egAZebFDgycnkxnqAPeZRlWE0t0sH23DxkXWsQMZI+L1qHWHZJUm3+1SDLmOS7pCZk+9cwNSEWGhrA==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-10.12.0.tgz",
+      "integrity": "sha512-50kbN1P5YQUutaMCXL0UJd73diRfhlIV2gFX46les8qnyrHH23C1MQcG1Zmadk820gcx4qgoZhNnDSSFx1cYdw==",
       "dev": true,
       "requires": {
-        "@alcalzone/jsonl-db": "^2.5.3",
+        "@alcalzone/jsonl-db": "^3.0.0",
         "@alcalzone/pak": "^0.8.1",
         "@esm2cjs/got": "^12.5.3",
         "@esm2cjs/p-queue": "^7.3.0",
         "@sentry/integrations": "^7.12.1",
         "@sentry/node": "^7.12.1",
-        "@zwave-js/cc": "10.10.0",
-        "@zwave-js/config": "10.10.0",
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/host": "10.10.0",
-        "@zwave-js/nvmedit": "10.10.0",
-        "@zwave-js/serial": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
-        "@zwave-js/testing": "10.10.0",
+        "@zwave-js/cc": "10.12.0",
+        "@zwave-js/config": "10.12.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/host": "10.12.0",
+        "@zwave-js/nvmedit": "10.12.0",
+        "@zwave-js/serial": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
+        "@zwave-js/testing": "10.12.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "execa": "^5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,10 +34,10 @@
         "semver": "^7.3.5",
         "ts-node": "^10.5.0",
         "typescript": "^4.1.3",
-        "zwave-js": "^10.11.0"
+        "zwave-js": "^10.11.1"
       },
       "peerDependencies": {
-        "zwave-js": "^10.11.0"
+        "zwave-js": "^10.11.1"
       }
     },
     "node_modules/@alcalzone/jsonl-db": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@homebridge/ciao": "^1.1.3"
   },
   "peerDependencies": {
-    "zwave-js": "^10.10.0"
+    "zwave-js": "^10.11.0"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -53,7 +53,7 @@
     "semver": "^7.3.5",
     "ts-node": "^10.5.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^10.10.0"
+    "zwave-js": "^10.11.0"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@homebridge/ciao": "^1.1.3"
   },
   "peerDependencies": {
-    "zwave-js": "^10.11.0"
+    "zwave-js": "^10.11.1"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -53,7 +53,7 @@
     "semver": "^7.3.5",
     "ts-node": "^10.5.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^10.11.0"
+    "zwave-js": "^10.11.1"
   },
   "husky": {
     "hooks": {

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -4,7 +4,7 @@ export const version = require("../../package.json").version;
 export const minSchemaVersion = 0;
 
 // maximal/current schema version the server supports
-export const maxSchemaVersion = 26;
+export const maxSchemaVersion = 27;
 
 export const applicationName = "zwave-js-server";
 export const dnssdServiceType = applicationName;

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -170,7 +170,7 @@ interface ValueState extends TranslatedValueID {
   value?: any;
 }
 
-interface MetadataState {
+interface MetadataState0 {
   type: ValueType;
   default?: any;
   readable: boolean;
@@ -187,6 +187,13 @@ interface MetadataState {
   states?: Record<number, string>;
   unit?: string;
 }
+
+interface MetadataState1 extends MetadataState0 {
+  stateful?: boolean;
+  secret?: boolean;
+}
+
+type MetadataState = MetadataState0 | MetadataState1;
 
 interface ConfigurationMetadataState {
   type: ValueType;
@@ -441,7 +448,7 @@ export const dumpMetadata = (
     | ValueMetadataString,
   schemaVersion: number
 ): MetadataState => {
-  let newMetadata: MetadataState = {
+  let newMetadata0: MetadataState0 = {
     type: metadata.type,
     default: metadata.default,
     readable: metadata.readable,
@@ -453,38 +460,45 @@ export const dumpMetadata = (
   };
 
   if ("min" in metadata) {
-    newMetadata.min = metadata.min;
+    newMetadata0.min = metadata.min;
   }
 
   if ("max" in metadata) {
-    newMetadata.max = metadata.max;
+    newMetadata0.max = metadata.max;
   }
 
   if ("minLength" in metadata) {
-    newMetadata.minLength = metadata.minLength;
+    newMetadata0.minLength = metadata.minLength;
   }
 
   if ("maxLength" in metadata) {
-    newMetadata.maxLength = metadata.maxLength;
+    newMetadata0.maxLength = metadata.maxLength;
   }
 
   if ("steps" in metadata) {
-    newMetadata.steps = metadata.steps;
+    newMetadata0.steps = metadata.steps;
   }
 
   if ("states" in metadata) {
-    newMetadata.states = { ...metadata.states };
+    newMetadata0.states = { ...metadata.states };
   }
 
   if ("unit" in metadata) {
-    newMetadata.unit = metadata.unit;
+    newMetadata0.unit = metadata.unit;
   }
 
-  if (schemaVersion < 2 && newMetadata.type === "buffer") {
-    newMetadata.type = "string";
+  if (schemaVersion < 2 && newMetadata0.type === "buffer") {
+    newMetadata0.type = "string";
   }
 
-  return newMetadata;
+  if (schemaVersion < 27) {
+    return newMetadata0;
+  }
+
+  const newMetadata1 = newMetadata0 as MetadataState1;
+  newMetadata1.stateful = metadata.stateful;
+  newMetadata1.secret = metadata.secret;
+  return newMetadata1;
 };
 
 export const dumpNode = (node: ZWaveNode, schemaVersion: number): NodeState => {


### PR DESCRIPTION
- https://github.com/zwave-js/node-zwave-js/releases/tag/v10.11.0
- https://github.com/zwave-js/node-zwave-js/releases/tag/v10.11.1

We are not adding S2 multicast support yet per a conversation with @AlCalzone about making it easier for applications consuming zwave-js to leverage S2 multicast (added a [ticket](https://github.com/zwave-js/zwave-js-server/issues/894) to track this so we don't forget, corresponding zwave-js PR: https://github.com/zwave-js/node-zwave-js/pull/5593)