### PR TITLE
Bump zwave-js to 10.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,10 +34,10 @@
         "semver": "^7.3.5",
         "ts-node": "^10.5.0",
         "typescript": "^5.0.2",
-        "zwave-js": "^10.14.1"
+        "zwave-js": "^10.15.0"
       },
       "peerDependencies": {
-        "zwave-js": "^10.14.1"
+        "zwave-js": "^10.15.0"
       }
     },
     "node_modules/@alcalzone/jsonl-db": {
@@ -1234,14 +1234,14 @@
       }
     },
     "node_modules/@zwave-js/cc": {
-      "version": "10.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-10.14.0.tgz",
-      "integrity": "sha512-nxJ/gOl1LlrIGiNVOpgHRzjcWJ4YG47RQ27X/IFRKPfuNu+mtuQ5V8OWkzfMRm/fKaMXqezc+k4BDRBPcwJX0Q==",
+      "version": "10.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-10.15.0.tgz",
+      "integrity": "sha512-vCZQbiVsBRkrQvI6Sx5RzULNepaZ3rG3jKHnL+6VN17S14+6lf9CvKuyxEaIAtKLm+TCIypzPTo1F0QTpO1WZQ==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "10.14.0",
-        "@zwave-js/host": "10.14.0",
-        "@zwave-js/serial": "10.14.0",
+        "@zwave-js/core": "10.15.0",
+        "@zwave-js/host": "10.15.0",
+        "@zwave-js/serial": "10.15.0",
         "@zwave-js/shared": "10.13.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
@@ -1255,12 +1255,12 @@
       }
     },
     "node_modules/@zwave-js/config": {
-      "version": "10.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-10.14.0.tgz",
-      "integrity": "sha512-8Cz7+ApTRUbWv27/+wbzwqbY8gicyg7+E7FI6cluBEnfeHTICxECz6zPzhHy+V7lRMlN0OFZ9aCeHUUlpNguvw==",
+      "version": "10.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-10.15.0.tgz",
+      "integrity": "sha512-mfyX4/YHD5OTwkTgd6LIXV+/av1jo5Hc9zddNqkMz8K/FBJMmTg+W2t0PHTx8V+aq4a8U4R6A5lvMmmQjix7DA==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "10.14.0",
+        "@zwave-js/core": "10.15.0",
         "@zwave-js/shared": "10.13.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
@@ -1278,9 +1278,9 @@
       }
     },
     "node_modules/@zwave-js/core": {
-      "version": "10.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-10.14.0.tgz",
-      "integrity": "sha512-+Wi6MgMrzPufqWIgRg5FQok1vywWFk//IDmuQvKVVJWtk9W8OMBRPTNNnUt957xJ/ebgJngDWXeLCU2USRG+3A==",
+      "version": "10.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-10.15.0.tgz",
+      "integrity": "sha512-i288SZdA9olokb5GKc/OfAvDoTm7mhin+6QOkyqbQnZuLuDX0vm18powd7T0IXlj3aBn/A/3FockteZhCTydfQ==",
       "dev": true,
       "dependencies": {
         "@alcalzone/jsonl-db": "^3.1.0",
@@ -1304,13 +1304,13 @@
       }
     },
     "node_modules/@zwave-js/host": {
-      "version": "10.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-10.14.0.tgz",
-      "integrity": "sha512-QBXO9O4HqFB0a+lYCpZxawmlttoWqo9bkhKUUmuTcFLbBAh0qQOq9h8ESxMX+qDnvzMDKMp65UbpFKKIetPKKQ==",
+      "version": "10.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-10.15.0.tgz",
+      "integrity": "sha512-5BudC/AkM6Npiz4mfZr0B4gUMvc75eg1DdJJHXpLJqDYsDBslFMNb35l4smGk3sFZn0YcxVTjYGPT4WW0pBS5Q==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/config": "10.14.0",
-        "@zwave-js/core": "10.14.0",
+        "@zwave-js/config": "10.15.0",
+        "@zwave-js/core": "10.15.0",
         "@zwave-js/shared": "10.13.0",
         "alcalzone-shared": "^4.0.8"
       },
