### PR TITLE
Deprecate listen to logs cmds from driver and add them in server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          cache: 'npm'
+          cache: "npm"
       - run: npm ci
       - run: npm test

--- a/README.md
+++ b/README.md
@@ -308,33 +308,6 @@ interface {
 }
 ```
 
-#### Start listening to logging events
-
-[compatible with schema version: 4+]
-
-Start receiving logs as events. Look at the [`logging` event documentation](#logging) for more information about the events. If `filter` is included, only logs that match the `filter` will be sent as events, the rest will be skipped.
-
-```ts
-interface {
-  messageId: string;
-  command: "driver.start_listening_logs";
-  filter?: Partial<NodeLogContext| DriverLogContext | ControllerLogContext | SerialLogContext | ConfigLogContext>;
-}
-```
-
-#### Stop listening to logging events
-
-[compatible with schema version: 4+]
-
-Stop receiving logs as events.
-
-```ts
-interface {
-  messageId: string;
-  command: "driver.stop_listening_logs";
-}
-```
-
 #### [Check for config updates](https://zwave-js.github.io/node-zwave-js/#/api/driver?id=checkforconfigupdates)
 
 [compatible with schema version: 5+]

--- a/README.md
+++ b/README.md
@@ -149,6 +149,33 @@ interface {
 }
 ```
 
+#### Start listening to logging events
+
+[compatible with schema version: 31+]
+
+Start receiving logs as events. Look at the [`logging` event documentation](#logging) for more information about the events. If `filter` is included, only logs that match the `filter` will be sent as events, the rest will be skipped.
+
+```ts
+interface {
+  messageId: string;
+  command: "start_listening_logs";
+  filter?: Partial<NodeLogContext| DriverLogContext | ControllerLogContext | SerialLogContext | ConfigLogContext>;
+}
+```
+
+#### Stop listening to logging events
+
+[compatible with schema version: 31+]
+
+Stop receiving logs as events.
+
+```ts
+interface {
+  messageId: string;
+  command: "stop_listening_logs";
+}
+```
+
 ### Driver level commands
 
 #### Get the config of the driver
@@ -1315,7 +1342,7 @@ interface {
 }
 ```
 
-#### `nvm convert progress`
+#### `nvm backup progress`
 
 This event is sent on progress updates to the NVM conversion process when the [`controller.restore_nvm`](https://zwave-js.github.io/node-zwave-js/#/api/controller?id=nvm-backup-and-restore) command is issued by a client to the server and the NVM file that was passed in is being converted to the right format.
 

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -4,4 +4,6 @@ export enum ServerCommand {
   getLogConfig = "get_log_config",
   setApiSchema = "set_api_schema",
   initialize = "initialize",
+  startListeningLogs = "start_listening_logs",
+  stopListeningLogs = "stop_listening_logs",
 }

--- a/src/lib/incoming_message.ts
+++ b/src/lib/incoming_message.ts
@@ -8,6 +8,7 @@ import { IncomingMessageBroadcastNode } from "./broadcast_node/incoming_message"
 import { IncomingMessageMulticastGroup } from "./multicast_group/incoming_message";
 import { IncomingMessageEndpoint } from "./endpoint/incoming_message";
 import { IncomingMessageUtils } from "./utils/incoming_message";
+import { LogContexts } from "./logging";
 
 interface IncomingCommandStartListening extends IncomingCommandBase {
   command: ServerCommand.startListening;
@@ -33,6 +34,15 @@ interface IncomingCommandInitialize extends IncomingCommandBase {
   additionalUserAgentComponents?: Record<string, string>;
 }
 
+interface IncomingCommandStartListeningLogs extends IncomingCommandBase {
+  command: ServerCommand.startListeningLogs;
+  filter?: Partial<LogContexts>;
+}
+
+interface IncomingCommandStopListeningLogs extends IncomingCommandBase {
+  command: ServerCommand.stopListeningLogs;
+}
+
 export type IncomingMessage =
   | IncomingCommandStartListening
   | IncomingCommandUpdateLogConfig
@@ -45,4 +55,6 @@ export type IncomingMessage =
   | IncomingMessageBroadcastNode
   | IncomingMessageEndpoint
   | IncomingMessageUtils
-  | IncomingCommandInitialize;
+  | IncomingCommandInitialize
+  | IncomingCommandStartListeningLogs
+  | IncomingCommandStopListeningLogs;

--- a/src/lib/outgoing_message.ts
+++ b/src/lib/outgoing_message.ts
@@ -61,6 +61,8 @@ export interface ServerResultTypes {
   [ServerCommand.startListening]: { state: ZwaveState };
   [ServerCommand.updateLogConfig]: Record<string, never>;
   [ServerCommand.getLogConfig]: { config: Partial<LogConfig> };
+  [ServerCommand.initialize]: Record<string, never>;
+  [ServerCommand.setApiSchema]: Record<string, never>;
 }
 
 export type ResultTypes = ServerResultTypes &

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -182,6 +182,20 @@ export class Client {
         return;
       }
 
+      if (msg.command === ServerCommand.startListeningLogs) {
+        this.receiveLogs = true;
+        this.clientsController.configureLoggingEventForwarder(msg.filter);
+        this.sendResultSuccess(msg.messageId, {});
+        return;
+      }
+
+      if (msg.command === ServerCommand.stopListeningLogs) {
+        this.receiveLogs = false;
+        this.clientsController.cleanupLoggingEventForwarder();
+        this.sendResultSuccess(msg.messageId, {});
+        return;
+      }
+
       const instance = msg.command.split(".")[0] as Instance;
       if (this.instanceHandlers[instance]) {
         return this.sendResultSuccess(


### PR DESCRIPTION
Per the conversation in https://github.com/zwave-js/ZWaveJS.NET/pull/30