### PR TITLE
fix: return at the end of `enableErrorReporting` handler

### DIFF
--- a/src/lib/driver/message_handler.ts
+++ b/src/lib/driver/message_handler.ts
@@ -91,6 +91,7 @@ export class DriverMessageHandler {
             "an application that integrates with Z-Wave JS and you receive this " +
             "error, you may need to update the application.",
         );
+        return {};
       }
       case DriverCommand.softReset: {
         await driver.softReset();


### PR DESCRIPTION
This is the cause of https://github.com/home-assistant/core/issues/100987