@@ -1322,12 +1322,12 @@
       }
     },
     "node_modules/@zwave-js/nvmedit": {
-      "version": "10.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-10.14.0.tgz",
-      "integrity": "sha512-U0n+0Js5exr4rpzI1aUkdPuFSfanURyP/xJp/VH0bA0IEqlWlbEKS6QgxNBXaNnBJtiqSAaxeGDER5Dl26TrJA==",
+      "version": "10.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-10.15.0.tgz",
+      "integrity": "sha512-/MV4Ij5qLjjRaM/x5IwmDQlyPc5ewRTxRgdkfw8kGZHABU4CSTKXMMF3YJT/4dkOxqVuN7XcvdFBGS2iT1CD+w==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "10.14.0",
+        "@zwave-js/core": "10.15.0",
         "@zwave-js/shared": "10.13.0",
         "alcalzone-shared": "^4.0.8",
         "fs-extra": "^10.1.0",
@@ -1346,15 +1346,15 @@
       }
     },
     "node_modules/@zwave-js/serial": {
-      "version": "10.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-10.14.0.tgz",
-      "integrity": "sha512-lu0pXiYD+teb2kBEQtmMulmHmbwI4AbX9WQlNu3pU2z3rv39OOhGqz9LCelUzeLJfLa88D7Cs/PtyHIJdOzUdQ==",
+      "version": "10.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-10.15.0.tgz",
+      "integrity": "sha512-+W/J5Soi153coO2g0h34krPfzfbSlZ6gCd2ou40bhmcz2R5iG/CfqVnvEFeTdEUTi31LhUpgvGDU5iEPpNOZRg==",
       "dev": true,
       "dependencies": {
         "@sentry/node": "^7.12.1",
         "@serialport/stream": "^10.3.0",
-        "@zwave-js/core": "10.14.0",
-        "@zwave-js/host": "10.14.0",
+        "@zwave-js/core": "10.15.0",
+        "@zwave-js/host": "10.15.0",
         "@zwave-js/shared": "10.13.0",
         "alcalzone-shared": "^4.0.8",
         "serialport": "^10.4.0",
@@ -1384,14 +1384,14 @@
       }
     },
     "node_modules/@zwave-js/testing": {
-      "version": "10.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-10.14.0.tgz",
-      "integrity": "sha512-Z02VjYoDF+0ZF/6xbDBFXldPZdB65nWEAO/foShO4IGWIG0XGcN3svO/KXzBkdTlWMuB+y69TEomDLWwyzS9Jw==",
+      "version": "10.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-10.15.0.tgz",
+      "integrity": "sha512-zJ3GNdMh9G1Qz6Dj7jHbYPbbf7EX0irph5b4Pgwh+IxueQqNKzwkiBBjbqWMvhOt5HDQeyav3N3D3agz+DE3Pw==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "10.14.0",
-        "@zwave-js/host": "10.14.0",
-        "@zwave-js/serial": "10.14.0",
+        "@zwave-js/core": "10.15.0",
+        "@zwave-js/host": "10.15.0",
+        "@zwave-js/serial": "10.15.0",
         "@zwave-js/shared": "10.13.0",
         "ansi-colors": "^4.1.3"
       },
