### PR TITLE
Bump zwave-js to 11.1.0 and zwave-js-server to 1.29.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zwave-js/server",
-      "version": "1.29.0",
+      "version": "1.29.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/ciao": "^1.1.3",
@@ -34,10 +34,10 @@
         "semver": "^7.3.5",
         "ts-node": "^10.5.0",
         "typescript": "^5.0.2",
-        "zwave-js": "^11.0.0"
+        "zwave-js": "^11.1.0"
       },
       "peerDependencies": {
-        "zwave-js": "^11.0.0"
+        "zwave-js": "^11.1.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -596,73 +596,73 @@
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.56.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.56.0.tgz",
-      "integrity": "sha512-OKI4Pz/O13gng8hT9rNc+gRV3+P7nnk1HnHlV8fgaQydS6DsRxoDL1sHa42tZGbh7K9jqNAP3TC6VjBOsr2tXA==",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.57.0.tgz",
+      "integrity": "sha512-tpViyDd8AhQGYYhI94xi2aaDopXOPfL2Apwrtb3qirWkomIQ2K86W1mPmkce+B0cFOnW2Dxv/ZTFKz6ghjK75A==",
       "dev": true,
       "dependencies": {
-        "@sentry/core": "7.56.0",
-        "@sentry/types": "7.56.0",
-        "@sentry/utils": "7.56.0",
-        "tslib": "^1.9.3"
+        "@sentry/core": "7.57.0",
+        "@sentry/types": "7.57.0",
+        "@sentry/utils": "7.57.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry-internal/tracing/node_modules/@sentry/types": {
-      "version": "7.56.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.56.0.tgz",
-      "integrity": "sha512-5WjhVOQm75ItOytOx2jTx+5yw8/qJ316+g1Di8dS9+kgIi1zniqdMcX00C2yYe3FMUgFB49PegCUYulm9Evapw==",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.57.0.tgz",
+      "integrity": "sha512-D7ifoUfxuVCUyktIr5Gc+jXUbtcUMmfHdTtTbf1XCZHua5mJceK9wtl3YCg3eq/HK2Ppd52BKnTzEcS5ZKQM+w==",
       "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry-internal/tracing/node_modules/@sentry/utils": {
-      "version": "7.56.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.56.0.tgz",
-      "integrity": "sha512-wgeX7bufxc//TjjSIE+gCMm8hVId7Jzvc+f441bYrWnNZBuzPIDW2BummCcPrKzSYe5GeYZDTZGV8YZGMLGBjw==",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.57.0.tgz",
+      "integrity": "sha512-YXrkMCiNklqkXctn4mKYkrzNCf/dfVcRUQrkXjeBC+PHXbcpPyaJgInNvztR7Skl8lE3JPGPN4v5XhLxK1bUUg==",
       "dev": true,
       "dependencies": {
-        "@sentry/types": "7.56.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.57.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.56.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.56.0.tgz",
-      "integrity": "sha512-Nuyyfh09Yz27kPo74fXHlrdmZeK6zrlJVtxQ6LkwuoaTBcNcesNXVaOtr6gjvUGUmsfriVPP3Jero5LXufV7GQ==",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.57.0.tgz",
+      "integrity": "sha512-l014NudPH0vQlzybtXajPxYFfs9w762NoarjObC3gu76D1jzBBFzhdRelkGpDbSLNTIsKhEDDRpgAjBWJ9icfw==",
       "dev": true,
       "dependencies": {
-        "@sentry/types": "7.56.0",
-        "@sentry/utils": "7.56.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.57.0",
+        "@sentry/utils": "7.57.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core/node_modules/@sentry/types": {
-      "version": "7.56.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.56.0.tgz",
-      "integrity": "sha512-5WjhVOQm75ItOytOx2jTx+5yw8/qJ316+g1Di8dS9+kgIi1zniqdMcX00C2yYe3FMUgFB49PegCUYulm9Evapw==",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.57.0.tgz",
+      "integrity": "sha512-D7ifoUfxuVCUyktIr5Gc+jXUbtcUMmfHdTtTbf1XCZHua5mJceK9wtl3YCg3eq/HK2Ppd52BKnTzEcS5ZKQM+w==",
       "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core/node_modules/@sentry/utils": {
-      "version": "7.56.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.56.0.tgz",
-      "integrity": "sha512-wgeX7bufxc//TjjSIE+gCMm8hVId7Jzvc+f441bYrWnNZBuzPIDW2BummCcPrKzSYe5GeYZDTZGV8YZGMLGBjw==",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.57.0.tgz",
+      "integrity": "sha512-YXrkMCiNklqkXctn4mKYkrzNCf/dfVcRUQrkXjeBC+PHXbcpPyaJgInNvztR7Skl8lE3JPGPN4v5XhLxK1bUUg==",
       "dev": true,
       "dependencies": {
-        "@sentry/types": "7.56.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.57.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
         "node": ">=8"
@@ -684,41 +684,41 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "7.56.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.56.0.tgz",
-      "integrity": "sha512-QXbWy/ypRxfFd8iP6zLvHInYZyjGKPrkVNYt43mhKAZHm764NxX/29vDfj1FztgG9Z6lVLIG2eyqTvLruYmsWw==",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.57.0.tgz",
+      "integrity": "sha512-63mjyUVM6sfJFVQ5TGVRVGUsoEfESl5ABzIW1W0s9gUiQPaG8SOdaQJglb2VNrkMYxnRHgD8Q9LUh/qcmUyPGw==",
       "dev": true,
       "dependencies": {
-        "@sentry-internal/tracing": "7.56.0",
-        "@sentry/core": "7.56.0",
-        "@sentry/types": "7.56.0",
-        "@sentry/utils": "7.56.0",
+        "@sentry-internal/tracing": "7.57.0",
+        "@sentry/core": "7.57.0",
+        "@sentry/types": "7.57.0",
+        "@sentry/utils": "7.57.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/node/node_modules/@sentry/types": {
-      "version": "7.56.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.56.0.tgz",
-      "integrity": "sha512-5WjhVOQm75ItOytOx2jTx+5yw8/qJ316+g1Di8dS9+kgIi1zniqdMcX00C2yYe3FMUgFB49PegCUYulm9Evapw==",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.57.0.tgz",
+      "integrity": "sha512-D7ifoUfxuVCUyktIr5Gc+jXUbtcUMmfHdTtTbf1XCZHua5mJceK9wtl3YCg3eq/HK2Ppd52BKnTzEcS5ZKQM+w==",
       "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/node/node_modules/@sentry/utils": {
-      "version": "7.56.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.56.0.tgz",
-      "integrity": "sha512-wgeX7bufxc//TjjSIE+gCMm8hVId7Jzvc+f441bYrWnNZBuzPIDW2BummCcPrKzSYe5GeYZDTZGV8YZGMLGBjw==",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.57.0.tgz",
+      "integrity": "sha512-YXrkMCiNklqkXctn4mKYkrzNCf/dfVcRUQrkXjeBC+PHXbcpPyaJgInNvztR7Skl8lE3JPGPN4v5XhLxK1bUUg==",
       "dev": true,
       "dependencies": {
-        "@sentry/types": "7.56.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.57.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
         "node": ">=8"
@@ -1277,15 +1277,15 @@
       }
     },
     "node_modules/@zwave-js/cc": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-11.0.0.tgz",
-      "integrity": "sha512-DRaEz8vdS8H6FODY4h5HS2LXvcY6SLJaRo0NLrZXMbg0xbJkXLhyb7ySZ5FukEZKPggC096ulphBHVFP1QcXKQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-11.1.0.tgz",
+      "integrity": "sha512-QVJ32vYi7CRsVYLryOsD9yvF5SY+4EUBGrH40/wK7uHmrm7s/isvoaniHsm9wAy77nUyTIeSxipsLKRZ82FDvA==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "11.0.0",
-        "@zwave-js/host": "11.0.0",
-        "@zwave-js/serial": "11.0.0",
-        "@zwave-js/shared": "11.0.0",
+        "@zwave-js/core": "11.1.0",
+        "@zwave-js/host": "11.1.0",
+        "@zwave-js/serial": "11.1.0",
+        "@zwave-js/shared": "11.1.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "reflect-metadata": "^0.1.13"
@@ -1298,19 +1298,19 @@
       }
     },
     "node_modules/@zwave-js/config": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-11.0.0.tgz",
-      "integrity": "sha512-nm3vs9pdAXzeAf503CQVaS88MqTgq82DrwTZH678KBE9dtgV9oXmpLM6ImykdWjALoMD208HV7PnGqq13AytFg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-11.1.0.tgz",
+      "integrity": "sha512-ZmQzg9CwcdhwYZbW/70RpaQQJAw7xw05Te7v5MKzJUD3yRzlGi1gJZ+8fjKSVBG8bE25fO08yg4oZs3wMGNxKg==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "11.0.0",
-        "@zwave-js/shared": "11.0.0",
+        "@zwave-js/core": "11.1.0",
+        "@zwave-js/shared": "11.1.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "fs-extra": "^10.1.0",
         "json-logic-js": "^2.0.2",
         "json5": "^2.2.3",
-        "semver": "^7.5.0",
+        "semver": "^7.5.2",
         "winston": "^3.8.2"
       },
       "engines": {
@@ -1321,13 +1321,13 @@
       }
     },
     "node_modules/@zwave-js/core": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-11.0.0.tgz",
-      "integrity": "sha512-yLYhiI060dmKscJNCdhDxrBsGSEGhd2IyOFyXOeQO4913ZO6yvgsJORca8eFFvoyUJn4TVqPYb3ZoTE9qyDXxA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-11.1.0.tgz",
+      "integrity": "sha512-L051D4QWGWpoCB1YxVZtc3wmGlDGN9bpdAWREvDBpcfUsbKGK0JNc2LoS+hGj7kXgp7dPxwp4MwBMkkBH6k/0g==",
       "dev": true,
       "dependencies": {
         "@alcalzone/jsonl-db": "^3.1.0",
-        "@zwave-js/shared": "11.0.0",
+        "@zwave-js/shared": "11.1.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "dayjs": "^1.11.7",
@@ -1347,14 +1347,14 @@
       }
     },
     "node_modules/@zwave-js/host": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-11.0.0.tgz",
-      "integrity": "sha512-dRFtxGO+xNwruObPMffGNKXmPdqvO7LiIgvmbC+oVlgqOt6zQ+SYAsf+XxLHg5C/iZiOrUaxfOtmddzoBGiUtA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-11.1.0.tgz",
+      "integrity": "sha512-UTcP3hUaBO0puy5s0kQIIEQI3Y40MV62SCiaaVY2CEuPfCTVS6qII9Zn5RVVV2qa44AnuPmOl9C2V71gqEEgwg==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/config": "11.0.0",
-        "@zwave-js/core": "11.0.0",
-        "@zwave-js/shared": "11.0.0",
+        "@zwave-js/config": "11.1.0",
+        "@zwave-js/core": "11.1.0",
+        "@zwave-js/shared": "11.1.0",
         "alcalzone-shared": "^4.0.8"
       },
       "engines": {
@@ -1365,17 +1365,17 @@
       }
     },
     "node_modules/@zwave-js/nvmedit": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-11.0.0.tgz",
-      "integrity": "sha512-gPgcSkn1HgDW5+J7BnPTMWZglT3C0kIRjGqkh2MT9iMjHAsyj3TT2t92FYUVJClw0KkEDduHl7NonYYI5eBzHA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-11.1.0.tgz",
+      "integrity": "sha512-IkVEG1jGbI8nPuHJBFd7qXhpK8TxiZe+mSX23Ov1sOA6j7Ru1eT8hko7R4EDRN/cyYCyx9nsjgySubMzj34eIA==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "11.0.0",
-        "@zwave-js/shared": "11.0.0",
+        "@zwave-js/core": "11.1.0",
+        "@zwave-js/shared": "11.1.0",
         "alcalzone-shared": "^4.0.8",
         "fs-extra": "^10.1.0",
         "reflect-metadata": "^0.1.13",
-        "semver": "^7.5.0",
+        "semver": "^7.5.2",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -1389,16 +1389,16 @@
       }
     },
     "node_modules/@zwave-js/serial": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-11.0.0.tgz",
-      "integrity": "sha512-P70yF+JxWlpp7qE342vgPm+eQMHoDOhEILxVrQRU75EPqRqxdhnYr001xDGu0kGWFymz6u4SQ+4g0RHQzr+wng==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-11.1.0.tgz",
+      "integrity": "sha512-z25tH1nyogpSgUId8r8+M8IG8+Eksz4wN/ULlG5ApFQxOzJkic4Fo/bdoCmReTYgA8RFzPdlnwJwMhdFb+qVbw==",
       "dev": true,
       "dependencies": {
         "@sentry/node": "^7.12.1",
         "@serialport/stream": "^10.3.0",
-        "@zwave-js/core": "11.0.0",
-        "@zwave-js/host": "11.0.0",
-        "@zwave-js/shared": "11.0.0",
+        "@zwave-js/core": "11.1.0",
+        "@zwave-js/host": "11.1.0",
+        "@zwave-js/shared": "11.1.0",
         "alcalzone-shared": "^4.0.8",
         "serialport": "^10.4.0",
         "winston": "^3.8.2"
@@ -1411,9 +1411,9 @@
       }
     },
     "node_modules/@zwave-js/shared": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-11.0.0.tgz",
-      "integrity": "sha512-2KovZFoN68ydhZ7vGycHSvmNzIyon42NxNcl28HE6KHI2eUWoJJBfAMrY1vWPGNJVAzNLoUxL2gWj0ZvJTDUeQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-11.1.0.tgz",
+      "integrity": "sha512-aegwOgeG4r3aLtGF6Dc9fEjmNNr+1Od9sgwADy6eGTYRY1c/QlwQgYMvai7kK0aITd8TxySR5tN+nAnC51NEHg==",
       "dev": true,
       "dependencies": {
         "alcalzone-shared": "^4.0.8",
@@ -1427,15 +1427,15 @@
       }
     },
     "node_modules/@zwave-js/testing": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-11.0.0.tgz",
