### PR TITLE
Bump zwave-js to 11.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,6 +879,30 @@ interface {
 }
 ```
 
+#### [Set Default Volume](https://zwave-js.github.io/node-zwave-js/#/api/node?id=defaultvolume)
+
+[compatible with schema version: 31+]
+
+```ts
+interface {
+  messageId: string;
+  command: "node.set_default_volume";
+  defaultVolume?: number;
+}
+```
+
+#### [Set Default Transition Duration](https://zwave-js.github.io/node-zwave-js/#/api/node?id=defaulttransitionduration)
+
+[compatible with schema version: 31+]
+
+```ts
+interface {
+  messageId: string;
+  command: "node.set_default_transition_duration";
+  defaultTransitionDuration?: string; // Will be converted to a Duration object
+}
+```
+
 ### Endpoint level commands
 
 #### [Invoke a Command Classes API method](https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=invokeccapi)

--- a/README.md
+++ b/README.md
@@ -903,6 +903,17 @@ interface {
 }
 ```
 
+#### [Has Device Config Changed](https://zwave-js.github.io/node-zwave-js/#/api/node?id=hasdeviceconfigchanged)
+
+[compatible with schema version: 31+]
+
+```ts
+interface {
+  messageId: string;
+  command: "node.has_device_config_changed";
+}
+```
+
 ### Endpoint level commands
 
 #### [Invoke a Command Classes API method](https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=invokeccapi)

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,10 +34,10 @@
         "semver": "^7.5.4",
         "ts-node": "^10.9.1",
         "typescript": "^5.1.6",
-        "zwave-js": "^11.11.0"
+        "zwave-js": "^11.13.0"
       },
       "peerDependencies": {
-        "zwave-js": "^11.11.0"
+        "zwave-js": "^11.13.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1382,15 +1382,15 @@
       }
     },
     "node_modules/@zwave-js/cc": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-11.11.0.tgz",
-      "integrity": "sha512-ku5yynsZbwzcWCyYo/R7MJF+lCWXSYyNktdI2MufPvNyuo5tfeKlnagFtykEqepoqOCC296A0X2Ib870ojrKxw==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-11.13.0.tgz",
+      "integrity": "sha512-fmk34PzLjKJf7i/JtqqNL62v1Q+vTlAPyLLYgAf6F6Pag3Yazwp4gjyFFtj+ClSovmvlDMPbkbpob/H903t4nA==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "11.9.1",
-        "@zwave-js/host": "11.11.0",
-        "@zwave-js/serial": "11.11.0",
-        "@zwave-js/shared": "11.8.0",
+        "@zwave-js/core": "11.13.0",
+        "@zwave-js/host": "11.13.0",
+        "@zwave-js/serial": "11.13.0",
+        "@zwave-js/shared": "11.13.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "reflect-metadata": "^0.1.13"
@@ -1403,13 +1403,13 @@
       }
     },
     "node_modules/@zwave-js/config": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-11.11.0.tgz",
-      "integrity": "sha512-niYE7buGcEEYONOngE+t4PgmqABtCMai0fDKAUvgY4zstU4yQUicar+5kfiKOhEqcjHT3u6Tt2EUw0+GgAGuHg==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-11.13.0.tgz",
+      "integrity": "sha512-lJn0OOXxYe74GvdjdywlLw7gfgC+Z2i4dmOlt21S15NApdpJFlz5v22JZVELiHW6aBRj2dcDbBLT/iP09N9TNQ==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "11.9.1",
-        "@zwave-js/shared": "11.8.0",
+        "@zwave-js/core": "11.13.0",
+        "@zwave-js/shared": "11.13.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "fs-extra": "^10.1.0",
@@ -1426,13 +1426,13 @@
       }
     },
     "node_modules/@zwave-js/core": {
-      "version": "11.9.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-11.9.1.tgz",
-      "integrity": "sha512-bfkGk+kWobTC6p4xswgSkdKKF45oMh3dq6isuL1uL0KPVnD1kAq2QlRpisG6Fl3BVnXiB48o6TvWaRyhkHHk6w==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-11.13.0.tgz",
+      "integrity": "sha512-jZlu8iOgT635SE1S3EbeOOBucJW8SJygZlpGMAW/OWaXABGfxeZsh4ZQ5P9bK12ONYegvpDx6LE+briYFFSZBw==",
       "dev": true,
       "dependencies": {
         "@alcalzone/jsonl-db": "^3.1.0",
-        "@zwave-js/shared": "11.8.0",
+        "@zwave-js/shared": "11.13.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "dayjs": "^1.11.7",
@@ -1452,14 +1452,14 @@
       }
     },
     "node_modules/@zwave-js/host": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-11.11.0.tgz",
-      "integrity": "sha512-Wc5wa//JGPoCnQIxXug9XV5NOPFlnpAnU+QvdAk11YIQU5Srjr8e4L1+Gyi0we0EuDdLcQvFo5wHBHqycTXh/Q==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-11.13.0.tgz",
+      "integrity": "sha512-Zd/D3XDHWpl2Lbt87mjjV/DGxWUIKgqTM+V2PwlW+447YoeMYrXZZUeCiQ3PEPgyB41eZXtmWT7Cx+Yn3b5btA==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/config": "11.11.0",
-        "@zwave-js/core": "11.9.1",
-        "@zwave-js/shared": "11.8.0",
+        "@zwave-js/config": "11.13.0",
+        "@zwave-js/core": "11.13.0",
+        "@zwave-js/shared": "11.13.0",
         "alcalzone-shared": "^4.0.8"
       },
       "engines": {
@@ -1470,13 +1470,13 @@
       }
     },
     "node_modules/@zwave-js/nvmedit": {
-      "version": "11.9.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-11.9.1.tgz",
-      "integrity": "sha512-QfsJbb8t2VlkGIhB4V3XhzBA0u8ViDbA+2KcJqtQWTo5715wWJnJ2J2s9mcPmw946l4Hsv3dC5LfaztbgSxnUw==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-11.13.0.tgz",
+      "integrity": "sha512-a/rxGfvJwkrIyALtbCkhWEXx38V9Zi6h6Qa1Mn2lG9ssrLwsir7HA4aCuWoHywFDJdQ0QTPUwHPL3Lj5PCj1VA==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "11.9.1",
-        "@zwave-js/shared": "11.8.0",
+        "@zwave-js/core": "11.13.0",
+        "@zwave-js/shared": "11.13.0",
         "alcalzone-shared": "^4.0.8",
         "fs-extra": "^10.1.0",
         "reflect-metadata": "^0.1.13",
@@ -1494,16 +1494,16 @@
       }
     },
     "node_modules/@zwave-js/serial": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-11.11.0.tgz",
