### PR TITLE
fix: avoid type error on SIGINT/SIGTERM

### DIFF
--- a/src/bin/server.ts
+++ b/src/bin/server.ts
@@ -196,8 +196,8 @@ interface Args {
     process.exit(exitCode);
   };
 
-  process.on("SIGINT", handleShutdown);
-  process.on("SIGTERM", handleShutdown);
+  process.on("SIGINT", () => handleShutdown(0));
+  process.on("SIGTERM", () => handleShutdown(0));
 })().catch((err) => {
   console.error("Unable to start driver", err);
   process.exit(1);


### PR DESCRIPTION
Without this, I'm getting an error when shutting down:
```
TypeError [ERR_INVALID_ARG_TYPE]: The "code" argument must be of type number. Received type string ('SIGINT')
    at process.set [as exitCode] (node:internal/bootstrap/node:123:9)
    at process.exit (node:internal/process/per_thread:188:24)
    at process.handleShutdown (/home/dominic/Repositories/zwave-js-server/src/bin/server.ts:196:13) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```