-      "integrity": "sha512-8UyxrWZp49MoCQ3KQuBLBBAhAlD9pF4rzQPUuBCqWyaLor9T/B4H8sN8YSFlSoT/H/1/Y6k+ZgcHgZe7/fFdxw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-11.1.0.tgz",
+      "integrity": "sha512-KGPWx6HptpvyWxh+DKUyjJfK3erGR7RgCPKQG9YWB7ONVbjjTwg+S5KkBqclrh3toO0iV8Vrczsyz710MKDlYw==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "11.0.0",
-        "@zwave-js/host": "11.0.0",
-        "@zwave-js/serial": "11.0.0",
-        "@zwave-js/shared": "11.0.0",
+        "@zwave-js/core": "11.1.0",
+        "@zwave-js/host": "11.1.0",
+        "@zwave-js/serial": "11.1.0",
+        "@zwave-js/shared": "11.1.0",
         "ansi-colors": "^4.1.3"
       },
       "engines": {
@@ -1965,9 +1965,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.8",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.8.tgz",
-      "integrity": "sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ==",
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
+      "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==",
       "dev": true
     },
     "node_modules/debug": {
@@ -4647,9 +4647,9 @@
       }
     },
     "node_modules/zwave-js": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-11.0.0.tgz",
-      "integrity": "sha512-u7m9oRWANILKaCXhKu1o91isSBMIbVyXPyI/72+5bn4WrDW6NpU1Qazvmsx2aCrt9qKhWqgZFYggeByLcM2d4w==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-11.1.0.tgz",
+      "integrity": "sha512-u7fuWL4lODlrB8HJEpMoPp8eBQ1zUGq2laU+UroDxmrj1yakAxItExeCVfEK0fFB5U6/qeWLvwJV/WlvDNuyvw==",
       "dev": true,
       "dependencies": {
         "@alcalzone/jsonl-db": "^3.1.0",
@@ -4658,14 +4658,14 @@
         "@esm2cjs/p-queue": "^7.3.0",
         "@sentry/integrations": "^7.12.1",
         "@sentry/node": "^7.12.1",
-        "@zwave-js/cc": "11.0.0",
-        "@zwave-js/config": "11.0.0",
-        "@zwave-js/core": "11.0.0",
-        "@zwave-js/host": "11.0.0",
-        "@zwave-js/nvmedit": "11.0.0",
-        "@zwave-js/serial": "11.0.0",
-        "@zwave-js/shared": "11.0.0",
-        "@zwave-js/testing": "11.0.0",
+        "@zwave-js/cc": "11.1.0",
+        "@zwave-js/config": "11.1.0",
+        "@zwave-js/core": "11.1.0",
+        "@zwave-js/host": "11.1.0",
+        "@zwave-js/nvmedit": "11.1.0",
+        "@zwave-js/serial": "11.1.0",
+        "@zwave-js/shared": "11.1.0",
+        "@zwave-js/testing": "11.1.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "execa": "^5.1.1",
@@ -4673,7 +4673,7 @@
         "mdns-server": "^1.0.11",
         "proper-lockfile": "^4.1.2",
         "reflect-metadata": "^0.1.13",
-        "semver": "^7.5.0",
+        "semver": "^7.5.2",
         "serialport": "^10.4.0",
         "source-map-support": "^0.5.21",
         "winston": "^3.8.2",
@@ -5099,60 +5099,60 @@
       }
     },
     "@sentry-internal/tracing": {
-      "version": "7.56.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.56.0.tgz",
-      "integrity": "sha512-OKI4Pz/O13gng8hT9rNc+gRV3+P7nnk1HnHlV8fgaQydS6DsRxoDL1sHa42tZGbh7K9jqNAP3TC6VjBOsr2tXA==",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.57.0.tgz",
+      "integrity": "sha512-tpViyDd8AhQGYYhI94xi2aaDopXOPfL2Apwrtb3qirWkomIQ2K86W1mPmkce+B0cFOnW2Dxv/ZTFKz6ghjK75A==",
       "dev": true,
       "requires": {
-        "@sentry/core": "7.56.0",
-        "@sentry/types": "7.56.0",
-        "@sentry/utils": "7.56.0",
-        "tslib": "^1.9.3"
+        "@sentry/core": "7.57.0",
+        "@sentry/types": "7.57.0",
+        "@sentry/utils": "7.57.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "dependencies": {
         "@sentry/types": {
-          "version": "7.56.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.56.0.tgz",
-          "integrity": "sha512-5WjhVOQm75ItOytOx2jTx+5yw8/qJ316+g1Di8dS9+kgIi1zniqdMcX00C2yYe3FMUgFB49PegCUYulm9Evapw==",
+          "version": "7.57.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.57.0.tgz",
+          "integrity": "sha512-D7ifoUfxuVCUyktIr5Gc+jXUbtcUMmfHdTtTbf1XCZHua5mJceK9wtl3YCg3eq/HK2Ppd52BKnTzEcS5ZKQM+w==",
           "dev": true
         },
         "@sentry/utils": {
-          "version": "7.56.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.56.0.tgz",
-          "integrity": "sha512-wgeX7bufxc//TjjSIE+gCMm8hVId7Jzvc+f441bYrWnNZBuzPIDW2BummCcPrKzSYe5GeYZDTZGV8YZGMLGBjw==",
+          "version": "7.57.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.57.0.tgz",
+          "integrity": "sha512-YXrkMCiNklqkXctn4mKYkrzNCf/dfVcRUQrkXjeBC+PHXbcpPyaJgInNvztR7Skl8lE3JPGPN4v5XhLxK1bUUg==",
           "dev": true,
           "requires": {
-            "@sentry/types": "7.56.0",
-            "tslib": "^1.9.3"
+            "@sentry/types": "7.57.0",
+            "tslib": "^2.4.1 || ^1.9.3"
           }
         }
       }
     },
     "@sentry/core": {
-      "version": "7.56.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.56.0.tgz",
-      "integrity": "sha512-Nuyyfh09Yz27kPo74fXHlrdmZeK6zrlJVtxQ6LkwuoaTBcNcesNXVaOtr6gjvUGUmsfriVPP3Jero5LXufV7GQ==",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.57.0.tgz",
+      "integrity": "sha512-l014NudPH0vQlzybtXajPxYFfs9w762NoarjObC3gu76D1jzBBFzhdRelkGpDbSLNTIsKhEDDRpgAjBWJ9icfw==",
       "dev": true,
       "requires": {
-        "@sentry/types": "7.56.0",
-        "@sentry/utils": "7.56.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.57.0",
+        "@sentry/utils": "7.57.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "dependencies": {
         "@sentry/types": {
-          "version": "7.56.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.56.0.tgz",
-          "integrity": "sha512-5WjhVOQm75ItOytOx2jTx+5yw8/qJ316+g1Di8dS9+kgIi1zniqdMcX00C2yYe3FMUgFB49PegCUYulm9Evapw==",
+          "version": "7.57.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.57.0.tgz",
+          "integrity": "sha512-D7ifoUfxuVCUyktIr5Gc+jXUbtcUMmfHdTtTbf1XCZHua5mJceK9wtl3YCg3eq/HK2Ppd52BKnTzEcS5ZKQM+w==",
           "dev": true
         },
         "@sentry/utils": {
-          "version": "7.56.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.56.0.tgz",
-          "integrity": "sha512-wgeX7bufxc//TjjSIE+gCMm8hVId7Jzvc+f441bYrWnNZBuzPIDW2BummCcPrKzSYe5GeYZDTZGV8YZGMLGBjw==",
+          "version": "7.57.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.57.0.tgz",
+          "integrity": "sha512-YXrkMCiNklqkXctn4mKYkrzNCf/dfVcRUQrkXjeBC+PHXbcpPyaJgInNvztR7Skl8lE3JPGPN4v5XhLxK1bUUg==",
           "dev": true,
           "requires": {
-            "@sentry/types": "7.56.0",
-            "tslib": "^1.9.3"
+            "@sentry/types": "7.57.0",
+            "tslib": "^2.4.1 || ^1.9.3"
           }
         }
       }
@@ -5170,35 +5170,35 @@
       }
     },
     "@sentry/node": {
-      "version": "7.56.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.56.0.tgz",
-      "integrity": "sha512-QXbWy/ypRxfFd8iP6zLvHInYZyjGKPrkVNYt43mhKAZHm764NxX/29vDfj1FztgG9Z6lVLIG2eyqTvLruYmsWw==",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.57.0.tgz",
+      "integrity": "sha512-63mjyUVM6sfJFVQ5TGVRVGUsoEfESl5ABzIW1W0s9gUiQPaG8SOdaQJglb2VNrkMYxnRHgD8Q9LUh/qcmUyPGw==",
       "dev": true,
       "requires": {
-        "@sentry-internal/tracing": "7.56.0",
-        "@sentry/core": "7.56.0",
-        "@sentry/types": "7.56.0",
-        "@sentry/utils": "7.56.0",
+        "@sentry-internal/tracing": "7.57.0",
+        "@sentry/core": "7.57.0",
+        "@sentry/types": "7.57.0",
+        "@sentry/utils": "7.57.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "dependencies": {
         "@sentry/types": {
-          "version": "7.56.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.56.0.tgz",
-          "integrity": "sha512-5WjhVOQm75ItOytOx2jTx+5yw8/qJ316+g1Di8dS9+kgIi1zniqdMcX00C2yYe3FMUgFB49PegCUYulm9Evapw==",
+          "version": "7.57.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.57.0.tgz",
+          "integrity": "sha512-D7ifoUfxuVCUyktIr5Gc+jXUbtcUMmfHdTtTbf1XCZHua5mJceK9wtl3YCg3eq/HK2Ppd52BKnTzEcS5ZKQM+w==",
           "dev": true
         },
         "@sentry/utils": {
-          "version": "7.56.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.56.0.tgz",
-          "integrity": "sha512-wgeX7bufxc//TjjSIE+gCMm8hVId7Jzvc+f441bYrWnNZBuzPIDW2BummCcPrKzSYe5GeYZDTZGV8YZGMLGBjw==",
+          "version": "7.57.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.57.0.tgz",
+          "integrity": "sha512-YXrkMCiNklqkXctn4mKYkrzNCf/dfVcRUQrkXjeBC+PHXbcpPyaJgInNvztR7Skl8lE3JPGPN4v5XhLxK1bUUg==",
           "dev": true,
           "requires": {
-            "@sentry/types": "7.56.0",
-            "tslib": "^1.9.3"
+            "@sentry/types": "7.57.0",
+            "tslib": "^2.4.1 || ^1.9.3"
           }
         }
       }
@@ -5554,45 +5554,45 @@
       }
     },
     "@zwave-js/cc": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-11.0.0.tgz",