-      "integrity": "sha512-mA0Y8rV119LGKV4eovd708fW/IpoegLrUJhxfuVFUP3HhHdpVzyztgcfPWCCiL5X8LXFIzvK+Vfboe9vBdnFrA==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-11.13.0.tgz",
+      "integrity": "sha512-Hiw6nh2fnMu3tSq1EZFBFV5Geo0+1s3YMwKXbnQPLX94CvzFbQaDgiv/BWWhrdKexC9wXFR65VCSADBfHufSrQ==",
       "dev": true,
       "dependencies": {
         "@sentry/node": "^7.12.1",
         "@serialport/stream": "^10.3.0",
-        "@zwave-js/core": "11.9.1",
-        "@zwave-js/host": "11.11.0",
-        "@zwave-js/shared": "11.8.0",
+        "@zwave-js/core": "11.13.0",
+        "@zwave-js/host": "11.13.0",
+        "@zwave-js/shared": "11.13.0",
         "alcalzone-shared": "^4.0.8",
         "serialport": "^10.4.0",
         "winston": "^3.8.2"
@@ -1516,9 +1516,9 @@
       }
     },
     "node_modules/@zwave-js/shared": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-11.8.0.tgz",
-      "integrity": "sha512-xEh31zJ+qIjcmFv249yxPCCUlZExwk+qKRcLxXqOsDyt7GUyU5jzEqoGlDe0ijCWmZxlbJdmXzOU/a9IhAffzw==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-11.13.0.tgz",
+      "integrity": "sha512-EV+0B3XHcoP1Ix8vSPkAH2pUPgg/wxej7JnNhKvByiglSuTZ1YBNaOKaMut/UCd2WcNDjiG1GZqdSh4Q5LYIAg==",
       "dev": true,
       "dependencies": {
         "alcalzone-shared": "^4.0.8",
@@ -1532,15 +1532,15 @@
       }
     },
     "node_modules/@zwave-js/testing": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-11.11.0.tgz",
-      "integrity": "sha512-AXnhnXz9x/xFRx3UoOCYTmH6cmNi0DrdtHKgZnRVkD4y+J3RJU611PFtyiwlU9nrDTTttaSxn+QZkzO9KzMGIw==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-11.13.0.tgz",
+      "integrity": "sha512-pXVSmsnTv7TTPAfLyFXsMrFWHyXFWC2fmK2rSaFWXwoHJyNzWJI0cEdIo7LQJjRXbzHZ3I1S/25Q0DYZ+qAnJQ==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/core": "11.9.1",
-        "@zwave-js/host": "11.11.0",
-        "@zwave-js/serial": "11.11.0",
-        "@zwave-js/shared": "11.8.0",
+        "@zwave-js/core": "11.13.0",
+        "@zwave-js/host": "11.13.0",
+        "@zwave-js/serial": "11.13.0",
+        "@zwave-js/shared": "11.13.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3"
       },
@@ -3594,9 +3594,9 @@
       "dev": true
     },
     "node_modules/node-gyp-build": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
+      "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
       "dev": true,
       "bin": {
         "node-gyp-build": "bin.js",
@@ -4704,9 +4704,9 @@
       }
     },
     "node_modules/zwave-js": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-11.11.0.tgz",
-      "integrity": "sha512-L5B178E860U6fK3Kgavxa3bsmcYCmsIEZ1pLLnFKKn3Q3QQA9gT7mhJSaTkdomVWGtVmnSbPonKc4IJRHEsYwg==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-11.13.0.tgz",
+      "integrity": "sha512-oa7dP95HM+0yVV/5ktCHxO3k4tZR4jeXlELZYxiv6gWRe1+T5rWrEVF1Lf00l2bR7Br1vNUco7yGbEPQDeAhbQ==",
       "dev": true,
       "dependencies": {
         "@alcalzone/jsonl-db": "^3.1.0",
@@ -4715,14 +4715,14 @@
         "@esm2cjs/p-queue": "^7.3.0",
         "@sentry/integrations": "^7.12.1",
         "@sentry/node": "^7.12.1",
-        "@zwave-js/cc": "11.11.0",
-        "@zwave-js/config": "11.11.0",
-        "@zwave-js/core": "11.9.1",
-        "@zwave-js/host": "11.11.0",
-        "@zwave-js/nvmedit": "11.9.1",
-        "@zwave-js/serial": "11.11.0",
-        "@zwave-js/shared": "11.8.0",
-        "@zwave-js/testing": "11.11.0",
+        "@zwave-js/cc": "11.13.0",
+        "@zwave-js/config": "11.13.0",
+        "@zwave-js/core": "11.13.0",
+        "@zwave-js/host": "11.13.0",
+        "@zwave-js/nvmedit": "11.13.0",
+        "@zwave-js/serial": "11.13.0",
+        "@zwave-js/shared": "11.13.0",
+        "@zwave-js/testing": "11.13.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "execa": "^5.1.1",
@@ -5673,28 +5673,28 @@
       }
     },
     "@zwave-js/cc": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-11.11.0.tgz",
-      "integrity": "sha512-ku5yynsZbwzcWCyYo/R7MJF+lCWXSYyNktdI2MufPvNyuo5tfeKlnagFtykEqepoqOCC296A0X2Ib870ojrKxw==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-11.13.0.tgz",
+      "integrity": "sha512-fmk34PzLjKJf7i/JtqqNL62v1Q+vTlAPyLLYgAf6F6Pag3Yazwp4gjyFFtj+ClSovmvlDMPbkbpob/H903t4nA==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "11.9.1",
-        "@zwave-js/host": "11.11.0",
-        "@zwave-js/serial": "11.11.0",
-        "@zwave-js/shared": "11.8.0",
+        "@zwave-js/core": "11.13.0",
+        "@zwave-js/host": "11.13.0",
+        "@zwave-js/serial": "11.13.0",
+        "@zwave-js/shared": "11.13.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "reflect-metadata": "^0.1.13"
       }
     },
     "@zwave-js/config": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-11.11.0.tgz",
-      "integrity": "sha512-niYE7buGcEEYONOngE+t4PgmqABtCMai0fDKAUvgY4zstU4yQUicar+5kfiKOhEqcjHT3u6Tt2EUw0+GgAGuHg==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-11.13.0.tgz",
+      "integrity": "sha512-lJn0OOXxYe74GvdjdywlLw7gfgC+Z2i4dmOlt21S15NApdpJFlz5v22JZVELiHW6aBRj2dcDbBLT/iP09N9TNQ==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "11.9.1",
-        "@zwave-js/shared": "11.8.0",
+        "@zwave-js/core": "11.13.0",
+        "@zwave-js/shared": "11.13.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "fs-extra": "^10.1.0",
@@ -5705,13 +5705,13 @@
       }
     },
     "@zwave-js/core": {
-      "version": "11.9.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-11.9.1.tgz",
-      "integrity": "sha512-bfkGk+kWobTC6p4xswgSkdKKF45oMh3dq6isuL1uL0KPVnD1kAq2QlRpisG6Fl3BVnXiB48o6TvWaRyhkHHk6w==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-11.13.0.tgz",
+      "integrity": "sha512-jZlu8iOgT635SE1S3EbeOOBucJW8SJygZlpGMAW/OWaXABGfxeZsh4ZQ5P9bK12ONYegvpDx6LE+briYFFSZBw==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^3.1.0",
-        "@zwave-js/shared": "11.8.0",
+        "@zwave-js/shared": "11.13.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "dayjs": "^1.11.7",
@@ -5725,25 +5725,25 @@
       }
     },
     "@zwave-js/host": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-11.11.0.tgz",
