### PR TITLE
Bump zwave-js-server to 0.36.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zwave-js/server",
-      "version": "1.35.0",
+      "version": "1.36.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/ciao": "^1.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "description": "Full access to zwave-js driver through Websockets",
   "homepage": "https://github.com/zwave-js/zwave-js-server#readme",
   "repository": {


### PR DESCRIPTION
* Add version info to mDNS advertisement (#1221) @raman325
* Remove mandatoryControlledCCs + mandatorySupportedCCs fields (#1208) @raman325
* Remove CC properties from device class dump (#1190) @raman325
* Bump schema to 36 and add support for zwave-js 12.9 (#1207) @raman325
* https://github.com/zwave-js/zwave-js-server/pull/1222