-      "integrity": "sha512-DRaEz8vdS8H6FODY4h5HS2LXvcY6SLJaRo0NLrZXMbg0xbJkXLhyb7ySZ5FukEZKPggC096ulphBHVFP1QcXKQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-11.1.0.tgz",
+      "integrity": "sha512-QVJ32vYi7CRsVYLryOsD9yvF5SY+4EUBGrH40/wK7uHmrm7s/isvoaniHsm9wAy77nUyTIeSxipsLKRZ82FDvA==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "11.0.0",
-        "@zwave-js/host": "11.0.0",
-        "@zwave-js/serial": "11.0.0",
-        "@zwave-js/shared": "11.0.0",
+        "@zwave-js/core": "11.1.0",
+        "@zwave-js/host": "11.1.0",
+        "@zwave-js/serial": "11.1.0",
+        "@zwave-js/shared": "11.1.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "reflect-metadata": "^0.1.13"
       }
     },
     "@zwave-js/config": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-11.0.0.tgz",
-      "integrity": "sha512-nm3vs9pdAXzeAf503CQVaS88MqTgq82DrwTZH678KBE9dtgV9oXmpLM6ImykdWjALoMD208HV7PnGqq13AytFg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-11.1.0.tgz",
+      "integrity": "sha512-ZmQzg9CwcdhwYZbW/70RpaQQJAw7xw05Te7v5MKzJUD3yRzlGi1gJZ+8fjKSVBG8bE25fO08yg4oZs3wMGNxKg==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "11.0.0",
-        "@zwave-js/shared": "11.0.0",
+        "@zwave-js/core": "11.1.0",
+        "@zwave-js/shared": "11.1.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "fs-extra": "^10.1.0",
         "json-logic-js": "^2.0.2",
         "json5": "^2.2.3",