-      "integrity": "sha512-Wc5wa//JGPoCnQIxXug9XV5NOPFlnpAnU+QvdAk11YIQU5Srjr8e4L1+Gyi0we0EuDdLcQvFo5wHBHqycTXh/Q==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-11.13.0.tgz",
+      "integrity": "sha512-Zd/D3XDHWpl2Lbt87mjjV/DGxWUIKgqTM+V2PwlW+447YoeMYrXZZUeCiQ3PEPgyB41eZXtmWT7Cx+Yn3b5btA==",
       "dev": true,
       "requires": {
-        "@zwave-js/config": "11.11.0",
-        "@zwave-js/core": "11.9.1",
-        "@zwave-js/shared": "11.8.0",
+        "@zwave-js/config": "11.13.0",
+        "@zwave-js/core": "11.13.0",
+        "@zwave-js/shared": "11.13.0",
         "alcalzone-shared": "^4.0.8"
       }
     },
     "@zwave-js/nvmedit": {
-      "version": "11.9.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-11.9.1.tgz",
-      "integrity": "sha512-QfsJbb8t2VlkGIhB4V3XhzBA0u8ViDbA+2KcJqtQWTo5715wWJnJ2J2s9mcPmw946l4Hsv3dC5LfaztbgSxnUw==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-11.13.0.tgz",
+      "integrity": "sha512-a/rxGfvJwkrIyALtbCkhWEXx38V9Zi6h6Qa1Mn2lG9ssrLwsir7HA4aCuWoHywFDJdQ0QTPUwHPL3Lj5PCj1VA==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "11.9.1",
-        "@zwave-js/shared": "11.8.0",
+        "@zwave-js/core": "11.13.0",
+        "@zwave-js/shared": "11.13.0",
         "alcalzone-shared": "^4.0.8",
         "fs-extra": "^10.1.0",
         "reflect-metadata": "^0.1.13",
@@ -5752,25 +5752,25 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-11.11.0.tgz",
-      "integrity": "sha512-mA0Y8rV119LGKV4eovd708fW/IpoegLrUJhxfuVFUP3HhHdpVzyztgcfPWCCiL5X8LXFIzvK+Vfboe9vBdnFrA==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-11.13.0.tgz",
+      "integrity": "sha512-Hiw6nh2fnMu3tSq1EZFBFV5Geo0+1s3YMwKXbnQPLX94CvzFbQaDgiv/BWWhrdKexC9wXFR65VCSADBfHufSrQ==",
       "dev": true,
       "requires": {
         "@sentry/node": "^7.12.1",
         "@serialport/stream": "^10.3.0",
-        "@zwave-js/core": "11.9.1",
-        "@zwave-js/host": "11.11.0",
-        "@zwave-js/shared": "11.8.0",
+        "@zwave-js/core": "11.13.0",
+        "@zwave-js/host": "11.13.0",
+        "@zwave-js/shared": "11.13.0",
         "alcalzone-shared": "^4.0.8",
         "serialport": "^10.4.0",
         "winston": "^3.8.2"
       }
     },
     "@zwave-js/shared": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-11.8.0.tgz",
-      "integrity": "sha512-xEh31zJ+qIjcmFv249yxPCCUlZExwk+qKRcLxXqOsDyt7GUyU5jzEqoGlDe0ijCWmZxlbJdmXzOU/a9IhAffzw==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-11.13.0.tgz",
+      "integrity": "sha512-EV+0B3XHcoP1Ix8vSPkAH2pUPgg/wxej7JnNhKvByiglSuTZ1YBNaOKaMut/UCd2WcNDjiG1GZqdSh4Q5LYIAg==",
       "dev": true,
       "requires": {
         "alcalzone-shared": "^4.0.8",
@@ -5778,15 +5778,15 @@
       }
     },
     "@zwave-js/testing": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-11.11.0.tgz",
-      "integrity": "sha512-AXnhnXz9x/xFRx3UoOCYTmH6cmNi0DrdtHKgZnRVkD4y+J3RJU611PFtyiwlU9nrDTTttaSxn+QZkzO9KzMGIw==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-11.13.0.tgz",
+      "integrity": "sha512-pXVSmsnTv7TTPAfLyFXsMrFWHyXFWC2fmK2rSaFWXwoHJyNzWJI0cEdIo7LQJjRXbzHZ3I1S/25Q0DYZ+qAnJQ==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "11.9.1",
-        "@zwave-js/host": "11.11.0",
-        "@zwave-js/serial": "11.11.0",
-        "@zwave-js/shared": "11.8.0",
+        "@zwave-js/core": "11.13.0",
+        "@zwave-js/host": "11.13.0",
+        "@zwave-js/serial": "11.13.0",
+        "@zwave-js/shared": "11.13.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3"
       }
@@ -7307,9 +7307,9 @@
       "dev": true
     },
     "node-gyp-build": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
