### PR TITLE
Bump zwave-js to 10.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,17 @@ interface {
 }
 ```
 
+#### [Shutdown](https://zwave-js.github.io/node-zwave-js/#/api/node?id=shutdown)
+
+[compatible with schema version: 27+]
+
+```ts
+interface {
+  messageId: string;
+  command: "driver.shutdown";
+}
+```
+
 #### [Perform a hard reset on the controller](https://zwave-js.github.io/node-zwave-js/#/api/driver?id=hardreset)
 
 [compatible with schema version: 25+]
@@ -783,6 +794,24 @@ interface {
   messageId: string;
   nodeId: number;
   command: "node.interview";
+}
+```
+
+#### [Get value timestamp](https://zwave-js.github.io/node-zwave-js/#/api/node?id=getvaluetimestamp)
+
+[compatible with schema version: 27+]
+
+```ts
+interface {
+  messageId: string;
+  command: "node.get_value_timestamp";
+  nodeId: number;
+  valueId: {
+    commandClass: CommandClasses;
+    endpoint?: number;
+    property: string | number;
+    propertyKey?: string | number;
+  };
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,24 +34,24 @@
         "semver": "^7.3.5",
         "ts-node": "^10.5.0",
         "typescript": "^4.1.3",
-        "zwave-js": "^10.10.0"
+        "zwave-js": "^10.12.0"
       },
       "peerDependencies": {
-        "zwave-js": "^10.10.0"
+        "zwave-js": "^10.12.0"
       }
     },
     "node_modules/@alcalzone/jsonl-db": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@alcalzone/jsonl-db/-/jsonl-db-2.5.3.tgz",
-      "integrity": "sha512-CuQ6aoBusGex0AJWEgwXfgApdUD9YsxM9JCnim8S6Z1icO5AxecxWEiBm1a2/m2vfwA7roqg+LEHbwon9EkgRw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@alcalzone/jsonl-db/-/jsonl-db-3.1.0.tgz",
+      "integrity": "sha512-Wc1nxOyJVBF0NWrG1X7SQcb6mWWtr2i9e1cOSHQsjmnHlBYlFoj82fsP1NCZrHdXBhqQyYpdXP8ZQ8zz0iddFQ==",
       "dev": true,
       "dependencies": {
         "@alcalzone/proper-lockfile": "^4.1.3-0",
-        "alcalzone-shared": "^4.0.3",
+        "alcalzone-shared": "^4.0.8",
         "fs-extra": "^10.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@alcalzone/pak": {
@@ -529,13 +529,13 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.37.0.tgz",
-      "integrity": "sha512-2M6aZKIG/1HgfE0hobQ9tKSo6ZsyBrSQqjtQhMVFwVzZJyFw3m1AqcrB+f0myi+1ay2MMPbJ+HhYtBPR3e4EvA==",
+      "version": "7.44.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.44.1.tgz",
+      "integrity": "sha512-MiDQ7cGPrWMvvnU1pszSNak4DuH7RnPS/WLVKPJDBh1paozA9bPaxRRfJu0BGtw0BV1pRoTP2CQyp0AHdNaHow==",
       "dev": true,
       "dependencies": {
-        "@sentry/types": "7.37.0",
-        "@sentry/utils": "7.37.0",
+        "@sentry/types": "7.44.1",
+        "@sentry/utils": "7.44.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -543,21 +543,21 @@
       }
     },
     "node_modules/@sentry/core/node_modules/@sentry/types": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.37.0.tgz",
-      "integrity": "sha512-p8iw5oGvWLIk7osMgXhxshUpebJD0riiuT3ihBP0DV+Gs8r0qdQ5gtcStl7Cn0D4013p4j/f3T5q85Z9ENE6fA==",
+      "version": "7.44.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.44.1.tgz",
+      "integrity": "sha512-g0vlu7EdphUv7x0p/r1t7kjh1kNCoSMmK2G6FQCfGH2cr1AMcOAKF5iFxTN2dv0Ap3glLQPgid0bRyqcQAlCBw==",
       "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core/node_modules/@sentry/utils": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.37.0.tgz",
-      "integrity": "sha512-CN86EKQ07+SgqfgGehMJsgrCEjc0sl1YDcj2xf9dA0Bn3ma2MTDkCyutxVcRfc2IVWfqAN1rn/L8/BH2v2+eqA==",
+      "version": "7.44.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.44.1.tgz",
+      "integrity": "sha512-KfgfyurxBMFUBBPmYUPH2L46wT1nf5CbBq1wP/7D1p3EKwspb13ubK7VbxC779+JeSHqtGNOeWfY1jl1/8XBYg==",
       "dev": true,
       "dependencies": {
-        "@sentry/types": "7.37.0",
+        "@sentry/types": "7.44.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -580,14 +580,14 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.37.0.tgz",
-      "integrity": "sha512-ohkk5K7V3+lK1MtVVpTzqu09xcGNu9IeGK2VjjMD68deojdYrxWXINuO4ta0aE1hmg1rwAlpPebQkmXspo9zOw==",
+      "version": "7.44.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.44.1.tgz",
+      "integrity": "sha512-ISmmrN37m7acLWKLDdLynaIvdMI+Mu2KjVmunz68cnYOt/+DlZnElBxBvpAbVauJ4tRqqqlrbCpKCOIWLtJrvQ==",
       "dev": true,
       "dependencies": {
-        "@sentry/core": "7.37.0",
-        "@sentry/types": "7.37.0",
-        "@sentry/utils": "7.37.0",
+        "@sentry/core": "7.44.1",
+        "@sentry/types": "7.44.1",
+        "@sentry/utils": "7.44.1",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -598,21 +598,21 @@
       }
     },
     "node_modules/@sentry/node/node_modules/@sentry/types": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.37.0.tgz",
-      "integrity": "sha512-p8iw5oGvWLIk7osMgXhxshUpebJD0riiuT3ihBP0DV+Gs8r0qdQ5gtcStl7Cn0D4013p4j/f3T5q85Z9ENE6fA==",
+      "version": "7.44.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.44.1.tgz",
+      "integrity": "sha512-g0vlu7EdphUv7x0p/r1t7kjh1kNCoSMmK2G6FQCfGH2cr1AMcOAKF5iFxTN2dv0Ap3glLQPgid0bRyqcQAlCBw==",
       "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/node/node_modules/@sentry/utils": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.37.0.tgz",
-      "integrity": "sha512-CN86EKQ07+SgqfgGehMJsgrCEjc0sl1YDcj2xf9dA0Bn3ma2MTDkCyutxVcRfc2IVWfqAN1rn/L8/BH2v2+eqA==",
+      "version": "7.44.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.44.1.tgz",
+      "integrity": "sha512-KfgfyurxBMFUBBPmYUPH2L46wT1nf5CbBq1wP/7D1p3EKwspb13ubK7VbxC779+JeSHqtGNOeWfY1jl1/8XBYg==",
       "dev": true,
       "dependencies": {
-        "@sentry/types": "7.37.0",
+        "@sentry/types": "7.44.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1190,15 +1190,15 @@
       }
     },
     "node_modules/@zwave-js/cc": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-10.10.0.tgz",
-      "integrity": "sha512-ZT+V5+llCZknSe5CwaVom5PpEFbFfm6pXbzS6nJ2Nt5m7//G4qExK+356qOfE7vsEz9KgIDEbDGfEtfhq/heUQ==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-10.12.0.tgz",
+      "integrity": "sha512-So6QJZ18fTcYrZcrQNYn9K1Jaq2HEV63U/XhcrSizv/wIKunGToSKuSt96Hs0JR/NwkxMZXeEtxkN0/lnLmh+w==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/host": "10.10.0",
-        "@zwave-js/serial": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/host": "10.12.0",
+        "@zwave-js/serial": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "reflect-metadata": "^0.1.13"
@@ -1211,13 +1211,13 @@
       }
     },
     "node_modules/@zwave-js/config": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-10.10.0.tgz",
-      "integrity": "sha512-nlCYS8SZol0IM66OFgOF2eFC0NRc4qreVrC2NfUTdxy3plClSOhsQeZsREyvXyxEtrhMaW5G93M6Ad7+YbIh7Q==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-10.12.0.tgz",
+      "integrity": "sha512-xJqX2alrQ+BT4f2SYuFxfkZ5/iyboz5cBI45nrXZFGXfq9Elu45xQyWsjayvPbItnltYPYH29UtVq1V7s/hHJw==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "fs-extra": "^10.1.0",
@@ -1234,13 +1234,13 @@
       }
     },
     "node_modules/@zwave-js/core": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-10.10.0.tgz",
-      "integrity": "sha512-jwejHy/HEAHTCIJJkAF+4b8F1mTK2xVLdZzdPNh4t9RBRpFH+cxuKS4DP7iEHAyDROvyOmzW//QOxZMHEmbqwg==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-10.12.0.tgz",
+      "integrity": "sha512-xonkV4fUjKFfdrZU2sp/atL5hQC7uEJs7OIfGXMzaLp8KYqgN1a5BB2G/e8GhCSLj3bQHub4PSKGi9JfrDc83A==",
       "dev": true,
       "dependencies": {
-        "@alcalzone/jsonl-db": "^2.5.3",
-        "@zwave-js/shared": "10.10.0",
+        "@alcalzone/jsonl-db": "^3.0.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "dayjs": "^1.11.5",
@@ -1260,14 +1260,14 @@
       }
     },
     "node_modules/@zwave-js/host": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-10.10.0.tgz",
-      "integrity": "sha512-SrbfE3um8S1lFhW9WaZcbIIzqCirB0ej6U64azhxSQLRWDj0mbkqso1FZvbqzOgT67HTFejiICDe6MqVnl2beA==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-10.12.0.tgz",
+      "integrity": "sha512-tCSStxymrFNNmjgUk905uzrBZ7xvC+eSJ0yztxYgIgeNNfRQ0mQADJJEO+FYbyWMdwx1FkByQP87EPDLIchWdg==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/config": "10.10.0",
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/config": "10.12.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8"
       },
       "engines": {
@@ -1278,13 +1278,13 @@
       }
     },
     "node_modules/@zwave-js/nvmedit": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-10.10.0.tgz",
-      "integrity": "sha512-EGSXNUptfwQPONtrZPkYkV3wefaKrheEx2GheH11L9v4Bg1KfxVMLJh92p9c0/sGZTayZnAR0q5Pt41BeuMhBA==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-10.12.0.tgz",
+      "integrity": "sha512-mqq8dBKe3ZLUaMzI/4t78w3/wKWwjpfSDs02c4bVbhJvKn3WuX1xgSgpY99qA1LSqCMG3VE3wQeQk/jwArKxqw==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "fs-extra": "^10.1.0",
         "reflect-metadata": "^0.1.13",
@@ -1302,16 +1302,16 @@
       }
     },
     "node_modules/@zwave-js/serial": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-10.10.0.tgz",
-      "integrity": "sha512-3Bp9lR3uojiEyZV6wtj8RDijRDhcGPhK3xu0wQZ2OEYZOKuGyGB1XNpVaRhowj26UQ2e6ztcz8S/tr8poNRDXA==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-10.12.0.tgz",
+      "integrity": "sha512-FackmvPXNfLX/0eePyCYvud4p9r+6aP2E9EJDzWwg4CuCquW9R/HSPY1d/7Hfh/qAv2n6U9vN3xVPqdCR6YqEQ==",
       "dev": true,
       "dependencies": {
         "@sentry/node": "^7.12.1",
         "@serialport/stream": "^10.3.0",
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/host": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/host": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "serialport": "^10.4.0",
         "winston": "^3.8.2"
@@ -1324,9 +1324,9 @@
       }
     },
     "node_modules/@zwave-js/shared": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-10.10.0.tgz",
-      "integrity": "sha512-UOEyaQ60nRO9zWlsOyK3prYZCUtjfbXNPd/mZSzWrWeZcNzKcU5VdZGHHJnbCDf3wS0zyOhB66afBlY7O0RpuQ==",
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-10.11.1.tgz",
+      "integrity": "sha512-lAxZ1qPkZB4Kl4lMAUVIqMcdTLW5ZAdKUKYOVGXpdfOdXkavhtLYbjdW5kdsjU7R9fwB7lO1BRooGsC8m2L/gQ==",
       "dev": true,
       "dependencies": {
         "alcalzone-shared": "^4.0.8",
@@ -1340,15 +1340,15 @@
       }
     },
     "node_modules/@zwave-js/testing": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-10.10.0.tgz",
-      "integrity": "sha512-VylUNmdrGMVaUFOvFqZuQGa9fLmZ6HPhrgLHcECbn7YBjgk7kz2Ha+irrsfny73zYT0t/BtYlZl3M54I2S5ahQ==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-10.12.0.tgz",
+      "integrity": "sha512-BCKuGJVahBsmVfXuuE+ujs0ATL7ZUuGtjWcGVF+BJj/8RDrCn68kuG6SNV5VuFWTF8e+IZ51VHcYo/dDXbuHNQ==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/host": "10.10.0",
-        "@zwave-js/serial": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/host": "10.12.0",
+        "@zwave-js/serial": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "ansi-colors": "^4.1.3"
       },
       "engines": {
@@ -3681,9 +3681,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
@@ -3863,9 +3863,9 @@
       ]
     },
     "node_modules/safe-stable-stringify": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.2.tgz",
-      "integrity": "sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -4455,9 +4455,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
@@ -4503,25 +4503,25 @@
       }
     },
     "node_modules/zwave-js": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-10.10.0.tgz",
-      "integrity": "sha512-mirnbCz9egAZebFDgycnkxnqAPeZRlWE0t0sH23DxkXWsQMZI+L1qHWHZJUm3+1SDLmOS7pCZk+9cwNSEWGhrA==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-10.12.0.tgz",
+      "integrity": "sha512-50kbN1P5YQUutaMCXL0UJd73diRfhlIV2gFX46les8qnyrHH23C1MQcG1Zmadk820gcx4qgoZhNnDSSFx1cYdw==",
       "dev": true,
       "dependencies": {
-        "@alcalzone/jsonl-db": "^2.5.3",
+        "@alcalzone/jsonl-db": "^3.0.0",
         "@alcalzone/pak": "^0.8.1",
         "@esm2cjs/got": "^12.5.3",
         "@esm2cjs/p-queue": "^7.3.0",
         "@sentry/integrations": "^7.12.1",
         "@sentry/node": "^7.12.1",
-        "@zwave-js/cc": "10.10.0",
-        "@zwave-js/config": "10.10.0",
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/host": "10.10.0",
-        "@zwave-js/nvmedit": "10.10.0",
-        "@zwave-js/serial": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
-        "@zwave-js/testing": "10.10.0",
+        "@zwave-js/cc": "10.12.0",
+        "@zwave-js/config": "10.12.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/host": "10.12.0",
+        "@zwave-js/nvmedit": "10.12.0",
+        "@zwave-js/serial": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
+        "@zwave-js/testing": "10.12.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "execa": "^5.1.1",
@@ -4544,13 +4544,13 @@
   },
   "dependencies": {
     "@alcalzone/jsonl-db": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@alcalzone/jsonl-db/-/jsonl-db-2.5.3.tgz",
-      "integrity": "sha512-CuQ6aoBusGex0AJWEgwXfgApdUD9YsxM9JCnim8S6Z1icO5AxecxWEiBm1a2/m2vfwA7roqg+LEHbwon9EkgRw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@alcalzone/jsonl-db/-/jsonl-db-3.1.0.tgz",
+      "integrity": "sha512-Wc1nxOyJVBF0NWrG1X7SQcb6mWWtr2i9e1cOSHQsjmnHlBYlFoj82fsP1NCZrHdXBhqQyYpdXP8ZQ8zz0iddFQ==",
       "dev": true,
       "requires": {
         "@alcalzone/proper-lockfile": "^4.1.3-0",
-        "alcalzone-shared": "^4.0.3",
+        "alcalzone-shared": "^4.0.8",
         "fs-extra": "^10.1.0"
       }
     },
@@ -4903,29 +4903,29 @@
       }
     },
     "@sentry/core": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.37.0.tgz",
-      "integrity": "sha512-2M6aZKIG/1HgfE0hobQ9tKSo6ZsyBrSQqjtQhMVFwVzZJyFw3m1AqcrB+f0myi+1ay2MMPbJ+HhYtBPR3e4EvA==",
+      "version": "7.44.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.44.1.tgz",
+      "integrity": "sha512-MiDQ7cGPrWMvvnU1pszSNak4DuH7RnPS/WLVKPJDBh1paozA9bPaxRRfJu0BGtw0BV1pRoTP2CQyp0AHdNaHow==",
       "dev": true,
       "requires": {
-        "@sentry/types": "7.37.0",
-        "@sentry/utils": "7.37.0",
+        "@sentry/types": "7.44.1",
+        "@sentry/utils": "7.44.1",
         "tslib": "^1.9.3"
       },
       "dependencies": {
         "@sentry/types": {
-          "version": "7.37.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.37.0.tgz",
-          "integrity": "sha512-p8iw5oGvWLIk7osMgXhxshUpebJD0riiuT3ihBP0DV+Gs8r0qdQ5gtcStl7Cn0D4013p4j/f3T5q85Z9ENE6fA==",
+          "version": "7.44.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.44.1.tgz",
+          "integrity": "sha512-g0vlu7EdphUv7x0p/r1t7kjh1kNCoSMmK2G6FQCfGH2cr1AMcOAKF5iFxTN2dv0Ap3glLQPgid0bRyqcQAlCBw==",
           "dev": true
         },
         "@sentry/utils": {
-          "version": "7.37.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.37.0.tgz",
-          "integrity": "sha512-CN86EKQ07+SgqfgGehMJsgrCEjc0sl1YDcj2xf9dA0Bn3ma2MTDkCyutxVcRfc2IVWfqAN1rn/L8/BH2v2+eqA==",
+          "version": "7.44.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.44.1.tgz",
+          "integrity": "sha512-KfgfyurxBMFUBBPmYUPH2L46wT1nf5CbBq1wP/7D1p3EKwspb13ubK7VbxC779+JeSHqtGNOeWfY1jl1/8XBYg==",
           "dev": true,
           "requires": {
-            "@sentry/types": "7.37.0",
+            "@sentry/types": "7.44.1",
             "tslib": "^1.9.3"
           }
         }
@@ -4944,14 +4944,14 @@
       }
     },
     "@sentry/node": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.37.0.tgz",
-      "integrity": "sha512-ohkk5K7V3+lK1MtVVpTzqu09xcGNu9IeGK2VjjMD68deojdYrxWXINuO4ta0aE1hmg1rwAlpPebQkmXspo9zOw==",
+      "version": "7.44.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.44.1.tgz",
+      "integrity": "sha512-ISmmrN37m7acLWKLDdLynaIvdMI+Mu2KjVmunz68cnYOt/+DlZnElBxBvpAbVauJ4tRqqqlrbCpKCOIWLtJrvQ==",
       "dev": true,
       "requires": {
-        "@sentry/core": "7.37.0",
-        "@sentry/types": "7.37.0",
-        "@sentry/utils": "7.37.0",
+        "@sentry/core": "7.44.1",
+        "@sentry/types": "7.44.1",
+        "@sentry/utils": "7.44.1",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -4959,18 +4959,18 @@
       },
       "dependencies": {
         "@sentry/types": {
-          "version": "7.37.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.37.0.tgz",
-          "integrity": "sha512-p8iw5oGvWLIk7osMgXhxshUpebJD0riiuT3ihBP0DV+Gs8r0qdQ5gtcStl7Cn0D4013p4j/f3T5q85Z9ENE6fA==",
+          "version": "7.44.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.44.1.tgz",
+          "integrity": "sha512-g0vlu7EdphUv7x0p/r1t7kjh1kNCoSMmK2G6FQCfGH2cr1AMcOAKF5iFxTN2dv0Ap3glLQPgid0bRyqcQAlCBw==",
           "dev": true
         },
         "@sentry/utils": {
-          "version": "7.37.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.37.0.tgz",
-          "integrity": "sha512-CN86EKQ07+SgqfgGehMJsgrCEjc0sl1YDcj2xf9dA0Bn3ma2MTDkCyutxVcRfc2IVWfqAN1rn/L8/BH2v2+eqA==",
+          "version": "7.44.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.44.1.tgz",
+          "integrity": "sha512-KfgfyurxBMFUBBPmYUPH2L46wT1nf5CbBq1wP/7D1p3EKwspb13ubK7VbxC779+JeSHqtGNOeWfY1jl1/8XBYg==",
           "dev": true,
           "requires": {
-            "@sentry/types": "7.37.0",
+            "@sentry/types": "7.44.1",
             "tslib": "^1.9.3"
           }
         }
@@ -5341,28 +5341,28 @@
       }
     },
     "@zwave-js/cc": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-10.10.0.tgz",
-      "integrity": "sha512-ZT+V5+llCZknSe5CwaVom5PpEFbFfm6pXbzS6nJ2Nt5m7//G4qExK+356qOfE7vsEz9KgIDEbDGfEtfhq/heUQ==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-10.12.0.tgz",
+      "integrity": "sha512-So6QJZ18fTcYrZcrQNYn9K1Jaq2HEV63U/XhcrSizv/wIKunGToSKuSt96Hs0JR/NwkxMZXeEtxkN0/lnLmh+w==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/host": "10.10.0",
-        "@zwave-js/serial": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/host": "10.12.0",
+        "@zwave-js/serial": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "reflect-metadata": "^0.1.13"
       }
     },
     "@zwave-js/config": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-10.10.0.tgz",
-      "integrity": "sha512-nlCYS8SZol0IM66OFgOF2eFC0NRc4qreVrC2NfUTdxy3plClSOhsQeZsREyvXyxEtrhMaW5G93M6Ad7+YbIh7Q==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-10.12.0.tgz",
+      "integrity": "sha512-xJqX2alrQ+BT4f2SYuFxfkZ5/iyboz5cBI45nrXZFGXfq9Elu45xQyWsjayvPbItnltYPYH29UtVq1V7s/hHJw==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "fs-extra": "^10.1.0",
@@ -5373,13 +5373,13 @@
       }
     },
     "@zwave-js/core": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-10.10.0.tgz",
-      "integrity": "sha512-jwejHy/HEAHTCIJJkAF+4b8F1mTK2xVLdZzdPNh4t9RBRpFH+cxuKS4DP7iEHAyDROvyOmzW//QOxZMHEmbqwg==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-10.12.0.tgz",
+      "integrity": "sha512-xonkV4fUjKFfdrZU2sp/atL5hQC7uEJs7OIfGXMzaLp8KYqgN1a5BB2G/e8GhCSLj3bQHub4PSKGi9JfrDc83A==",
       "dev": true,
       "requires": {
-        "@alcalzone/jsonl-db": "^2.5.3",
-        "@zwave-js/shared": "10.10.0",
+        "@alcalzone/jsonl-db": "^3.0.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "dayjs": "^1.11.5",
@@ -5393,25 +5393,25 @@
       }
     },
     "@zwave-js/host": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-10.10.0.tgz",
-      "integrity": "sha512-SrbfE3um8S1lFhW9WaZcbIIzqCirB0ej6U64azhxSQLRWDj0mbkqso1FZvbqzOgT67HTFejiICDe6MqVnl2beA==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-10.12.0.tgz",
+      "integrity": "sha512-tCSStxymrFNNmjgUk905uzrBZ7xvC+eSJ0yztxYgIgeNNfRQ0mQADJJEO+FYbyWMdwx1FkByQP87EPDLIchWdg==",
       "dev": true,
       "requires": {
-        "@zwave-js/config": "10.10.0",
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/config": "10.12.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8"
       }
     },
     "@zwave-js/nvmedit": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-10.10.0.tgz",
-      "integrity": "sha512-EGSXNUptfwQPONtrZPkYkV3wefaKrheEx2GheH11L9v4Bg1KfxVMLJh92p9c0/sGZTayZnAR0q5Pt41BeuMhBA==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-10.12.0.tgz",
+      "integrity": "sha512-mqq8dBKe3ZLUaMzI/4t78w3/wKWwjpfSDs02c4bVbhJvKn3WuX1xgSgpY99qA1LSqCMG3VE3wQeQk/jwArKxqw==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "fs-extra": "^10.1.0",
         "reflect-metadata": "^0.1.13",
@@ -5420,25 +5420,25 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-10.10.0.tgz",
-      "integrity": "sha512-3Bp9lR3uojiEyZV6wtj8RDijRDhcGPhK3xu0wQZ2OEYZOKuGyGB1XNpVaRhowj26UQ2e6ztcz8S/tr8poNRDXA==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-10.12.0.tgz",
+      "integrity": "sha512-FackmvPXNfLX/0eePyCYvud4p9r+6aP2E9EJDzWwg4CuCquW9R/HSPY1d/7Hfh/qAv2n6U9vN3xVPqdCR6YqEQ==",
       "dev": true,
       "requires": {
         "@sentry/node": "^7.12.1",
         "@serialport/stream": "^10.3.0",
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/host": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/host": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "alcalzone-shared": "^4.0.8",
         "serialport": "^10.4.0",
         "winston": "^3.8.2"
       }
     },
     "@zwave-js/shared": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-10.10.0.tgz",
-      "integrity": "sha512-UOEyaQ60nRO9zWlsOyK3prYZCUtjfbXNPd/mZSzWrWeZcNzKcU5VdZGHHJnbCDf3wS0zyOhB66afBlY7O0RpuQ==",
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-10.11.1.tgz",
+      "integrity": "sha512-lAxZ1qPkZB4Kl4lMAUVIqMcdTLW5ZAdKUKYOVGXpdfOdXkavhtLYbjdW5kdsjU7R9fwB7lO1BRooGsC8m2L/gQ==",
       "dev": true,
       "requires": {
         "alcalzone-shared": "^4.0.8",
@@ -5446,15 +5446,15 @@
       }
     },
     "@zwave-js/testing": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-10.10.0.tgz",
-      "integrity": "sha512-VylUNmdrGMVaUFOvFqZuQGa9fLmZ6HPhrgLHcECbn7YBjgk7kz2Ha+irrsfny73zYT0t/BtYlZl3M54I2S5ahQ==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-10.12.0.tgz",
+      "integrity": "sha512-BCKuGJVahBsmVfXuuE+ujs0ATL7ZUuGtjWcGVF+BJj/8RDrCn68kuG6SNV5VuFWTF8e+IZ51VHcYo/dDXbuHNQ==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/host": "10.10.0",
-        "@zwave-js/serial": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/host": "10.12.0",
+        "@zwave-js/serial": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
         "ansi-colors": "^4.1.3"
       }
     },
@@ -7166,9 +7166,9 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -7285,9 +7285,9 @@
       "dev": true
     },
     "safe-stable-stringify": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.2.tgz",
-      "integrity": "sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
       "dev": true
     },
     "semver": {
@@ -7705,9 +7705,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
       "requires": {
         "cliui": "^8.0.1",
@@ -7738,25 +7738,25 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-10.10.0.tgz",
-      "integrity": "sha512-mirnbCz9egAZebFDgycnkxnqAPeZRlWE0t0sH23DxkXWsQMZI+L1qHWHZJUm3+1SDLmOS7pCZk+9cwNSEWGhrA==",
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-10.12.0.tgz",
+      "integrity": "sha512-50kbN1P5YQUutaMCXL0UJd73diRfhlIV2gFX46les8qnyrHH23C1MQcG1Zmadk820gcx4qgoZhNnDSSFx1cYdw==",
       "dev": true,
       "requires": {
-        "@alcalzone/jsonl-db": "^2.5.3",
+        "@alcalzone/jsonl-db": "^3.0.0",
         "@alcalzone/pak": "^0.8.1",
         "@esm2cjs/got": "^12.5.3",
         "@esm2cjs/p-queue": "^7.3.0",
         "@sentry/integrations": "^7.12.1",
         "@sentry/node": "^7.12.1",
-        "@zwave-js/cc": "10.10.0",
-        "@zwave-js/config": "10.10.0",
-        "@zwave-js/core": "10.10.0",
-        "@zwave-js/host": "10.10.0",
-        "@zwave-js/nvmedit": "10.10.0",
-        "@zwave-js/serial": "10.10.0",
-        "@zwave-js/shared": "10.10.0",
-        "@zwave-js/testing": "10.10.0",
+        "@zwave-js/cc": "10.12.0",
+        "@zwave-js/config": "10.12.0",
+        "@zwave-js/core": "10.12.0",
+        "@zwave-js/host": "10.12.0",
+        "@zwave-js/nvmedit": "10.12.0",
+        "@zwave-js/serial": "10.12.0",
+        "@zwave-js/shared": "10.11.1",
+        "@zwave-js/testing": "10.12.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "execa": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@homebridge/ciao": "^1.1.3"
   },
   "peerDependencies": {
-    "zwave-js": "^10.10.0"
+    "zwave-js": "^10.12.0"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -53,7 +53,7 @@
     "semver": "^7.3.5",
     "ts-node": "^10.5.0",
     "typescript": "^4.1.3",
-    "zwave-js": "^10.10.0"
+    "zwave-js": "^10.12.0"
   },
   "husky": {
     "hooks": {

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -4,7 +4,7 @@ export const version = require("../../package.json").version;
 export const minSchemaVersion = 0;
 
 // maximal/current schema version the server supports
-export const maxSchemaVersion = 26;
+export const maxSchemaVersion = 27;
 
 export const applicationName = "zwave-js-server";
 export const dnssdServiceType = applicationName;

--- a/src/lib/driver/command.ts
+++ b/src/lib/driver/command.ts
@@ -14,4 +14,5 @@ export enum DriverCommand {
   softReset = "driver.soft_reset",
   trySoftReset = "driver.try_soft_reset",
   hardReset = "driver.hard_reset",
+  shutdown = "driver.shutdown",
 }

--- a/src/lib/driver/incoming_message.ts
+++ b/src/lib/driver/incoming_message.ts
@@ -69,6 +69,10 @@ interface IncomingCommandHardReset extends IncomingCommandBase {
   command: DriverCommand.hardReset;
 }
 
+interface IncomingCommandShutdown extends IncomingCommandBase {
+  command: DriverCommand.shutdown;
+}
+
 export type IncomingMessageDriver =
   | IncomingCommandGetConfig
   | IncomingCommandUpdateLogConfig
@@ -84,4 +88,5 @@ export type IncomingMessageDriver =
   | IncomingCommandEnableErrorReporting
   | IncomingCommandSoftReset
   | IncomingCommandTrySoftReset
-  | IncomingCommandHardReset;
+  | IncomingCommandHardReset
+  | IncomingCommandShutdown;

--- a/src/lib/driver/message_handler.ts
+++ b/src/lib/driver/message_handler.ts
@@ -19,6 +19,7 @@ export class DriverMessageHandler {
     client: Client
   ): Promise<DriverResultTypes[DriverCommand]> {
     const { command } = message;
+    let success: boolean;
     switch (message.command) {
       case DriverCommand.getConfig:
         return { config: dumpDriver(driver, client.schemaVersion) };
@@ -62,7 +63,7 @@ export class DriverMessageHandler {
         const updateAvailable = newVersion !== undefined;
         return { installedVersion, updateAvailable, newVersion };
       case DriverCommand.installConfigUpdate:
-        const success = await driver.installConfigUpdate();
+        success = await driver.installConfigUpdate();
         return { success };
       case DriverCommand.setPreferredScales:
         driver.setPreferredScales(message.scales);
@@ -79,6 +80,9 @@ export class DriverMessageHandler {
       case DriverCommand.hardReset:
         setTimeout(() => remoteController.hardResetController(), 1);
         return {};
+      case DriverCommand.shutdown:
+        success = await driver.shutdown();
+        return { success };
       default:
         throw new UnknownCommandError(command);
     }

--- a/src/lib/driver/outgoing_message.ts
+++ b/src/lib/driver/outgoing_message.ts
@@ -22,4 +22,5 @@ export interface DriverResultTypes {
   [DriverCommand.softReset]: Record<string, never>;
   [DriverCommand.trySoftReset]: Record<string, never>;
   [DriverCommand.hardReset]: Record<string, never>;
+  [DriverCommand.shutdown]: { success: boolean };
 }

--- a/src/lib/node/command.ts
+++ b/src/lib/node/command.ts
@@ -29,4 +29,5 @@ export enum NodeCommand {
   isFirmwareUpdateInProgress = "node.is_firmware_update_in_progress",
   waitForWakeup = "node.wait_for_wakeup",
   interview = "node.interview",
+  getValueTimestamp = "node.get_value_timestamp",
 }

--- a/src/lib/node/incoming_message.ts
+++ b/src/lib/node/incoming_message.ts
@@ -188,7 +188,7 @@ export interface IncomingCommandInterview extends IncomingCommandNodeBase {
   command: NodeCommand.interview;
 }
 
-export interface IncomingCommandGetValueTimestamp
+export interface IncomingCommandNodeGetValueTimestamp
   extends IncomingCommandNodeBase {
   command: NodeCommand.getValueTimestamp;
   valueId: ValueID;

--- a/src/lib/node/incoming_message.ts
+++ b/src/lib/node/incoming_message.ts
@@ -188,6 +188,12 @@ export interface IncomingCommandInterview extends IncomingCommandNodeBase {
   command: NodeCommand.interview;
 }
 
+export interface IncomingCommandGetValueTimestamp
+  extends IncomingCommandNodeBase {
+  command: NodeCommand.getValueTimestamp;
+  valueId: ValueID;
+}
+
 export type IncomingMessageNode =
   | IncomingCommandNodeSetValue
   | IncomingCommandNodeRefreshInfo
@@ -217,4 +223,5 @@ export type IncomingMessageNode =
   | IncomingCommandSetKeepAwake
   | IncomingCommandIsFirmwareUpdateInProgress
   | IncomingCommandWaitForWakeup
-  | IncomingCommandInterview;
+  | IncomingCommandInterview
+  | IncomingCommandNodeGetValueTimestamp;

--- a/src/lib/node/message_handler.ts
+++ b/src/lib/node/message_handler.ts
@@ -222,6 +222,9 @@ export class NodeMessageHandler {
       case NodeCommand.interview:
         await node.interview();
         return {};
+      case NodeCommand.getValueTimestamp:
+        const timestamp = node.getValueTimestamp(message.valueId);
+        return { timestamp };
       default:
         throw new UnknownCommandError(command);
     }

--- a/src/lib/node/outgoing_message.ts
+++ b/src/lib/node/outgoing_message.ts
@@ -46,4 +46,5 @@ export interface NodeResultTypes {
   [NodeCommand.isFirmwareUpdateInProgress]: { progress: boolean };
   [NodeCommand.waitForWakeup]: Record<string, never>;
   [NodeCommand.interview]: Record<string, never>;
+  [NodeCommand.getValueTimestamp]: { timestamp?: number };
 }


### PR DESCRIPTION
- https://github.com/zwave-js/node-zwave-js/releases/tag/v10.12.0

Depends on https://github.com/zwave-js/zwave-js-server/pull/892