### PR TITLE
fix: align @types/node with the minimum supported Node.js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@types/minimist": "^1.2.2",
-        "@types/node": "^20.4.4",
+        "@types/node": "^18.17.14",
         "@types/triple-beam": "^1.3.2",
         "@types/ws": "^8.5.5",
         "@types/yargs": "^17.0.24",
@@ -967,9 +967,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.5.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
-      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==",
+      "version": "18.17.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.14.tgz",
+      "integrity": "sha512-ZE/5aB73CyGqgQULkLG87N9GnyGe5TcQjv34pwS8tfBs1IkCh0ASM69mydb2znqd6v0eX+9Ytvk6oQRqu8T1Vw==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -5421,9 +5421,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.5.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
-      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==",
+      "version": "18.17.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.14.tgz",
+      "integrity": "sha512-ZE/5aB73CyGqgQULkLG87N9GnyGe5TcQjv34pwS8tfBs1IkCh0ASM69mydb2znqd6v0eX+9Ytvk6oQRqu8T1Vw==",
       "dev": true
     },
     "@types/parse-json": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@types/minimist": "^1.2.2",
-    "@types/node": "^20.4.4",
+    "@types/node": "^18.17.14",
     "@types/triple-beam": "^1.3.2",
     "@types/ws": "^8.5.5",
     "@types/yargs": "^17.0.24",


### PR DESCRIPTION
This ensures that we don't accidentally use an API that's not available on all supported versions.