+      "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
       "dev": true
     },
     "npm-run-path": {
@@ -8060,9 +8060,9 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-11.11.0.tgz",
-      "integrity": "sha512-L5B178E860U6fK3Kgavxa3bsmcYCmsIEZ1pLLnFKKn3Q3QQA9gT7mhJSaTkdomVWGtVmnSbPonKc4IJRHEsYwg==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-11.13.0.tgz",
+      "integrity": "sha512-oa7dP95HM+0yVV/5ktCHxO3k4tZR4jeXlELZYxiv6gWRe1+T5rWrEVF1Lf00l2bR7Br1vNUco7yGbEPQDeAhbQ==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^3.1.0",
@@ -8071,14 +8071,14 @@
         "@esm2cjs/p-queue": "^7.3.0",
         "@sentry/integrations": "^7.12.1",
         "@sentry/node": "^7.12.1",
-        "@zwave-js/cc": "11.11.0",
-        "@zwave-js/config": "11.11.0",
-        "@zwave-js/core": "11.9.1",
-        "@zwave-js/host": "11.11.0",
-        "@zwave-js/nvmedit": "11.9.1",
-        "@zwave-js/serial": "11.11.0",
-        "@zwave-js/shared": "11.8.0",
-        "@zwave-js/testing": "11.11.0",
+        "@zwave-js/cc": "11.13.0",
+        "@zwave-js/config": "11.13.0",
+        "@zwave-js/core": "11.13.0",
+        "@zwave-js/host": "11.13.0",
+        "@zwave-js/nvmedit": "11.13.0",
+        "@zwave-js/serial": "11.13.0",
+        "@zwave-js/shared": "11.13.0",
+        "@zwave-js/testing": "11.13.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "execa": "^5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,10 +34,10 @@
         "semver": "^7.5.4",
         "ts-node": "^10.9.1",
         "typescript": "^5.1.6",
-        "zwave-js": "^11.10.0"
+        "zwave-js": "^11.11.0"
       },
       "peerDependencies": {
-        "zwave-js": "^11.10.0"
+        "zwave-js": "^11.11.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -596,14 +596,14 @@
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.63.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.63.0.tgz",
-      "integrity": "sha512-Fxpc53p6NGvLSURg3iRvZA0k10K9yfeVhtczvJnpX30POBuV41wxpkLHkb68fjksirjEma1K3Ut1iLOEEDpPQg==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.64.0.tgz",
+      "integrity": "sha512-1XE8W6ki7hHyBvX9hfirnGkKDBKNq3bDJyXS86E0bYVDl94nvbRM9BD9DHsCFetqYkVm1yDGEK+6aUVs4CztoQ==",
       "dev": true,
       "dependencies": {
-        "@sentry/core": "7.63.0",
-        "@sentry/types": "7.63.0",
-        "@sentry/utils": "7.63.0",
+        "@sentry/core": "7.64.0",
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -611,21 +611,21 @@
       }
     },
     "node_modules/@sentry-internal/tracing/node_modules/@sentry/types": {
-      "version": "7.63.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.63.0.tgz",
-      "integrity": "sha512-pZNwJVW7RqNLGuTUAhoygt0c9zmc0js10eANAz0MstygJRhQI1tqPDuiELVdujPrbeL+IFKF+7NvRDAydR2Niw==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.64.0.tgz",
+      "integrity": "sha512-LqjQprWXjUFRmzIlUjyA+KL+38elgIYmAeoDrdyNVh8MK5IC1W2Lh1Q87b4yOiZeMiIhIVNBd7Ecoh2rodGrGA==",
       "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry-internal/tracing/node_modules/@sentry/utils": {
-      "version": "7.63.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.63.0.tgz",
-      "integrity": "sha512-7FQv1RYAwnuTuarruP+1+Jd6YQuN7i/Y7KltwPMVEwU7j5mzYQaexLr/Jz1XIdR2KYVdkbXQyP8jj8BmA6u9Jw==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.64.0.tgz",
+      "integrity": "sha512-HRlM1INzK66Gt+F4vCItiwGKAng4gqzCR4C5marsL3qv6SrKH98dQnCGYgXluSWaaa56h97FRQu7TxCk6jkSvQ==",
       "dev": true,
       "dependencies": {
-        "@sentry/types": "7.63.0",
+        "@sentry/types": "7.64.0",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -633,13 +633,13 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.63.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.63.0.tgz",
-      "integrity": "sha512-13Ljiq8hv6ieCkO+Am99/PljYJO5ynKT/hRQrWgGy9IIEgUr8sV3fW+1W6K4/3MCeOJou0HsiGBjOD1mASItVg==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.64.0.tgz",
+      "integrity": "sha512-IzmEyl5sNG7NyEFiyFHEHC+sizsZp9MEw1+RJRLX6U5RITvcsEgcajSkHQFafaBPzRrcxZMdm47Cwhl212LXcw==",
       "dev": true,
       "dependencies": {
-        "@sentry/types": "7.63.0",
-        "@sentry/utils": "7.63.0",
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -647,21 +647,21 @@
       }
     },
     "node_modules/@sentry/core/node_modules/@sentry/types": {
-      "version": "7.63.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.63.0.tgz",
-      "integrity": "sha512-pZNwJVW7RqNLGuTUAhoygt0c9zmc0js10eANAz0MstygJRhQI1tqPDuiELVdujPrbeL+IFKF+7NvRDAydR2Niw==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.64.0.tgz",
+      "integrity": "sha512-LqjQprWXjUFRmzIlUjyA+KL+38elgIYmAeoDrdyNVh8MK5IC1W2Lh1Q87b4yOiZeMiIhIVNBd7Ecoh2rodGrGA==",
       "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core/node_modules/@sentry/utils": {
-      "version": "7.63.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.63.0.tgz",
-      "integrity": "sha512-7FQv1RYAwnuTuarruP+1+Jd6YQuN7i/Y7KltwPMVEwU7j5mzYQaexLr/Jz1XIdR2KYVdkbXQyP8jj8BmA6u9Jw==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.64.0.tgz",
+      "integrity": "sha512-HRlM1INzK66Gt+F4vCItiwGKAng4gqzCR4C5marsL3qv6SrKH98dQnCGYgXluSWaaa56h97FRQu7TxCk6jkSvQ==",
       "dev": true,
       "dependencies": {
-        "@sentry/types": "7.63.0",
+        "@sentry/types": "7.64.0",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -684,15 +684,15 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "7.63.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.63.0.tgz",
-      "integrity": "sha512-tSMyfQNbfjX1w8vJDZtvWeaD4QQ/Z4zVW/TLXfL/JZFIIksPgDZmqLdF+NJS4bSGTU5JiHiUh4pYhME4mHgNBQ==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.64.0.tgz",
+      "integrity": "sha512-wRi0uTnp1WSa83X2yLD49tV9QPzGh5e42IKdIDBiQ7lV9JhLILlyb34BZY1pq6p4dp35yDasDrP3C7ubn7wo6A==",
       "dev": true,
       "dependencies": {
-        "@sentry-internal/tracing": "7.63.0",
-        "@sentry/core": "7.63.0",
-        "@sentry/types": "7.63.0",
-        "@sentry/utils": "7.63.0",
+        "@sentry-internal/tracing": "7.64.0",
+        "@sentry/core": "7.64.0",
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -703,21 +703,21 @@
       }
     },
     "node_modules/@sentry/node/node_modules/@sentry/types": {
-      "version": "7.63.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.63.0.tgz",
-      "integrity": "sha512-pZNwJVW7RqNLGuTUAhoygt0c9zmc0js10eANAz0MstygJRhQI1tqPDuiELVdujPrbeL+IFKF+7NvRDAydR2Niw==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.64.0.tgz",
+      "integrity": "sha512-LqjQprWXjUFRmzIlUjyA+KL+38elgIYmAeoDrdyNVh8MK5IC1W2Lh1Q87b4yOiZeMiIhIVNBd7Ecoh2rodGrGA==",
       "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/node/node_modules/@sentry/utils": {
-      "version": "7.63.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.63.0.tgz",
-      "integrity": "sha512-7FQv1RYAwnuTuarruP+1+Jd6YQuN7i/Y7KltwPMVEwU7j5mzYQaexLr/Jz1XIdR2KYVdkbXQyP8jj8BmA6u9Jw==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.64.0.tgz",
+      "integrity": "sha512-HRlM1INzK66Gt+F4vCItiwGKAng4gqzCR4C5marsL3qv6SrKH98dQnCGYgXluSWaaa56h97FRQu7TxCk6jkSvQ==",
       "dev": true,
       "dependencies": {
-        "@sentry/types": "7.63.0",
+        "@sentry/types": "7.64.0",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
@@ -1382,14 +1382,14 @@
       }
     },
     "node_modules/@zwave-js/cc": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-11.10.0.tgz",
-      "integrity": "sha512-8xtEkn1pMF5pnzCYqg1cJ4Rhqd4DLoEeq8RgG+m2JKpY3NWs8WZwOfekDv2BaI7uWZPLlocgmYmwMpnsvRYyVw==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-11.11.0.tgz",
+      "integrity": "sha512-ku5yynsZbwzcWCyYo/R7MJF+lCWXSYyNktdI2MufPvNyuo5tfeKlnagFtykEqepoqOCC296A0X2Ib870ojrKxw==",
       "dev": true,
       "dependencies": {
         "@zwave-js/core": "11.9.1",
-        "@zwave-js/host": "11.10.0",
-        "@zwave-js/serial": "11.10.0",
+        "@zwave-js/host": "11.11.0",
+        "@zwave-js/serial": "11.11.0",
         "@zwave-js/shared": "11.8.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
@@ -1403,9 +1403,9 @@
       }
     },
     "node_modules/@zwave-js/config": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-11.10.0.tgz",
-      "integrity": "sha512-D0csSHnUBkPkKMtV6pB9uKRrRj3OIfpxjJ2kEo3nu61/eyDSx+HYoyNvt93mWp8A4kNLUIBcwcqIDE92jjclTQ==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-11.11.0.tgz",
+      "integrity": "sha512-niYE7buGcEEYONOngE+t4PgmqABtCMai0fDKAUvgY4zstU4yQUicar+5kfiKOhEqcjHT3u6Tt2EUw0+GgAGuHg==",
       "dev": true,
       "dependencies": {
         "@zwave-js/core": "11.9.1",
@@ -1452,12 +1452,12 @@
       }
     },
     "node_modules/@zwave-js/host": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-11.10.0.tgz",
-      "integrity": "sha512-5ZFKPg7NCLmAb4kHnPQOJ5xehCkba2ZkOYueYgeQMnBP4l0jByG4Q0M6fNxE1sLirOAT6USg1cN6P/RTWq259g==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-11.11.0.tgz",
+      "integrity": "sha512-Wc5wa//JGPoCnQIxXug9XV5NOPFlnpAnU+QvdAk11YIQU5Srjr8e4L1+Gyi0we0EuDdLcQvFo5wHBHqycTXh/Q==",
       "dev": true,
       "dependencies": {
-        "@zwave-js/config": "11.10.0",
+        "@zwave-js/config": "11.11.0",
         "@zwave-js/core": "11.9.1",
         "@zwave-js/shared": "11.8.0",
         "alcalzone-shared": "^4.0.8"
@@ -1494,15 +1494,15 @@
       }
     },
     "node_modules/@zwave-js/serial": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-11.10.0.tgz",
-      "integrity": "sha512-S5GX1fMdDLcdhJGmgVmSIcG2YWuCDn5APpyqF9tKle1fMtRvGTi4Yq/EP7C3pZB2iSKju339Qms0V+oRCZ4u3w==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-11.11.0.tgz",
+      "integrity": "sha512-mA0Y8rV119LGKV4eovd708fW/IpoegLrUJhxfuVFUP3HhHdpVzyztgcfPWCCiL5X8LXFIzvK+Vfboe9vBdnFrA==",
       "dev": true,
       "dependencies": {
         "@sentry/node": "^7.12.1",
         "@serialport/stream": "^10.3.0",
         "@zwave-js/core": "11.9.1",
-        "@zwave-js/host": "11.10.0",
+        "@zwave-js/host": "11.11.0",
         "@zwave-js/shared": "11.8.0",
         "alcalzone-shared": "^4.0.8",
         "serialport": "^10.4.0",
@@ -1532,14 +1532,14 @@
       }
     },
     "node_modules/@zwave-js/testing": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-11.10.0.tgz",
-      "integrity": "sha512-9MmltpM7c2u98VLLIThk4y/V88ehDITzQ+CHxAjLybk4eK2hsB3jnDPeWhk9su0umRGMpG5LfxB7iZxMwEOxug==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-11.11.0.tgz",
+      "integrity": "sha512-AXnhnXz9x/xFRx3UoOCYTmH6cmNi0DrdtHKgZnRVkD4y+J3RJU611PFtyiwlU9nrDTTttaSxn+QZkzO9KzMGIw==",
       "dev": true,
       "dependencies": {
         "@zwave-js/core": "11.9.1",
-        "@zwave-js/host": "11.10.0",
-        "@zwave-js/serial": "11.10.0",
+        "@zwave-js/host": "11.11.0",
+        "@zwave-js/serial": "11.11.0",
         "@zwave-js/shared": "11.8.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3"
@@ -4704,9 +4704,9 @@
       }
     },
     "node_modules/zwave-js": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-11.10.0.tgz",