-        "semver": "^7.5.0",
+        "semver": "^7.5.2",
         "winston": "^3.8.2"
       }
     },
     "@zwave-js/core": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-11.0.0.tgz",
-      "integrity": "sha512-yLYhiI060dmKscJNCdhDxrBsGSEGhd2IyOFyXOeQO4913ZO6yvgsJORca8eFFvoyUJn4TVqPYb3ZoTE9qyDXxA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-11.1.0.tgz",
+      "integrity": "sha512-L051D4QWGWpoCB1YxVZtc3wmGlDGN9bpdAWREvDBpcfUsbKGK0JNc2LoS+hGj7kXgp7dPxwp4MwBMkkBH6k/0g==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^3.1.0",
-        "@zwave-js/shared": "11.0.0",
+        "@zwave-js/shared": "11.1.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "dayjs": "^1.11.7",
@@ -5606,52 +5606,52 @@
       }
     },
     "@zwave-js/host": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-11.0.0.tgz",
-      "integrity": "sha512-dRFtxGO+xNwruObPMffGNKXmPdqvO7LiIgvmbC+oVlgqOt6zQ+SYAsf+XxLHg5C/iZiOrUaxfOtmddzoBGiUtA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-11.1.0.tgz",
+      "integrity": "sha512-UTcP3hUaBO0puy5s0kQIIEQI3Y40MV62SCiaaVY2CEuPfCTVS6qII9Zn5RVVV2qa44AnuPmOl9C2V71gqEEgwg==",
       "dev": true,
       "requires": {
-        "@zwave-js/config": "11.0.0",
-        "@zwave-js/core": "11.0.0",
-        "@zwave-js/shared": "11.0.0",
+        "@zwave-js/config": "11.1.0",
+        "@zwave-js/core": "11.1.0",
+        "@zwave-js/shared": "11.1.0",
         "alcalzone-shared": "^4.0.8"
       }
     },
     "@zwave-js/nvmedit": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-11.0.0.tgz",
