### PR TITLE
Bump zwave-js-server to 1.35.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.34.0",
+  "version": "1.35.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zwave-js/server",
-      "version": "1.34.0",
+      "version": "1.35.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/ciao": "^1.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.34.0",
+  "version": "1.35.0-beta.1",
   "description": "Full access to zwave-js driver through Websockets",
   "homepage": "https://github.com/zwave-js/zwave-js-server#readme",
   "repository": {


### PR DESCRIPTION
to release https://github.com/zwave-js/zwave-js-server/pull/1141 and unblock zwave-js-ui from working on Long Range support. In beta because we still need to validate we have everything we need in the server to support Long Range