-      "integrity": "sha512-ud0f11973uuqVgAyC0x/lxiV9epLSqkMJgrnwnGS0i1kkWxyGOwAWy5cK2koK8KbqEQYIsbdsDQ3rNOC0e4DkA==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-11.11.0.tgz",
+      "integrity": "sha512-L5B178E860U6fK3Kgavxa3bsmcYCmsIEZ1pLLnFKKn3Q3QQA9gT7mhJSaTkdomVWGtVmnSbPonKc4IJRHEsYwg==",
       "dev": true,
       "dependencies": {
         "@alcalzone/jsonl-db": "^3.1.0",
@@ -4715,14 +4715,14 @@
         "@esm2cjs/p-queue": "^7.3.0",
         "@sentry/integrations": "^7.12.1",
         "@sentry/node": "^7.12.1",
-        "@zwave-js/cc": "11.10.0",
-        "@zwave-js/config": "11.10.0",
+        "@zwave-js/cc": "11.11.0",
+        "@zwave-js/config": "11.11.0",
         "@zwave-js/core": "11.9.1",
-        "@zwave-js/host": "11.10.0",
+        "@zwave-js/host": "11.11.0",
         "@zwave-js/nvmedit": "11.9.1",
-        "@zwave-js/serial": "11.10.0",
+        "@zwave-js/serial": "11.11.0",
         "@zwave-js/shared": "11.8.0",
-        "@zwave-js/testing": "11.10.0",
+        "@zwave-js/testing": "11.11.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "execa": "^5.1.1",
@@ -5156,59 +5156,59 @@
       }
     },
     "@sentry-internal/tracing": {
-      "version": "7.63.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.63.0.tgz",
-      "integrity": "sha512-Fxpc53p6NGvLSURg3iRvZA0k10K9yfeVhtczvJnpX30POBuV41wxpkLHkb68fjksirjEma1K3Ut1iLOEEDpPQg==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.64.0.tgz",
+      "integrity": "sha512-1XE8W6ki7hHyBvX9hfirnGkKDBKNq3bDJyXS86E0bYVDl94nvbRM9BD9DHsCFetqYkVm1yDGEK+6aUVs4CztoQ==",
       "dev": true,
       "requires": {
-        "@sentry/core": "7.63.0",
-        "@sentry/types": "7.63.0",
-        "@sentry/utils": "7.63.0",
+        "@sentry/core": "7.64.0",
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "dependencies": {
         "@sentry/types": {
-          "version": "7.63.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.63.0.tgz",
-          "integrity": "sha512-pZNwJVW7RqNLGuTUAhoygt0c9zmc0js10eANAz0MstygJRhQI1tqPDuiELVdujPrbeL+IFKF+7NvRDAydR2Niw==",
+          "version": "7.64.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.64.0.tgz",
+          "integrity": "sha512-LqjQprWXjUFRmzIlUjyA+KL+38elgIYmAeoDrdyNVh8MK5IC1W2Lh1Q87b4yOiZeMiIhIVNBd7Ecoh2rodGrGA==",
           "dev": true
         },
         "@sentry/utils": {
-          "version": "7.63.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.63.0.tgz",
-          "integrity": "sha512-7FQv1RYAwnuTuarruP+1+Jd6YQuN7i/Y7KltwPMVEwU7j5mzYQaexLr/Jz1XIdR2KYVdkbXQyP8jj8BmA6u9Jw==",
+          "version": "7.64.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.64.0.tgz",
+          "integrity": "sha512-HRlM1INzK66Gt+F4vCItiwGKAng4gqzCR4C5marsL3qv6SrKH98dQnCGYgXluSWaaa56h97FRQu7TxCk6jkSvQ==",
           "dev": true,
           "requires": {
-            "@sentry/types": "7.63.0",
+            "@sentry/types": "7.64.0",
             "tslib": "^2.4.1 || ^1.9.3"
           }
         }
       }
     },
     "@sentry/core": {
-      "version": "7.63.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.63.0.tgz",
-      "integrity": "sha512-13Ljiq8hv6ieCkO+Am99/PljYJO5ynKT/hRQrWgGy9IIEgUr8sV3fW+1W6K4/3MCeOJou0HsiGBjOD1mASItVg==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.64.0.tgz",
+      "integrity": "sha512-IzmEyl5sNG7NyEFiyFHEHC+sizsZp9MEw1+RJRLX6U5RITvcsEgcajSkHQFafaBPzRrcxZMdm47Cwhl212LXcw==",
       "dev": true,
       "requires": {
-        "@sentry/types": "7.63.0",
-        "@sentry/utils": "7.63.0",
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
         "tslib": "^2.4.1 || ^1.9.3"
       },
       "dependencies": {
         "@sentry/types": {
-          "version": "7.63.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.63.0.tgz",
-          "integrity": "sha512-pZNwJVW7RqNLGuTUAhoygt0c9zmc0js10eANAz0MstygJRhQI1tqPDuiELVdujPrbeL+IFKF+7NvRDAydR2Niw==",
+          "version": "7.64.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.64.0.tgz",
+          "integrity": "sha512-LqjQprWXjUFRmzIlUjyA+KL+38elgIYmAeoDrdyNVh8MK5IC1W2Lh1Q87b4yOiZeMiIhIVNBd7Ecoh2rodGrGA==",
           "dev": true
         },
         "@sentry/utils": {
-          "version": "7.63.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.63.0.tgz",
-          "integrity": "sha512-7FQv1RYAwnuTuarruP+1+Jd6YQuN7i/Y7KltwPMVEwU7j5mzYQaexLr/Jz1XIdR2KYVdkbXQyP8jj8BmA6u9Jw==",
+          "version": "7.64.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.64.0.tgz",
+          "integrity": "sha512-HRlM1INzK66Gt+F4vCItiwGKAng4gqzCR4C5marsL3qv6SrKH98dQnCGYgXluSWaaa56h97FRQu7TxCk6jkSvQ==",
           "dev": true,
           "requires": {
-            "@sentry/types": "7.63.0",
+            "@sentry/types": "7.64.0",
             "tslib": "^2.4.1 || ^1.9.3"
           }
         }
@@ -5227,15 +5227,15 @@
       }
     },
     "@sentry/node": {
-      "version": "7.63.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.63.0.tgz",
-      "integrity": "sha512-tSMyfQNbfjX1w8vJDZtvWeaD4QQ/Z4zVW/TLXfL/JZFIIksPgDZmqLdF+NJS4bSGTU5JiHiUh4pYhME4mHgNBQ==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.64.0.tgz",
+      "integrity": "sha512-wRi0uTnp1WSa83X2yLD49tV9QPzGh5e42IKdIDBiQ7lV9JhLILlyb34BZY1pq6p4dp35yDasDrP3C7ubn7wo6A==",
       "dev": true,
       "requires": {
-        "@sentry-internal/tracing": "7.63.0",
-        "@sentry/core": "7.63.0",
-        "@sentry/types": "7.63.0",
-        "@sentry/utils": "7.63.0",
+        "@sentry-internal/tracing": "7.64.0",
+        "@sentry/core": "7.64.0",
+        "@sentry/types": "7.64.0",
+        "@sentry/utils": "7.64.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -5243,18 +5243,18 @@
       },
       "dependencies": {
         "@sentry/types": {
-          "version": "7.63.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.63.0.tgz",
-          "integrity": "sha512-pZNwJVW7RqNLGuTUAhoygt0c9zmc0js10eANAz0MstygJRhQI1tqPDuiELVdujPrbeL+IFKF+7NvRDAydR2Niw==",
+          "version": "7.64.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.64.0.tgz",
+          "integrity": "sha512-LqjQprWXjUFRmzIlUjyA+KL+38elgIYmAeoDrdyNVh8MK5IC1W2Lh1Q87b4yOiZeMiIhIVNBd7Ecoh2rodGrGA==",
           "dev": true
         },
         "@sentry/utils": {
-          "version": "7.63.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.63.0.tgz",
-          "integrity": "sha512-7FQv1RYAwnuTuarruP+1+Jd6YQuN7i/Y7KltwPMVEwU7j5mzYQaexLr/Jz1XIdR2KYVdkbXQyP8jj8BmA6u9Jw==",
+          "version": "7.64.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.64.0.tgz",
+          "integrity": "sha512-HRlM1INzK66Gt+F4vCItiwGKAng4gqzCR4C5marsL3qv6SrKH98dQnCGYgXluSWaaa56h97FRQu7TxCk6jkSvQ==",
           "dev": true,
           "requires": {
-            "@sentry/types": "7.63.0",
+            "@sentry/types": "7.64.0",
             "tslib": "^2.4.1 || ^1.9.3"
           }
         }
@@ -5673,14 +5673,14 @@
       }
     },
     "@zwave-js/cc": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-11.10.0.tgz",
-      "integrity": "sha512-8xtEkn1pMF5pnzCYqg1cJ4Rhqd4DLoEeq8RgG+m2JKpY3NWs8WZwOfekDv2BaI7uWZPLlocgmYmwMpnsvRYyVw==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-11.11.0.tgz",
+      "integrity": "sha512-ku5yynsZbwzcWCyYo/R7MJF+lCWXSYyNktdI2MufPvNyuo5tfeKlnagFtykEqepoqOCC296A0X2Ib870ojrKxw==",
       "dev": true,
       "requires": {
         "@zwave-js/core": "11.9.1",
-        "@zwave-js/host": "11.10.0",
-        "@zwave-js/serial": "11.10.0",
+        "@zwave-js/host": "11.11.0",
+        "@zwave-js/serial": "11.11.0",
         "@zwave-js/shared": "11.8.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
@@ -5688,9 +5688,9 @@
       }
     },
     "@zwave-js/config": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-11.10.0.tgz",