-      "integrity": "sha512-gPgcSkn1HgDW5+J7BnPTMWZglT3C0kIRjGqkh2MT9iMjHAsyj3TT2t92FYUVJClw0KkEDduHl7NonYYI5eBzHA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-11.1.0.tgz",
+      "integrity": "sha512-IkVEG1jGbI8nPuHJBFd7qXhpK8TxiZe+mSX23Ov1sOA6j7Ru1eT8hko7R4EDRN/cyYCyx9nsjgySubMzj34eIA==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "11.0.0",
-        "@zwave-js/shared": "11.0.0",
+        "@zwave-js/core": "11.1.0",
+        "@zwave-js/shared": "11.1.0",
         "alcalzone-shared": "^4.0.8",
         "fs-extra": "^10.1.0",
         "reflect-metadata": "^0.1.13",
-        "semver": "^7.5.0",
+        "semver": "^7.5.2",
         "yargs": "^17.7.2"
       }
     },
     "@zwave-js/serial": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-11.0.0.tgz",
-      "integrity": "sha512-P70yF+JxWlpp7qE342vgPm+eQMHoDOhEILxVrQRU75EPqRqxdhnYr001xDGu0kGWFymz6u4SQ+4g0RHQzr+wng==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-11.1.0.tgz",
+      "integrity": "sha512-z25tH1nyogpSgUId8r8+M8IG8+Eksz4wN/ULlG5ApFQxOzJkic4Fo/bdoCmReTYgA8RFzPdlnwJwMhdFb+qVbw==",
       "dev": true,
       "requires": {
         "@sentry/node": "^7.12.1",
         "@serialport/stream": "^10.3.0",
-        "@zwave-js/core": "11.0.0",
-        "@zwave-js/host": "11.0.0",
-        "@zwave-js/shared": "11.0.0",
+        "@zwave-js/core": "11.1.0",
+        "@zwave-js/host": "11.1.0",
+        "@zwave-js/shared": "11.1.0",
         "alcalzone-shared": "^4.0.8",
         "serialport": "^10.4.0",
         "winston": "^3.8.2"
       }
     },
     "@zwave-js/shared": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-11.0.0.tgz",
