### PR TITLE
Remove mandatoryControlledCCs + mandatorySupportedCCs fields

### DIFF
--- a/API_SCHEMA.md
+++ b/API_SCHEMA.md
@@ -64,3 +64,4 @@ Base schema.
 
 - Added `maxLongRangePowerlevel`, `longRangeChannel`, and `supportsLongRangeAutoChannelSelection` to controller state dump
 - Added commands for controller methods `getMaxLongRangePowerlevel`, `setMaxLongRangePowerlevel`, `getLongRangeChannel`, and `setLongRangeChannel`
+- Removed deprecated `mandatoryControlledCCs` and `mandatorySupportedCCs` properties from device class dump

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -788,8 +788,8 @@ export const dumpDeviceClass = (
     },
   };
   if (schemaVersion < 36) {
-    base.mandatoryControlledCCs = deviceClass.mandatoryControlledCCs;
-    base.mandatorySupportedCCs = deviceClass.mandatorySupportedCCs;
+    base.mandatoryControlledCCs = [];
+    base.mandatorySupportedCCs = [];
     return base as DeviceClassState0;
   }
   const deviceClass36 = base as DeviceClassState36;


### PR DESCRIPTION
The following properties have been deprecated from a node's device class definition:
- mandatoryControlledCCs
- mandatorySupportedCCs

They will be removed in the next major release which will break earlier server schemas, so rather than waiting for that to happen, we are removing them now.

To make the breaking change slightly less painful, we will return an empty list for both properties in schemas that still supported these properties.