-      "integrity": "sha512-D0csSHnUBkPkKMtV6pB9uKRrRj3OIfpxjJ2kEo3nu61/eyDSx+HYoyNvt93mWp8A4kNLUIBcwcqIDE92jjclTQ==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-11.11.0.tgz",
+      "integrity": "sha512-niYE7buGcEEYONOngE+t4PgmqABtCMai0fDKAUvgY4zstU4yQUicar+5kfiKOhEqcjHT3u6Tt2EUw0+GgAGuHg==",
       "dev": true,
       "requires": {
         "@zwave-js/core": "11.9.1",
@@ -5725,12 +5725,12 @@
       }
     },
     "@zwave-js/host": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-11.10.0.tgz",
-      "integrity": "sha512-5ZFKPg7NCLmAb4kHnPQOJ5xehCkba2ZkOYueYgeQMnBP4l0jByG4Q0M6fNxE1sLirOAT6USg1cN6P/RTWq259g==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-11.11.0.tgz",
+      "integrity": "sha512-Wc5wa//JGPoCnQIxXug9XV5NOPFlnpAnU+QvdAk11YIQU5Srjr8e4L1+Gyi0we0EuDdLcQvFo5wHBHqycTXh/Q==",
       "dev": true,
       "requires": {
-        "@zwave-js/config": "11.10.0",
+        "@zwave-js/config": "11.11.0",
         "@zwave-js/core": "11.9.1",
         "@zwave-js/shared": "11.8.0",
         "alcalzone-shared": "^4.0.8"
@@ -5752,15 +5752,15 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-11.10.0.tgz",
-      "integrity": "sha512-S5GX1fMdDLcdhJGmgVmSIcG2YWuCDn5APpyqF9tKle1fMtRvGTi4Yq/EP7C3pZB2iSKju339Qms0V+oRCZ4u3w==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-11.11.0.tgz",
+      "integrity": "sha512-mA0Y8rV119LGKV4eovd708fW/IpoegLrUJhxfuVFUP3HhHdpVzyztgcfPWCCiL5X8LXFIzvK+Vfboe9vBdnFrA==",
       "dev": true,
       "requires": {
         "@sentry/node": "^7.12.1",
         "@serialport/stream": "^10.3.0",
         "@zwave-js/core": "11.9.1",
-        "@zwave-js/host": "11.10.0",
+        "@zwave-js/host": "11.11.0",
         "@zwave-js/shared": "11.8.0",
         "alcalzone-shared": "^4.0.8",
         "serialport": "^10.4.0",
@@ -5778,14 +5778,14 @@
       }
     },
     "@zwave-js/testing": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-11.10.0.tgz",