-      "integrity": "sha512-2KovZFoN68ydhZ7vGycHSvmNzIyon42NxNcl28HE6KHI2eUWoJJBfAMrY1vWPGNJVAzNLoUxL2gWj0ZvJTDUeQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-11.1.0.tgz",
+      "integrity": "sha512-aegwOgeG4r3aLtGF6Dc9fEjmNNr+1Od9sgwADy6eGTYRY1c/QlwQgYMvai7kK0aITd8TxySR5tN+nAnC51NEHg==",
       "dev": true,
       "requires": {
         "alcalzone-shared": "^4.0.8",
@@ -5659,15 +5659,15 @@
       }
     },
     "@zwave-js/testing": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-11.0.0.tgz",
-      "integrity": "sha512-8UyxrWZp49MoCQ3KQuBLBBAhAlD9pF4rzQPUuBCqWyaLor9T/B4H8sN8YSFlSoT/H/1/Y6k+ZgcHgZe7/fFdxw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-11.1.0.tgz",
+      "integrity": "sha512-KGPWx6HptpvyWxh+DKUyjJfK3erGR7RgCPKQG9YWB7ONVbjjTwg+S5KkBqclrh3toO0iV8Vrczsyz710MKDlYw==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "11.0.0",
-        "@zwave-js/host": "11.0.0",
-        "@zwave-js/serial": "11.0.0",
-        "@zwave-js/shared": "11.0.0",
+        "@zwave-js/core": "11.1.0",
+        "@zwave-js/host": "11.1.0",
+        "@zwave-js/serial": "11.1.0",
+        "@zwave-js/shared": "11.1.0",
         "ansi-colors": "^4.1.3"
       }
     },