@@ -4499,9 +4499,9 @@
       }
     },
     "node_modules/zwave-js": {
-      "version": "10.14.1",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-10.14.1.tgz",
-      "integrity": "sha512-GT+AMNVPwOGpFG2UFZw2l2/PUfHDBddha9S724cY+ZPnzR5iMXBDotF6pzawVTca5vRLF00Zzr2ocwUBje4wew==",
+      "version": "10.15.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-10.15.0.tgz",
+      "integrity": "sha512-on3bQtu0WOvUEbmI16m+/fvGE2CVC7ox1NCRxSWbFcXKkcQvuSkdqPVgP6ZfmlkoJeWSYoiYAtvUorCj6OWcdg==",
       "dev": true,
       "dependencies": {
         "@alcalzone/jsonl-db": "^3.1.0",
@@ -4510,14 +4510,14 @@
         "@esm2cjs/p-queue": "^7.3.0",
         "@sentry/integrations": "^7.12.1",
         "@sentry/node": "^7.12.1",
-        "@zwave-js/cc": "10.14.0",
-        "@zwave-js/config": "10.14.0",
-        "@zwave-js/core": "10.14.0",
-        "@zwave-js/host": "10.14.0",
-        "@zwave-js/nvmedit": "10.14.0",
-        "@zwave-js/serial": "10.14.0",
+        "@zwave-js/cc": "10.15.0",
+        "@zwave-js/config": "10.15.0",
+        "@zwave-js/core": "10.15.0",
+        "@zwave-js/host": "10.15.0",
+        "@zwave-js/nvmedit": "10.15.0",
+        "@zwave-js/serial": "10.15.0",
         "@zwave-js/shared": "10.13.0",
-        "@zwave-js/testing": "10.14.0",
+        "@zwave-js/testing": "10.15.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "execa": "^5.1.1",
@@ -5369,14 +5369,14 @@
       }
     },
     "@zwave-js/cc": {
-      "version": "10.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-10.14.0.tgz",
-      "integrity": "sha512-nxJ/gOl1LlrIGiNVOpgHRzjcWJ4YG47RQ27X/IFRKPfuNu+mtuQ5V8OWkzfMRm/fKaMXqezc+k4BDRBPcwJX0Q==",
+      "version": "10.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-10.15.0.tgz",
+      "integrity": "sha512-vCZQbiVsBRkrQvI6Sx5RzULNepaZ3rG3jKHnL+6VN17S14+6lf9CvKuyxEaIAtKLm+TCIypzPTo1F0QTpO1WZQ==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "10.14.0",
-        "@zwave-js/host": "10.14.0",
-        "@zwave-js/serial": "10.14.0",
+        "@zwave-js/core": "10.15.0",
+        "@zwave-js/host": "10.15.0",
+        "@zwave-js/serial": "10.15.0",
         "@zwave-js/shared": "10.13.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
@@ -5384,12 +5384,12 @@
       }
     },
     "@zwave-js/config": {
-      "version": "10.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-10.14.0.tgz",
-      "integrity": "sha512-8Cz7+ApTRUbWv27/+wbzwqbY8gicyg7+E7FI6cluBEnfeHTICxECz6zPzhHy+V7lRMlN0OFZ9aCeHUUlpNguvw==",
+      "version": "10.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-10.15.0.tgz",
+      "integrity": "sha512-mfyX4/YHD5OTwkTgd6LIXV+/av1jo5Hc9zddNqkMz8K/FBJMmTg+W2t0PHTx8V+aq4a8U4R6A5lvMmmQjix7DA==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "10.14.0",
+        "@zwave-js/core": "10.15.0",
         "@zwave-js/shared": "10.13.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
@@ -5401,9 +5401,9 @@
       }
     },
     "@zwave-js/core": {
-      "version": "10.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-10.14.0.tgz",
-      "integrity": "sha512-+Wi6MgMrzPufqWIgRg5FQok1vywWFk//IDmuQvKVVJWtk9W8OMBRPTNNnUt957xJ/ebgJngDWXeLCU2USRG+3A==",
+      "version": "10.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-10.15.0.tgz",
+      "integrity": "sha512-i288SZdA9olokb5GKc/OfAvDoTm7mhin+6QOkyqbQnZuLuDX0vm18powd7T0IXlj3aBn/A/3FockteZhCTydfQ==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^3.1.0",
@@ -5421,24 +5421,24 @@
       }
     },
     "@zwave-js/host": {
-      "version": "10.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-10.14.0.tgz",
-      "integrity": "sha512-QBXO9O4HqFB0a+lYCpZxawmlttoWqo9bkhKUUmuTcFLbBAh0qQOq9h8ESxMX+qDnvzMDKMp65UbpFKKIetPKKQ==",
+      "version": "10.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-10.15.0.tgz",
+      "integrity": "sha512-5BudC/AkM6Npiz4mfZr0B4gUMvc75eg1DdJJHXpLJqDYsDBslFMNb35l4smGk3sFZn0YcxVTjYGPT4WW0pBS5Q==",
       "dev": true,
       "requires": {
-        "@zwave-js/config": "10.14.0",
-        "@zwave-js/core": "10.14.0",
+        "@zwave-js/config": "10.15.0",
+        "@zwave-js/core": "10.15.0",
         "@zwave-js/shared": "10.13.0",
         "alcalzone-shared": "^4.0.8"
       }
     },
     "@zwave-js/nvmedit": {
-      "version": "10.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-10.14.0.tgz",
-      "integrity": "sha512-U0n+0Js5exr4rpzI1aUkdPuFSfanURyP/xJp/VH0bA0IEqlWlbEKS6QgxNBXaNnBJtiqSAaxeGDER5Dl26TrJA==",
+      "version": "10.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-10.15.0.tgz",
+      "integrity": "sha512-/MV4Ij5qLjjRaM/x5IwmDQlyPc5ewRTxRgdkfw8kGZHABU4CSTKXMMF3YJT/4dkOxqVuN7XcvdFBGS2iT1CD+w==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "10.14.0",
+        "@zwave-js/core": "10.15.0",
         "@zwave-js/shared": "10.13.0",
         "alcalzone-shared": "^4.0.8",
         "fs-extra": "^10.1.0",
@@ -5448,15 +5448,15 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "10.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-10.14.0.tgz",
-      "integrity": "sha512-lu0pXiYD+teb2kBEQtmMulmHmbwI4AbX9WQlNu3pU2z3rv39OOhGqz9LCelUzeLJfLa88D7Cs/PtyHIJdOzUdQ==",
+      "version": "10.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-10.15.0.tgz",
+      "integrity": "sha512-+W/J5Soi153coO2g0h34krPfzfbSlZ6gCd2ou40bhmcz2R5iG/CfqVnvEFeTdEUTi31LhUpgvGDU5iEPpNOZRg==",
       "dev": true,
       "requires": {
         "@sentry/node": "^7.12.1",
         "@serialport/stream": "^10.3.0",
-        "@zwave-js/core": "10.14.0",
-        "@zwave-js/host": "10.14.0",
+        "@zwave-js/core": "10.15.0",
+        "@zwave-js/host": "10.15.0",
         "@zwave-js/shared": "10.13.0",
         "alcalzone-shared": "^4.0.8",
         "serialport": "^10.4.0",
@@ -5474,14 +5474,14 @@
       }
     },
     "@zwave-js/testing": {
-      "version": "10.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-10.14.0.tgz",
-      "integrity": "sha512-Z02VjYoDF+0ZF/6xbDBFXldPZdB65nWEAO/foShO4IGWIG0XGcN3svO/KXzBkdTlWMuB+y69TEomDLWwyzS9Jw==",
+      "version": "10.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-10.15.0.tgz",
+      "integrity": "sha512-zJ3GNdMh9G1Qz6Dj7jHbYPbbf7EX0irph5b4Pgwh+IxueQqNKzwkiBBjbqWMvhOt5HDQeyav3N3D3agz+DE3Pw==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "10.14.0",
-        "@zwave-js/host": "10.14.0",
-        "@zwave-js/serial": "10.14.0",
+        "@zwave-js/core": "10.15.0",
+        "@zwave-js/host": "10.15.0",
+        "@zwave-js/serial": "10.15.0",
         "@zwave-js/shared": "10.13.0",
         "ansi-colors": "^4.1.3"
       }