-      "integrity": "sha512-9MmltpM7c2u98VLLIThk4y/V88ehDITzQ+CHxAjLybk4eK2hsB3jnDPeWhk9su0umRGMpG5LfxB7iZxMwEOxug==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-11.11.0.tgz",
+      "integrity": "sha512-AXnhnXz9x/xFRx3UoOCYTmH6cmNi0DrdtHKgZnRVkD4y+J3RJU611PFtyiwlU9nrDTTttaSxn+QZkzO9KzMGIw==",
       "dev": true,
       "requires": {
         "@zwave-js/core": "11.9.1",
-        "@zwave-js/host": "11.10.0",
-        "@zwave-js/serial": "11.10.0",
+        "@zwave-js/host": "11.11.0",
+        "@zwave-js/serial": "11.11.0",
         "@zwave-js/shared": "11.8.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3"
@@ -8060,9 +8060,9 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-11.10.0.tgz",
-      "integrity": "sha512-ud0f11973uuqVgAyC0x/lxiV9epLSqkMJgrnwnGS0i1kkWxyGOwAWy5cK2koK8KbqEQYIsbdsDQ3rNOC0e4DkA==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-11.11.0.tgz",
+      "integrity": "sha512-L5B178E860U6fK3Kgavxa3bsmcYCmsIEZ1pLLnFKKn3Q3QQA9gT7mhJSaTkdomVWGtVmnSbPonKc4IJRHEsYwg==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^3.1.0",
@@ -8071,14 +8071,14 @@
         "@esm2cjs/p-queue": "^7.3.0",
         "@sentry/integrations": "^7.12.1",
         "@sentry/node": "^7.12.1",
-        "@zwave-js/cc": "11.10.0",
-        "@zwave-js/config": "11.10.0",
+        "@zwave-js/cc": "11.11.0",
+        "@zwave-js/config": "11.11.0",
         "@zwave-js/core": "11.9.1",
-        "@zwave-js/host": "11.10.0",
+        "@zwave-js/host": "11.11.0",
         "@zwave-js/nvmedit": "11.9.1",
-        "@zwave-js/serial": "11.10.0",
+        "@zwave-js/serial": "11.11.0",
         "@zwave-js/shared": "11.8.0",
-        "@zwave-js/testing": "11.10.0",
+        "@zwave-js/testing": "11.11.0",
         "alcalzone-shared": "^4.0.8",
         "ansi-colors": "^4.1.3",
         "execa": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ws": "^8.13.0"
   },
   "peerDependencies": {
-    "zwave-js": "^11.11.0"
+    "zwave-js": "^11.13.0"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.2",
@@ -53,7 +53,7 @@
     "semver": "^7.5.4",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6",
-    "zwave-js": "^11.11.0"
+    "zwave-js": "^11.13.0"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ws": "^8.13.0"
   },
   "peerDependencies": {
-    "zwave-js": "^11.10.0"
+    "zwave-js": "^11.11.0"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.2",
@@ -53,7 +53,7 @@
     "semver": "^7.5.4",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6",
-    "zwave-js": "^11.10.0"
+    "zwave-js": "^11.11.0"
   },
   "husky": {
     "hooks": {

--- a/src/lib/forward.ts
+++ b/src/lib/forward.ts
@@ -146,6 +146,14 @@ export class EventForwarder {
         }),
     );
 