@@ -6074,9 +6074,9 @@
       }
     },
     "dayjs": {
-      "version": "1.11.8",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.8.tgz",
-      "integrity": "sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ==",
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
+      "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==",
       "dev": true
     },
     "debug": {
@@ -8003,9 +8003,9 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-11.0.0.tgz",
-      "integrity": "sha512-u7m9oRWANILKaCXhKu1o91isSBMIbVyXPyI/72+5bn4WrDW6NpU1Qazvmsx2aCrt9qKhWqgZFYggeByLcM2d4w==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-11.1.0.tgz",
+      "integrity": "sha512-u7fuWL4lODlrB8HJEpMoPp8eBQ1zUGq2laU+UroDxmrj1yakAxItExeCVfEK0fFB5U6/qeWLvwJV/WlvDNuyvw==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^3.1.0",
@@ -8014,14 +8014,14 @@
         "@esm2cjs/p-queue": "^7.3.0",
         "@sentry/integrations": "^7.12.1",
         "@sentry/node": "^7.12.1",
-        "@zwave-js/cc": "11.0.0",
-        "@zwave-js/config": "11.0.0",
-        "@zwave-js/core": "11.0.0",
-        "@zwave-js/host": "11.0.0",
-        "@zwave-js/nvmedit": "11.0.0",
-        "@zwave-js/serial": "11.0.0",
-        "@zwave-js/shared": "11.0.0",
-        "@zwave-js/testing": "11.0.0",
+        "@zwave-js/cc": "11.1.0",
+        "@zwave-js/config": "11.1.0",
+        "@zwave-js/core": "11.1.0",
+        "@zwave-js/host": "11.1.0",
+        "@zwave-js/nvmedit": "11.1.0",
+        "@zwave-js/serial": "11.1.0",
+        "@zwave-js/shared": "11.1.0",
+        "@zwave-js/testing": "11.1.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "execa": "^5.1.1",
@@ -8029,7 +8029,7 @@
         "mdns-server": "^1.0.11",
         "proper-lockfile": "^4.1.2",
         "reflect-metadata": "^0.1.13",
-        "semver": "^7.5.0",
+        "semver": "^7.5.2",
         "serialport": "^10.4.0",
         "source-map-support": "^0.5.21",
         "winston": "^3.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "description": "Full access to zwave-js driver through Websockets",
   "homepage": "https://github.com/zwave-js/zwave-js-server#readme",
   "repository": {
@@ -34,7 +34,7 @@
     "ws": "^8.0.0"
   },
   "peerDependencies": {
-    "zwave-js": "^11.0.0"
+    "zwave-js": "^11.1.0"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -53,7 +53,7 @@
     "semver": "^7.3.5",
     "ts-node": "^10.5.0",
     "typescript": "^5.0.2",
-    "zwave-js": "^11.0.0"
+    "zwave-js": "^11.1.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This is so we can release the new method to set user inclusion callbacks to unblock zwave-js-ui

CC @robertsLando  @AlCalzone 