@@ -7737,9 +7737,9 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "10.14.1",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-10.14.1.tgz",
-      "integrity": "sha512-GT+AMNVPwOGpFG2UFZw2l2/PUfHDBddha9S724cY+ZPnzR5iMXBDotF6pzawVTca5vRLF00Zzr2ocwUBje4wew==",
+      "version": "10.15.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-10.15.0.tgz",
+      "integrity": "sha512-on3bQtu0WOvUEbmI16m+/fvGE2CVC7ox1NCRxSWbFcXKkcQvuSkdqPVgP6ZfmlkoJeWSYoiYAtvUorCj6OWcdg==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^3.1.0",
@@ -7748,14 +7748,14 @@
         "@esm2cjs/p-queue": "^7.3.0",
         "@sentry/integrations": "^7.12.1",
         "@sentry/node": "^7.12.1",
-        "@zwave-js/cc": "10.14.0",
-        "@zwave-js/config": "10.14.0",
-        "@zwave-js/core": "10.14.0",
-        "@zwave-js/host": "10.14.0",
-        "@zwave-js/nvmedit": "10.14.0",
-        "@zwave-js/serial": "10.14.0",
+        "@zwave-js/cc": "10.15.0",
+        "@zwave-js/config": "10.15.0",
+        "@zwave-js/core": "10.15.0",
+        "@zwave-js/host": "10.15.0",
+        "@zwave-js/nvmedit": "10.15.0",
+        "@zwave-js/serial": "10.15.0",
         "@zwave-js/shared": "10.13.0",
-        "@zwave-js/testing": "10.14.0",
+        "@zwave-js/testing": "10.15.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "execa": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@homebridge/ciao": "^1.1.3"
   },
   "peerDependencies": {
-    "zwave-js": "^10.14.1"
+    "zwave-js": "^10.15.0"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -53,7 +53,7 @@
     "semver": "^7.3.5",
     "ts-node": "^10.5.0",
     "typescript": "^5.0.2",
-    "zwave-js": "^10.14.1"
+    "zwave-js": "^10.15.0"
   },
   "husky": {
     "hooks": {

--- a/src/lib/node/incoming_message.ts
+++ b/src/lib/node/incoming_message.ts
@@ -197,9 +197,7 @@ export interface IncomingCommandNodeGetValueTimestamp
 export interface IncomingCommandNodeManuallyIdleNotificationValue
   extends IncomingCommandNodeBase {
   command: NodeCommand.manuallyIdleNotificationValue;
-  notificationType: number;
-  prevValue: number;
-  endpointIndex?: number;
+  valueId: ValueID;
 }
 
 export interface IncomingCommandNodeSetDateAndTime

--- a/src/lib/node/message_handler.ts
+++ b/src/lib/node/message_handler.ts
@@ -226,11 +226,7 @@ export class NodeMessageHandler {
         const timestamp = node.getValueTimestamp(message.valueId);
         return { timestamp };
       case NodeCommand.manuallyIdleNotificationValue:
-        node.manuallyIdleNotificationValue(
-          message.notificationType,
-          message.prevValue,
-          message.endpointIndex
-        );
+        node.manuallyIdleNotificationValue(message.valueId);
         return {};
       case NodeCommand.setDateAndTime:
         success = await node.setDateAndTime(


### PR DESCRIPTION
Improves the input and experience for the `node.manuallyIdleNotificationValue` command.

We also get S2 multicast for free because of this: https://github.com/zwave-js/node-zwave-js/pull/5593