+    this.clientsController.driver.controller.on("status changed", (status) =>
+      this.forwardEvent({
+        source: "controller",
+        event: "status changed",
+        status,
+      }),
+    );
+
     this.clientsController.driver.controller.on("heal network done", (result) =>
       this.forwardEvent({
         source: "controller",

--- a/src/lib/node/command.ts
+++ b/src/lib/node/command.ts
@@ -37,4 +37,5 @@ export enum NodeCommand {
   abortHealthCheck = "node.abort_health_check",
   setDefaultVolume = "node.set_default_volume",
   setDefaultTransitionDuration = "node.set_default_transition_duration",
+  hasDeviceConfigChanged = "node.has_device_config_changed",
 }

--- a/src/lib/node/command.ts
+++ b/src/lib/node/command.ts
@@ -35,4 +35,6 @@ export enum NodeCommand {
   getDateAndTime = "node.get_date_and_time",
   isHealthCheckInProgress = "node.is_health_check_in_progress",
   abortHealthCheck = "node.abort_health_check",
+  setDefaultVolume = "node.set_default_volume",
+  setDefaultTransitionDuration = "node.set_default_transition_duration",
 }

--- a/src/lib/node/incoming_message.ts
+++ b/src/lib/node/incoming_message.ts
@@ -233,6 +233,11 @@ export interface IncomingCommandNodeSetDefaultTransitionDuration
   defaultTransitionDuration?: string; // Will be converted to a Duration object
 }
 
+export interface IncomingCommandNodeHasDeviceConfigChanged
+  extends IncomingCommandNodeBase {
+  command: NodeCommand.hasDeviceConfigChanged;
+}
+
 export type IncomingMessageNode =
   | IncomingCommandNodeSetValue
   | IncomingCommandNodeRefreshInfo
@@ -270,4 +275,5 @@ export type IncomingMessageNode =
   | IncomingCommandNodeIsHealthCheckInProgress
   | IncomingCommandNodeAbortHealthCheck
   | IncomingCommandNodeSetDefaultVolume
-  | IncomingCommandNodeSetDefaultTransitionDuration;
+  | IncomingCommandNodeSetDefaultTransitionDuration
+  | IncomingCommandNodeHasDeviceConfigChanged;

--- a/src/lib/node/incoming_message.ts
+++ b/src/lib/node/incoming_message.ts
@@ -221,6 +221,18 @@ export interface IncomingCommandNodeAbortHealthCheck
   command: NodeCommand.abortHealthCheck;
 }
 
+export interface IncomingCommandNodeSetDefaultVolume
+  extends IncomingCommandNodeBase {
+  command: NodeCommand.setDefaultVolume;
+  defaultVolume?: number;
+}
+
+export interface IncomingCommandNodeSetDefaultTransitionDuration
+  extends IncomingCommandNodeBase {
+  command: NodeCommand.setDefaultTransitionDuration;
+  defaultTransitionDuration?: string; // Will be converted to a Duration object
+}
+
 export type IncomingMessageNode =
   | IncomingCommandNodeSetValue
   | IncomingCommandNodeRefreshInfo
@@ -256,4 +268,6 @@ export type IncomingMessageNode =
   | IncomingCommandNodeSetDateAndTime
   | IncomingCommandNodeGetDateAndTime
   | IncomingCommandNodeIsHealthCheckInProgress
-  | IncomingCommandNodeAbortHealthCheck;
+  | IncomingCommandNodeAbortHealthCheck
+  | IncomingCommandNodeSetDefaultVolume
+  | IncomingCommandNodeSetDefaultTransitionDuration;

--- a/src/lib/node/message_handler.ts
+++ b/src/lib/node/message_handler.ts
@@ -294,6 +294,14 @@ export class NodeMessageHandler {
         await node.abortHealthCheck();
         return {};
       }
+      case NodeCommand.setDefaultVolume: {
+        node.defaultVolume = message.defaultVolume;
+        return {};
+      }
+      case NodeCommand.setDefaultTransitionDuration: {
+        node.defaultTransitionDuration = message.defaultTransitionDuration;
+        return {};
+      }
       default: {
         throw new UnknownCommandError(command);
       }

--- a/src/lib/node/message_handler.ts
+++ b/src/lib/node/message_handler.ts
@@ -302,6 +302,10 @@ export class NodeMessageHandler {
         node.defaultTransitionDuration = message.defaultTransitionDuration;
         return {};
       }
+      case NodeCommand.hasDeviceConfigChanged: {
+        const changed = node.hasDeviceConfigChanged();
+        return { changed };
+      }
       default: {
         throw new UnknownCommandError(command);
       }

--- a/src/lib/node/outgoing_message.ts
+++ b/src/lib/node/outgoing_message.ts
@@ -56,4 +56,5 @@ export interface NodeResultTypes {
   [NodeCommand.abortHealthCheck]: Record<string, never>;
   [NodeCommand.setDefaultVolume]: Record<string, never>;
   [NodeCommand.setDefaultTransitionDuration]: Record<string, never>;
+  [NodeCommand.hasDeviceConfigChanged]: { changed: MaybeNotKnown<boolean> };
 }

--- a/src/lib/node/outgoing_message.ts
+++ b/src/lib/node/outgoing_message.ts
@@ -54,4 +54,6 @@ export interface NodeResultTypes {
   [NodeCommand.getDateAndTime]: { dateAndTime: DateAndTime };
   [NodeCommand.isHealthCheckInProgress]: { progress: boolean };
   [NodeCommand.abortHealthCheck]: Record<string, never>;
+  [NodeCommand.setDefaultVolume]: Record<string, never>;
+  [NodeCommand.setDefaultTransitionDuration]: Record<string, never>;
 }

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -1,4 +1,5 @@
 import {
+  ControllerStatus,
   Driver,
   ZWaveNode,
   Endpoint,
@@ -96,15 +97,20 @@ type ControllerStateSchema22 = Omit<
   "isSlave" | "isSecondary" | "isStaticUpdateController"
 >;
 
-interface ControllerStateSchema25 extends ControllerStateSchema0 {
+interface ControllerStateSchema25 extends ControllerStateSchema22 {
   rfRegion?: RFRegion;
+}
+
+interface ControllerStateSchema31 extends ControllerStateSchema25 {
+  status: ControllerStatus;
 }
 
 export type ControllerState =
   | ControllerStateSchema0
   | ControllerStateSchema16
   | ControllerStateSchema22
-  | ControllerStateSchema25;
+  | ControllerStateSchema25
+  | ControllerStateSchema31;
 
 export interface ZwaveState {
   driver: DriverState;
@@ -813,7 +819,13 @@ export const dumpController = (
 
   const controller25 = controller22 as ControllerStateSchema25;
   controller25.rfRegion = controller.rfRegion;
-  return controller25;
+  if (schemaVersion < 31) {
+    return controller25;
+  }
+
+  const controller31 = controller25 as ControllerStateSchema31;
+  controller31.status = controller.status;
+  return controller31;
 };
 
 export const dumpState = (


### PR DESCRIPTION
Bumps zwave-js to [11.13.0](https://github.com/zwave-js/node-zwave-js/releases/tag/v11.13.0)

As part of this, we:
- offer two new commands to set default volume/transition duration
- add controller status to the state dump
- add support for the `status changed` controller event
- add support for the `node.hasDeviceConfigChanged` command