### PR TITLE
chore: use vendored tsconfig for Node 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "zwave-server": "dist/bin/server.js"
       },
       "devDependencies": {
+        "@tsconfig/node18": "^18.2.1",
         "@types/minimist": "^1.2.2",
         "@types/node": "^20.4.4",
         "@types/triple-beam": "^1.3.2",
@@ -946,6 +947,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node18": {
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.1.tgz",
+      "integrity": "sha512-RDDZFuofwkcKpl8Vpj5wFbY+H53xOtqK7ckEL1sXsbPwvKwDdjQf3LkHbtt9sxIHn9nWIEwkmCwBRZ6z5TKU2A==",
       "dev": true
     },
     "node_modules/@types/http-cache-semantics": {
@@ -5400,6 +5407,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
+    "@tsconfig/node18": {
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.1.tgz",
+      "integrity": "sha512-RDDZFuofwkcKpl8Vpj5wFbY+H53xOtqK7ckEL1sXsbPwvKwDdjQf3LkHbtt9sxIHn9nWIEwkmCwBRZ6z5TKU2A==",
       "dev": true
     },
     "@types/http-cache-semantics": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "zwave-js": "^11.13.0"
   },
   "devDependencies": {
+    "@tsconfig/node18": "^18.2.1",
     "@types/minimist": "^1.2.2",
     "@types/node": "^20.4.4",
     "@types/triple-beam": "^1.3.2",

--- a/src/lib/driver/message_handler.ts
+++ b/src/lib/driver/message_handler.ts
@@ -40,6 +40,7 @@ export class DriverMessageHandler {
         return { config };
       }
       case DriverCommand.updateLogConfig: {
+        // @ts-expect-error The DeepPartial in zwave-js is wrong
         driver.updateLogConfig(message.config);
         // If the logging event forwarder is enabled, we need to restart
         // it so that it picks up the new config.

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -43,6 +43,7 @@ export class LoggingEventForwarder {
     );
     transports = transports || [];
     transports.push(this.serverTransport);
+    // @ts-expect-error The DeepPartial in zwave-js is wrong
     this.driver.updateLogConfig({ transports });
   }
 
@@ -51,6 +52,7 @@ export class LoggingEventForwarder {
     const transports = this.driver
       .getLogConfig()
       .transports.filter((transport) => transport !== this.serverTransport);
+    // @ts-expect-error The DeepPartial in zwave-js is wrong
     this.driver.updateLogConfig({ transports });
     delete this.serverTransport;
   }

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -170,6 +170,7 @@ export class Client {
       }
 
       if (msg.command === ServerCommand.updateLogConfig) {
+        // @ts-expect-error The DeepPartial in zwave-js is wrong
         this.driver.updateLogConfig(msg.config);
         this.sendResultSuccess(msg.messageId, {});
         return;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,9 @@
 {
+  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
-    "target": "ES2019",
-    "module": "commonjs",
-    "lib": ["es6", "es2019", "dom"],
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src",
-    "types": ["node"],
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "strict": true,
-    "skipLibCheck": true
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
In preparation to upgrading to `node-zwave-js` v12, this PR uses a vendored tsconfig from https://github.com/tsconfig/bases which leaves less room for misconfiguration. Found a typing issue in the driver which I'll fix next beta.