### PR TITLE
Add utils.lookup_device

### DIFF
--- a/API_SCHEMA.md
+++ b/API_SCHEMA.md
@@ -76,4 +76,3 @@ Base schema.
 
 - Added controller `inclusion state changed` event
 - Added `config_manager` commands
-- Refactored message handlers to be stateful

--- a/API_SCHEMA.md
+++ b/API_SCHEMA.md
@@ -66,3 +66,7 @@ Base schema.
 - Added commands for controller methods `getMaxLongRangePowerlevel`, `setMaxLongRangePowerlevel`, `getLongRangeChannel`, and `setLongRangeChannel`
 - Removed deprecated `mandatoryControlledCCs` and `mandatorySupportedCCs` properties from device class dump
 - Added commands for `node.createDump` and `driver.sendTestFrame`
+
+# Schema 37
+
+- Added command for `utils.lookup_device`

--- a/API_SCHEMA.md
+++ b/API_SCHEMA.md
@@ -69,4 +69,5 @@ Base schema.
 
 # Schema 37
 
-- Added command for `utils.lookup_device`
+- Added `config_manager` commands
+- Refactored message handlers to be stateful

--- a/README.md
+++ b/README.md
@@ -1272,6 +1272,8 @@ interface {
 
 `zwave-js-server` supports all of the utility methods listed in the [Z-Wave JS documentation](https://zwave-js.github.io/node-zwave-js/#/api/utils). `zwave-js-server` uses [snake casing](https://en.wikipedia.org/wiki/Snake_case) for commands and prefixes every controller command with `utils.`, so `parseQRCodeString` is called using the `utils.parse_qr_code_string` command.
 
+> NOTE: While some string utility commands are made available in the server due to their availability within the driver, this functionality works best when implemented locally and should not be used over WebSocket for any practical purpose.
+
 ### Config manager commands
 
 `zwave-js-server` supports all of the config manager methods listed in the [Z-Wave JS documentation](https://zwave-js.github.io/node-zwave-js/#/api/config-manager). `zwave-js-server` uses [snake casing](https://en.wikipedia.org/wiki/Snake_case) for commands and prefixes every controller command with `config_manager.`, so `lookupDevice` is called using the `config_manager.lookup_device` command.

--- a/README.md
+++ b/README.md
@@ -1272,6 +1272,10 @@ interface {
 
 `zwave-js-server` supports all of the utility methods listed in the [Z-Wave JS documentation](https://zwave-js.github.io/node-zwave-js/#/api/utils). `zwave-js-server` uses [snake casing](https://en.wikipedia.org/wiki/Snake_case) for commands and prefixes every controller command with `utils.`, so `parseQRCodeString` is called using the `utils.parse_qr_code_string` command.
 
+### Config manager commands
+
+`zwave-js-server` supports all of the config manager methods listed in the [Z-Wave JS documentation](https://zwave-js.github.io/node-zwave-js/#/api/config-manager). `zwave-js-server` uses [snake casing](https://en.wikipedia.org/wiki/Snake_case) for commands and prefixes every controller command with `config_manager.`, so `lookupDevice` is called using the `config_manager.lookup_device` command.
+
 ## Events
 
 ### `zwave-js` Events

--- a/README.md
+++ b/README.md
@@ -1272,7 +1272,7 @@ interface {
 
 `zwave-js-server` supports all of the utility methods listed in the [Z-Wave JS documentation](https://zwave-js.github.io/node-zwave-js/#/api/utils). `zwave-js-server` uses [snake casing](https://en.wikipedia.org/wiki/Snake_case) for commands and prefixes every controller command with `utils.`, so `parseQRCodeString` is called using the `utils.parse_qr_code_string` command.
 
-> NOTE: While some string utility commands are made available in the server due to their availability within the driver, this functionality works best when implemented locally and should not be used over WebSocket for any practical purpose.
+> NOTE: While some string utility commands like `num2hex`, `buffer2hex`, etc. are made available in the server due to their availability within the driver, this functionality works best when implemented locally and should not be used over WebSocket for any practical purpose.
 
 ### Config manager commands
 

--- a/src/lib/broadcast_node/message_handler.ts
+++ b/src/lib/broadcast_node/message_handler.ts
@@ -7,14 +7,20 @@ import { Client } from "../server";
 import { setValueOutgoingMessage } from "../common";
 
 export class BroadcastNodeMessageHandler {
-  static async handle(
+  private driver: Driver;
+  private client: Client;
+
+  constructor(driver: Driver, client: Client) {
+    this.driver = driver;
+    this.client = client;
+  }
+
+  async handle(
     message: IncomingMessageBroadcastNode,
-    driver: Driver,
-    client: Client,
   ): Promise<BroadcastNodeResultTypes[BroadcastNodeCommand]> {
     const { command } = message;
 
-    const virtualNode = driver.controller.getBroadcastNode();
+    const virtualNode = this.driver.controller.getBroadcastNode();
 
     switch (message.command) {
       case BroadcastNodeCommand.setValue: {
@@ -23,7 +29,7 @@ export class BroadcastNodeMessageHandler {
           message.value,
           message.options,
         );
-        return setValueOutgoingMessage(result, client.schemaVersion);
+        return setValueOutgoingMessage(result, this.client.schemaVersion);
       }
       case BroadcastNodeCommand.getEndpointCount: {
         const count = virtualNode.getEndpointCount();

--- a/src/lib/config_manager/command.ts
+++ b/src/lib/config_manager/command.ts
@@ -8,4 +8,6 @@ export enum ConfigManagerCommand {
   lookupDevice = "config_manager.lookup_device",
   lookupDevicePreserveConditions = "config_manager.lookup_device_preserve_conditions",
   manufacturers = "config_manager.manufacturers",
+  loadAll = "config_manager.load_all",
+  configVersion = "config_manager.config_version",
 }

--- a/src/lib/config_manager/command.ts
+++ b/src/lib/config_manager/command.ts
@@ -1,0 +1,11 @@
+export enum ConfigManagerCommand {
+  loadManufacturers = "config_manager.load_manufacturers",
+  lookupManufacturer = "config_manager.lookup_manufacturer",
+  loadDeviceIndex = "config_manager.load_device_index",
+  getIndex = "config_manager.get_index",
+  loadFulltextDeviceIndex = "config_manager.load_fulltext_device_index",
+  getFulltextIndex = "config_manager.get_fulltext_index",
+  lookupDevice = "config_manager.lookup_device",
+  lookupDevicePreserveConditions = "config_manager.lookup_device_preserve_conditions",
+  manufacturers = "config_manager.manufacturers",
+}

--- a/src/lib/config_manager/incoming_message.ts
+++ b/src/lib/config_manager/incoming_message.ts
@@ -50,7 +50,14 @@ export interface IncomingCommandConfigManagerManufacturers
   extends IncomingCommandConfigManagerBase {
   command: ConfigManagerCommand.manufacturers;
 }
-
+export interface IncomingCommandConfigManagerLoadAll
+  extends IncomingCommandConfigManagerBase {
+  command: ConfigManagerCommand.loadAll;
+}
+export interface IncomingCommandConfigManagerConfigVersion
+  extends IncomingCommandConfigManagerBase {
+  command: ConfigManagerCommand.configVersion;
+}
 export type IncomingMessageConfigManager =
   | IncomingCommandConfigManagerLookupDevice
   | IncomingCommandConfigManagerLoadManufacturers
@@ -60,4 +67,6 @@ export type IncomingMessageConfigManager =
   | IncomingCommandConfigManagerLoadFulltextDeviceIndex
   | IncomingCommandConfigManagerGetFulltextIndex
   | IncomingCommandConfigManagerLookupDevicePreserveConditions
-  | IncomingCommandConfigManagerManufacturers;
+  | IncomingCommandConfigManagerManufacturers
+  | IncomingCommandConfigManagerLoadAll
+  | IncomingCommandConfigManagerConfigVersion;

--- a/src/lib/config_manager/incoming_message.ts
+++ b/src/lib/config_manager/incoming_message.ts
@@ -1,0 +1,63 @@
+import { IncomingCommandBase } from "../incoming_message_base";
+import { ConfigManagerCommand } from "./command";
+
+export interface IncomingCommandConfigManagerBase extends IncomingCommandBase {}
+
+export interface IncomingCommandConfigManagerLookupDevice
+  extends IncomingCommandConfigManagerBase {
+  command: ConfigManagerCommand.lookupDevice;
+  manufacturerId: number;
+  productType: number;
+  productId: number;
+  firmwareVersion?: string;
+}
+
+export interface IncomingCommandConfigManagerLoadManufacturers
+  extends IncomingCommandConfigManagerBase {
+  command: ConfigManagerCommand.loadManufacturers;
+}
+
+export interface IncomingCommandConfigManagerLookupManufacturer
+  extends IncomingCommandConfigManagerBase {
+  command: ConfigManagerCommand.lookupManufacturer;
+  manufacturerId: number;
+}
+export interface IncomingCommandConfigManagerLoadDeviceIndex
+  extends IncomingCommandConfigManagerBase {
+  command: ConfigManagerCommand.loadDeviceIndex;
+}
+export interface IncomingCommandConfigManagerGetIndex
+  extends IncomingCommandConfigManagerBase {
+  command: ConfigManagerCommand.getIndex;
+}
+export interface IncomingCommandConfigManagerLoadFulltextDeviceIndex
+  extends IncomingCommandConfigManagerBase {
+  command: ConfigManagerCommand.loadFulltextDeviceIndex;
+}
+export interface IncomingCommandConfigManagerGetFulltextIndex
+  extends IncomingCommandConfigManagerBase {
+  command: ConfigManagerCommand.getFulltextIndex;
+}
+export interface IncomingCommandConfigManagerLookupDevicePreserveConditions
+  extends IncomingCommandConfigManagerBase {
+  command: ConfigManagerCommand.lookupDevicePreserveConditions;
+  manufacturerId: number;
+  productType: number;
+  productId: number;
+  firmwareVersion?: string;
+}
+export interface IncomingCommandConfigManagerManufacturers
+  extends IncomingCommandConfigManagerBase {
+  command: ConfigManagerCommand.manufacturers;
+}
+
+export type IncomingMessageConfigManager =
+  | IncomingCommandConfigManagerLookupDevice
+  | IncomingCommandConfigManagerLoadManufacturers
+  | IncomingCommandConfigManagerLookupManufacturer
+  | IncomingCommandConfigManagerLoadDeviceIndex
+  | IncomingCommandConfigManagerGetIndex
+  | IncomingCommandConfigManagerLoadFulltextDeviceIndex
+  | IncomingCommandConfigManagerGetFulltextIndex
+  | IncomingCommandConfigManagerLookupDevicePreserveConditions
+  | IncomingCommandConfigManagerManufacturers;

--- a/src/lib/config_manager/message_handler.ts
+++ b/src/lib/config_manager/message_handler.ts
@@ -1,0 +1,73 @@
+import { ConfigManager } from "@zwave-js/config";
+import { UnknownCommandError } from "../error";
+import { ConfigManagerCommand } from "./command";
+import { IncomingMessageConfigManager } from "./incoming_message";
+import { ConfigManagerResultTypes } from "./outgoing_message";
+
+export class ConfigManagerMessageHandler {
+  private configManager: ConfigManager = new ConfigManager();
+
+  constructor() {
+    this.configManager.loadDeviceIndex().then(() => {});
+  }
+
+  async handle(
+    message: IncomingMessageConfigManager,
+  ): Promise<ConfigManagerResultTypes[ConfigManagerCommand]> {
+    const { command } = message;
+
+    switch (message.command) {
+      case ConfigManagerCommand.lookupDevice: {
+        const config = await this.configManager.lookupDevice(
+          message.manufacturerId,
+          message.productType,
+          message.productId,
+          message.firmwareVersion,
+        );
+        return { config };
+      }
+      case ConfigManagerCommand.loadManufacturers: {
+        await this.configManager.loadManufacturers();
+        return {};
+      }
+      case ConfigManagerCommand.lookupManufacturer: {
+        const name = this.configManager.lookupManufacturer(
+          message.manufacturerId,
+        );
+        return { name };
+      }
+      case ConfigManagerCommand.loadDeviceIndex: {
+        await this.configManager.loadDeviceIndex();
+        return {};
+      }
+      case ConfigManagerCommand.getIndex: {
+        const index = this.configManager.getIndex();
+        return { index };
+      }
+      case ConfigManagerCommand.loadFulltextDeviceIndex: {
+        await this.configManager.loadFulltextDeviceIndex();
+        return {};
+      }
+      case ConfigManagerCommand.getFulltextIndex: {
+        const index = this.configManager.getFulltextIndex();
+        return { index };
+      }
+      case ConfigManagerCommand.lookupDevicePreserveConditions: {
+        const config = await this.configManager.lookupDevicePreserveConditions(
+          message.manufacturerId,
+          message.productType,
+          message.productId,
+          message.firmwareVersion,
+        );
+        return { config };
+      }
+      case ConfigManagerCommand.manufacturers: {
+        const manufacturers = this.configManager.manufacturers;
+        return { manufacturers };
+      }
+      default: {
+        throw new UnknownCommandError(command);
+      }
+    }
+  }
+}

--- a/src/lib/config_manager/message_handler.ts
+++ b/src/lib/config_manager/message_handler.ts
@@ -65,6 +65,13 @@ export class ConfigManagerMessageHandler {
         const manufacturers = this.configManager.manufacturers;
         return { manufacturers };
       }
+      case ConfigManagerCommand.loadAll: {
+        await this.configManager.loadAll();
+        return {};
+      }
+      case ConfigManagerCommand.configVersion: {
+        return { configVersion: this.configManager.configVersion };
+      }
       default: {
         throw new UnknownCommandError(command);
       }

--- a/src/lib/config_manager/outgoing_message.ts
+++ b/src/lib/config_manager/outgoing_message.ts
@@ -1,0 +1,26 @@
+import {
+  ConditionalDeviceConfig,
+  DeviceConfig,
+  DeviceConfigIndex,
+  FulltextDeviceConfigIndex,
+  ManufacturersMap,
+} from "@zwave-js/config";
+import { ConfigManagerCommand } from "./command";
+
+export interface ConfigManagerResultTypes {
+  [ConfigManagerCommand.lookupDevice]: {
+    config?: DeviceConfig;
+  };
+  [ConfigManagerCommand.loadManufacturers]: Record<string, never>;
+  [ConfigManagerCommand.lookupManufacturer]: { name?: string };
+  [ConfigManagerCommand.loadDeviceIndex]: Record<string, never>;
+  [ConfigManagerCommand.getIndex]: { index?: DeviceConfigIndex };
+  [ConfigManagerCommand.loadFulltextDeviceIndex]: Record<string, never>;
+  [ConfigManagerCommand.getFulltextIndex]: {
+    index?: FulltextDeviceConfigIndex;
+  };
+  [ConfigManagerCommand.lookupDevicePreserveConditions]: {
+    config?: ConditionalDeviceConfig;
+  };
+  [ConfigManagerCommand.manufacturers]: { manufacturers: ManufacturersMap };
+}

--- a/src/lib/config_manager/outgoing_message.ts
+++ b/src/lib/config_manager/outgoing_message.ts
@@ -23,4 +23,6 @@ export interface ConfigManagerResultTypes {
     config?: ConditionalDeviceConfig;
   };
   [ConfigManagerCommand.manufacturers]: { manufacturers: ManufacturersMap };
+  [ConfigManagerCommand.loadAll]: Record<string, never>;
+  [ConfigManagerCommand.configVersion]: { configVersion: string };
 }

--- a/src/lib/controller/message_handler.ts
+++ b/src/lib/controller/message_handler.ts
@@ -1,11 +1,6 @@
 import {
-  createDeferredPromise,
-  DeferredPromise,
-} from "alcalzone-shared/deferred-promise";
-import {
   parseQRCodeString,
   Driver,
-  InclusionGrant,
   InclusionOptions,
   InclusionStrategy,
   ReplaceNodeOptions,
@@ -38,56 +33,69 @@ import { firmwareUpdateOutgoingMessage } from "../common";
 import { inclusionUserCallbacks } from "../inclusion_user_callbacks";
 
 export class ControllerMessageHandler {
-  static async handle(
-    message: IncomingMessageController,
+  private clientsController: ClientsController;
+  private driver: Driver;
+  private client: Client;
+
+  constructor(
     clientsController: ClientsController,
     driver: Driver,
     client: Client,
+  ) {
+    this.clientsController = clientsController;
+    this.driver = driver;
+    this.client = client;
+  }
+
+  async handle(
+    message: IncomingMessageController,
   ): Promise<ControllerResultTypes[ControllerCommand]> {
     const { command } = message;
 
     switch (message.command) {
       case ControllerCommand.beginInclusion: {
         if (
-          clientsController.grantSecurityClassesPromise ||
-          clientsController.validateDSKAndEnterPinPromise
+          this.clientsController.grantSecurityClassesPromise ||
+          this.clientsController.validateDSKAndEnterPinPromise
         )
           throw new InclusionAlreadyInProgressError();
-        const success = await driver.controller.beginInclusion(
-          processInclusionOptions(clientsController, client, message),
+        const success = await this.driver.controller.beginInclusion(
+          processInclusionOptions(this.clientsController, this.client, message),
         );
         return { success };
       }
       case ControllerCommand.grantSecurityClasses: {
-        if (!clientsController.grantSecurityClassesPromise)
+        if (!this.clientsController.grantSecurityClassesPromise)
           throw new InclusionPhaseNotInProgressError(
             "grantSecurityClassesPromise",
           );
-        clientsController.grantSecurityClassesPromise.resolve(
+        this.clientsController.grantSecurityClassesPromise.resolve(
           message.inclusionGrant,
         );
         return {};
       }
       case ControllerCommand.validateDSKAndEnterPIN: {
-        if (!clientsController.validateDSKAndEnterPinPromise)
+        if (!this.clientsController.validateDSKAndEnterPinPromise)
           throw new InclusionPhaseNotInProgressError(
             "validateDSKAndEnterPinPromise",
           );
-        clientsController.validateDSKAndEnterPinPromise.resolve(message.pin);
+        this.clientsController.validateDSKAndEnterPinPromise.resolve(
+          message.pin,
+        );
         return {};
       }
       case ControllerCommand.provisionSmartStartNode: {
         if (typeof message.entry === "string") {
-          driver.controller.provisionSmartStartNode(
+          this.driver.controller.provisionSmartStartNode(
             parseQRCodeString(message.entry),
           );
         } else {
-          driver.controller.provisionSmartStartNode(message.entry);
+          this.driver.controller.provisionSmartStartNode(message.entry);
         }
         return {};
       }
       case ControllerCommand.unprovisionSmartStartNode: {
-        driver.controller.unprovisionSmartStartNode(message.dskOrNodeId);
+        this.driver.controller.unprovisionSmartStartNode(message.dskOrNodeId);
         return {};
       }
       case ControllerCommand.getProvisioningEntry: {
@@ -97,37 +105,37 @@ export class ControllerMessageHandler {
             "Must include one of dsk or dskOrNodeId in call to getProvisioningEntry",
           );
         }
-        const entry = driver.controller.getProvisioningEntry(dskOrNodeId);
+        const entry = this.driver.controller.getProvisioningEntry(dskOrNodeId);
         return { entry };
       }
       case ControllerCommand.getProvisioningEntries: {
-        const entries = driver.controller.getProvisioningEntries();
+        const entries = this.driver.controller.getProvisioningEntries();
         return { entries };
       }
       case ControllerCommand.stopInclusion: {
-        const success = await driver.controller.stopInclusion();
+        const success = await this.driver.controller.stopInclusion();
         return { success };
       }
       case ControllerCommand.beginExclusion: {
-        const success = await driver.controller.beginExclusion(
+        const success = await this.driver.controller.beginExclusion(
           processExclusionOptions(message),
         );
         return { success };
       }
       case ControllerCommand.stopExclusion: {
-        const success = await driver.controller.stopExclusion();
+        const success = await this.driver.controller.stopExclusion();
         return { success };
       }
       case ControllerCommand.removeFailedNode: {
-        await driver.controller.removeFailedNode(message.nodeId);
+        await this.driver.controller.removeFailedNode(message.nodeId);
         return {};
       }
       case ControllerCommand.replaceFailedNode: {
-        const success = await driver.controller.replaceFailedNode(
+        const success = await this.driver.controller.replaceFailedNode(
           message.nodeId,
           processInclusionOptions(
-            clientsController,
-            client,
+            this.clientsController,
+            this.client,
             message,
           ) as ReplaceNodeOptions,
         );
@@ -136,19 +144,19 @@ export class ControllerMessageHandler {
       // Schema <= 31
       case ControllerCommand.healNode:
       case ControllerCommand.rebuildNodeRoutes: {
-        const success = await driver.controller.rebuildNodeRoutes(
+        const success = await this.driver.controller.rebuildNodeRoutes(
           message.nodeId,
         );
         return { success };
       }
       // Schema <= 31
       case ControllerCommand.beginHealingNetwork: {
-        const success = driver.controller.beginRebuildingRoutes();
+        const success = this.driver.controller.beginRebuildingRoutes();
         return { success };
       }
       // Schema >= 32
       case ControllerCommand.beginRebuildingRoutes: {
-        const success = driver.controller.beginRebuildingRoutes(
+        const success = this.driver.controller.beginRebuildingRoutes(
           message.options!,
         );
         return { success };
@@ -157,17 +165,19 @@ export class ControllerMessageHandler {
       case ControllerCommand.stopHealingNetwork:
       // Schema >= 32
       case ControllerCommand.stopRebuildingRoutes: {
-        const success = driver.controller.stopRebuildingRoutes();
+        const success = this.driver.controller.stopRebuildingRoutes();
         return { success };
       }
       case ControllerCommand.isFailedNode: {
-        const failed = await driver.controller.isFailedNode(message.nodeId);
+        const failed = await this.driver.controller.isFailedNode(
+          message.nodeId,
+        );
         return { failed };
       }
       case ControllerCommand.getAssociationGroups: {
         const groups: ControllerResultTypes[ControllerCommand.getAssociationGroups]["groups"] =
           {};
-        driver.controller
+        this.driver.controller
           .getAssociationGroups({
             nodeId: message.nodeId,
             endpoint: message.endpoint,
@@ -178,7 +188,7 @@ export class ControllerMessageHandler {
       case ControllerCommand.getAssociations: {
         const associations: ControllerResultTypes[ControllerCommand.getAssociations]["associations"] =
           {};
-        driver.controller
+        this.driver.controller
           .getAssociations({
             nodeId: message.nodeId,
             endpoint: message.endpoint,
@@ -187,7 +197,7 @@ export class ControllerMessageHandler {
         return { associations };
       }
       case ControllerCommand.isAssociationAllowed: {
-        const allowed = driver.controller.isAssociationAllowed(
+        const allowed = this.driver.controller.isAssociationAllowed(
           { nodeId: message.nodeId, endpoint: message.endpoint },
           message.group,
           message.association,
@@ -195,7 +205,7 @@ export class ControllerMessageHandler {
         return { allowed };
       }
       case ControllerCommand.addAssociations: {
-        await driver.controller.addAssociations(
+        await this.driver.controller.addAssociations(
           { nodeId: message.nodeId, endpoint: message.endpoint },
           message.group,
           message.associations,
@@ -203,7 +213,7 @@ export class ControllerMessageHandler {
         return {};
       }
       case ControllerCommand.removeAssociations: {
-        await driver.controller.removeAssociations(
+        await this.driver.controller.removeAssociations(
           { nodeId: message.nodeId, endpoint: message.endpoint },
           message.group,
           message.associations,
@@ -212,24 +222,28 @@ export class ControllerMessageHandler {
       }
       case ControllerCommand.removeNodeFromAllAssocations:
       case ControllerCommand.removeNodeFromAllAssociations: {
-        await driver.controller.removeNodeFromAllAssociations(message.nodeId);
+        await this.driver.controller.removeNodeFromAllAssociations(
+          message.nodeId,
+        );
         return {};
       }
       case ControllerCommand.getNodeNeighbors: {
-        const neighbors = await driver.controller.getNodeNeighbors(
+        const neighbors = await this.driver.controller.getNodeNeighbors(
           message.nodeId,
         );
         return { neighbors };
       }
       case ControllerCommand.supportsFeature: {
-        const supported = driver.controller.supportsFeature(message.feature);
+        const supported = this.driver.controller.supportsFeature(
+          message.feature,
+        );
         return { supported };
       }
       case ControllerCommand.backupNVMRaw: {
-        const nvmDataRaw = await driver.controller.backupNVMRaw(
+        const nvmDataRaw = await this.driver.controller.backupNVMRaw(
           (bytesRead: number, total: number) => {
-            clientsController.clients.forEach((client) =>
-              client.sendEvent({
+            this.clientsController.clients.forEach((client) =>
+              this.client.sendEvent({
                 source: "controller",
                 event: "nvm backup progress",
                 bytesRead,
@@ -242,11 +256,11 @@ export class ControllerMessageHandler {
       }
       case ControllerCommand.restoreNVM: {
         const nvmData = Buffer.from(message.nvmData, "base64");
-        await driver.controller.restoreNVM(
+        await this.driver.controller.restoreNVM(
           nvmData,
           (bytesRead: number, total: number) => {
-            clientsController.clients.forEach((client) =>
-              client.sendEvent({
+            this.clientsController.clients.forEach((client) =>
+              this.client.sendEvent({
                 source: "controller",
                 event: "nvm convert progress",
                 bytesRead,
@@ -255,8 +269,8 @@ export class ControllerMessageHandler {
             );
           },
           (bytesWritten: number, total: number) => {
-            clientsController.clients.forEach((client) =>
-              client.sendEvent({
+            this.clientsController.clients.forEach((client) =>
+              this.client.sendEvent({
                 source: "controller",
                 event: "nvm restore progress",
                 bytesWritten,
@@ -268,45 +282,47 @@ export class ControllerMessageHandler {
         return {};
       }
       case ControllerCommand.setRFRegion: {
-        const success = await driver.controller.setRFRegion(message.region);
+        const success = await this.driver.controller.setRFRegion(
+          message.region,
+        );
         return { success };
       }
       case ControllerCommand.getRFRegion: {
-        const region = await driver.controller.getRFRegion();
+        const region = await this.driver.controller.getRFRegion();
         return { region };
       }
       case ControllerCommand.setPowerlevel: {
-        const success = await driver.controller.setPowerlevel(
+        const success = await this.driver.controller.setPowerlevel(
           message.powerlevel,
           message.measured0dBm,
         );
         return { success };
       }
       case ControllerCommand.getPowerlevel: {
-        return await driver.controller.getPowerlevel();
+        return await this.driver.controller.getPowerlevel();
       }
       case ControllerCommand.getState: {
-        const state = dumpController(driver, client.schemaVersion);
+        const state = dumpController(this.driver, this.client.schemaVersion);
         return { state };
       }
       case ControllerCommand.getKnownLifelineRoutes: {
-        const routes = driver.controller.getKnownLifelineRoutes();
+        const routes = this.driver.controller.getKnownLifelineRoutes();
         return { routes };
       }
       case ControllerCommand.getAnyFirmwareUpdateProgress:
       case ControllerCommand.isAnyOTAFirmwareUpdateInProgress: {
         return {
-          progress: driver.controller.isAnyOTAFirmwareUpdateInProgress(),
+          progress: this.driver.controller.isAnyOTAFirmwareUpdateInProgress(),
         };
       }
       case ControllerCommand.getAvailableFirmwareUpdates: {
         return {
-          updates: await driver.controller.getAvailableFirmwareUpdates(
+          updates: await this.driver.controller.getAvailableFirmwareUpdates(
             message.nodeId,
             {
               apiKey: message.apiKey,
               additionalUserAgentComponents:
-                client.additionalUserAgentComponents,
+                this.client.additionalUserAgentComponents,
               includePrereleases: message.includePrereleases,
             },
           ),
@@ -330,47 +346,47 @@ export class ControllerMessageHandler {
             "Missing required parameter `updateInfo`",
           );
         }
-        const result = await driver.controller.firmwareUpdateOTA(
+        const result = await this.driver.controller.firmwareUpdateOTA(
           message.nodeId,
           message.updateInfo,
         );
-        return firmwareUpdateOutgoingMessage(result, client.schemaVersion);
+        return firmwareUpdateOutgoingMessage(result, this.client.schemaVersion);
       }
       case ControllerCommand.firmwareUpdateOTW: {
         const file = Buffer.from(message.file, "base64");
-        const result = await driver.controller.firmwareUpdateOTW(
+        const result = await this.driver.controller.firmwareUpdateOTW(
           extractFirmware(
             file,
             message.fileFormat ??
               guessFirmwareFileFormat(message.filename, file),
           ).data,
         );
-        return firmwareUpdateOutgoingMessage(result, client.schemaVersion);
+        return firmwareUpdateOutgoingMessage(result, this.client.schemaVersion);
       }
       case ControllerCommand.isFirmwareUpdateInProgress: {
-        const progress = driver.controller.isFirmwareUpdateInProgress();
+        const progress = this.driver.controller.isFirmwareUpdateInProgress();
         return { progress };
       }
       case ControllerCommand.setMaxLongRangePowerlevel: {
-        const success = await driver.controller.setMaxLongRangePowerlevel(
+        const success = await this.driver.controller.setMaxLongRangePowerlevel(
           message.limit,
         );
         return { success };
       }
       case ControllerCommand.getMaxLongRangePowerlevel: {
-        const limit = await driver.controller.getMaxLongRangePowerlevel();
+        const limit = await this.driver.controller.getMaxLongRangePowerlevel();
         return {
           limit,
         };
       }
       case ControllerCommand.setLongRangeChannel: {
-        const success = await driver.controller.setLongRangeChannel(
+        const success = await this.driver.controller.setLongRangeChannel(
           message.channel,
         );
         return { success };
       }
       case ControllerCommand.getLongRangeChannel: {
-        const response = await driver.controller.getLongRangeChannel();
+        const response = await this.driver.controller.getLongRangeChannel();
         return response;
       }
       default: {
@@ -421,7 +437,7 @@ function processInclusionOptions(
       options.strategy === InclusionStrategy.Security_S2
     ) {
       // When using Security_S2 inclusion, the user can either provide the provisioning details ahead
-      // of time or go through a standard inclusion process and let the driver/client prompt them
+      // of time or go through a standard inclusion process and let the this.driver/client prompt them
       // for provisioning details based on information received from the device. We have to handle
       // each scenario separately.
       if ("provisioning" in options) {

--- a/src/lib/controller/message_handler.ts
+++ b/src/lib/controller/message_handler.ts
@@ -198,7 +198,7 @@ export class ControllerMessageHandler {
         return { associations };
       }
       case ControllerCommand.checkAssociation: {
-        const result = driver.controller.checkAssociation(
+        const result = this.driver.controller.checkAssociation(
           { nodeId: message.nodeId, endpoint: message.endpoint },
           message.group,
           message.association,
@@ -206,7 +206,7 @@ export class ControllerMessageHandler {
         return { result };
       }
       case ControllerCommand.isAssociationAllowed: {
-        const result = driver.controller.checkAssociation(
+        const result = this.driver.controller.checkAssociation(
           { nodeId: message.nodeId, endpoint: message.endpoint },
           message.group,
           message.association,

--- a/src/lib/endpoint/message_handler.ts
+++ b/src/lib/endpoint/message_handler.ts
@@ -34,15 +34,21 @@ const deserializeBufferInArray = (array: Array<any>): Array<any> => {
 };
 
 export class EndpointMessageHandler {
-  static async handle(
+  private driver: Driver;
+  private client: Client;
+
+  constructor(driver: Driver, client: Client) {
+    this.driver = driver;
+    this.client = client;
+  }
+
+  async handle(
     message: IncomingMessageEndpoint,
-    driver: Driver,
-    client: Client,
   ): Promise<EndpointResultTypes[EndpointCommand]> {
     const { nodeId, command } = message;
     let endpoint;
 
-    const node = driver.controller.nodes.get(nodeId);
+    const node = this.driver.controller.nodes.get(nodeId);
     if (!node) {
       throw new NodeNotFoundError(nodeId);
     }
@@ -89,7 +95,9 @@ export class EndpointMessageHandler {
         const node = endpoint.getNodeUnsafe();
         return {
           node:
-            node === undefined ? node : dumpNode(node, client.schemaVersion),
+            node === undefined
+              ? node
+              : dumpNode(node, this.client.schemaVersion),
         };
       }
       case EndpointCommand.setRawConfigParameterValue: {

--- a/src/lib/incoming_message.ts
+++ b/src/lib/incoming_message.ts
@@ -8,6 +8,7 @@ import { IncomingMessageBroadcastNode } from "./broadcast_node/incoming_message"
 import { IncomingMessageMulticastGroup } from "./multicast_group/incoming_message";
 import { IncomingMessageEndpoint } from "./endpoint/incoming_message";
 import { IncomingMessageUtils } from "./utils/incoming_message";
+import { IncomingMessageConfigManager } from "./config_manager/incoming_message";
 import { LogContexts } from "./logging";
 
 interface IncomingCommandStartListening extends IncomingCommandBase {
@@ -55,6 +56,7 @@ export type IncomingMessage =
   | IncomingMessageBroadcastNode
   | IncomingMessageEndpoint
   | IncomingMessageUtils
+  | IncomingMessageConfigManager
   | IncomingCommandInitialize
   | IncomingCommandStartListeningLogs
   | IncomingCommandStopListeningLogs;

--- a/src/lib/instance.ts
+++ b/src/lib/instance.ts
@@ -1,5 +1,6 @@
 export enum Instance {
   broadcast_node = "broadcast_node",
+  config_manager = "config_manager",
   controller = "controller",
   driver = "driver",
   multicast_group = "multicast_group",

--- a/src/lib/message_handler.ts
+++ b/src/lib/message_handler.ts
@@ -1,0 +1,8 @@
+import { IncomingMessage } from "./incoming_message";
+import { ResultTypes } from "./outgoing_message";
+
+export abstract class MessageHandler {
+  abstract handle(
+    message: IncomingMessage,
+  ): Promise<ResultTypes[keyof ResultTypes]>;
+}

--- a/src/lib/multicast_group/message_handler.ts
+++ b/src/lib/multicast_group/message_handler.ts
@@ -7,14 +7,22 @@ import { Client } from "../server";
 import { setValueOutgoingMessage } from "../common";
 
 export class MulticastGroupMessageHandler {
-  static async handle(
+  private driver: Driver;
+  private client: Client;
+
+  constructor(driver: Driver, client: Client) {
+    this.driver = driver;
+    this.client = client;
+  }
+
+  async handle(
     message: IncomingMessageMulticastGroup,
-    driver: Driver,
-    client: Client,
   ): Promise<MulticastGroupResultTypes[MulticastGroupCommand]> {
     const { command } = message;
 
-    const virtualNode = driver.controller.getMulticastGroup(message.nodeIDs);
+    const virtualNode = this.driver.controller.getMulticastGroup(
+      message.nodeIDs,
+    );
 
     switch (message.command) {
       case MulticastGroupCommand.setValue: {
@@ -23,7 +31,7 @@ export class MulticastGroupMessageHandler {
           message.value,
           message.options,
         );
-        return setValueOutgoingMessage(result, client.schemaVersion);
+        return setValueOutgoingMessage(result, this.client.schemaVersion);
       }
       case MulticastGroupCommand.getEndpointCount: {
         const count = virtualNode.getEndpointCount();

--- a/src/lib/outgoing_message.ts
+++ b/src/lib/outgoing_message.ts
@@ -9,6 +9,7 @@ import { BroadcastNodeResultTypes } from "./broadcast_node/outgoing_message";
 import { MulticastGroupResultTypes } from "./multicast_group/outgoing_message";
 import { EndpointResultTypes } from "./endpoint/outgoing_message";
 import { UtilsResultTypes } from "./utils/outgoing_message";
+import { ConfigManagerResultTypes } from "./config_manager/outgoing_message";
 
 // https://github.com/microsoft/TypeScript/issues/1897#issuecomment-822032151
 export type JSONValue =
@@ -74,7 +75,8 @@ export type ResultTypes = ServerResultTypes &
   MulticastGroupResultTypes &
   BroadcastNodeResultTypes &
   EndpointResultTypes &
-  UtilsResultTypes;
+  UtilsResultTypes &
+  ConfigManagerResultTypes;
 
 export interface OutgoingResultMessageSuccess {
   type: "result";

--- a/src/lib/utils/command.ts
+++ b/src/lib/utils/command.ts
@@ -1,5 +1,9 @@
 export enum UtilsCommand {
   parseQRCodeString = "utils.parse_qr_code_string",
   tryParseDSKFromQRCodeString = "utils.try_parse_dsk_from_qr_code_string",
-  lookupDevice = "utils.lookup_device",
+  num2hex = "utils.num2hex",
+  formatId = "utils.format_id",
+  buffer2hex = "utils.buffer2hex",
+  getEnumMemberName = "utils.get_enum_member_name",
+  rssiToString = "utils.rssi_to_string",
 }

--- a/src/lib/utils/command.ts
+++ b/src/lib/utils/command.ts
@@ -1,4 +1,5 @@
 export enum UtilsCommand {
   parseQRCodeString = "utils.parse_qr_code_string",
   tryParseDSKFromQRCodeString = "utils.try_parse_dsk_from_qr_code_string",
+  lookupDevice = "utils.lookup_device",
 }

--- a/src/lib/utils/command.ts
+++ b/src/lib/utils/command.ts
@@ -1,9 +1,9 @@
 export enum UtilsCommand {
   parseQRCodeString = "utils.parse_qr_code_string",
   tryParseDSKFromQRCodeString = "utils.try_parse_dsk_from_qr_code_string",
-  num2hex = "utils.num2hex",
-  formatId = "utils.format_id",
-  buffer2hex = "utils.buffer2hex",
-  getEnumMemberName = "utils.get_enum_member_name",
+  num2hex = "utils.num2hex", // While made available in the server due to its availability within the driver, this logic should be implemented locally
+  formatId = "utils.format_id", // While made available in the server due to its availability within the driver, this logic should be implemented locally
+  buffer2hex = "utils.buffer2hex", // While made available in the server due to its availability within the driver, this logic should be implemented locally
+  getEnumMemberName = "utils.get_enum_member_name", // While made available in the server due to its availability within the driver, this logic should be implemented locally
   rssiToString = "utils.rssi_to_string",
 }

--- a/src/lib/utils/incoming_message.ts
+++ b/src/lib/utils/incoming_message.ts
@@ -15,6 +15,15 @@ export interface IncomingCommandUtilsTryParseDSKFromQRCodeString
   qr: string;
 }
 
+export interface IncomingCommandUtilsLookupDevice
+  extends IncomingCommandUtilsBase {
+  command: UtilsCommand.lookupDevice;
+  manufacturerId: number;
+  productType: number;
+  productId: number;
+}
+
 export type IncomingMessageUtils =
   | IncomingCommandUtilsParseQRCodeString
-  | IncomingCommandUtilsTryParseDSKFromQRCodeString;
+  | IncomingCommandUtilsTryParseDSKFromQRCodeString
+  | IncomingCommandUtilsLookupDevice;

--- a/src/lib/utils/incoming_message.ts
+++ b/src/lib/utils/incoming_message.ts
@@ -1,3 +1,4 @@
+import { RSSI } from "zwave-js";
 import { IncomingCommandBase } from "../incoming_message_base";
 import { UtilsCommand } from "./command";
 
@@ -15,15 +16,38 @@ export interface IncomingCommandUtilsTryParseDSKFromQRCodeString
   qr: string;
 }
 
-export interface IncomingCommandUtilsLookupDevice
+export interface IncomingCommandUtilsNum2hex extends IncomingCommandUtilsBase {
+  command: UtilsCommand.num2hex;
+  val?: number | null;
+  uppercase: boolean;
+}
+export interface IncomingCommandUtilsFormatId extends IncomingCommandUtilsBase {
+  command: UtilsCommand.formatId;
+  id: number | string;
+}
+export interface IncomingCommandUtilsBuffer2hex
   extends IncomingCommandUtilsBase {
-  command: UtilsCommand.lookupDevice;
-  manufacturerId: number;
-  productType: number;
-  productId: number;
+  command: UtilsCommand.buffer2hex;
+  buffer: Buffer;
+  uppercase: boolean;
+}
+export interface IncomingCommandUtilsGetEnumMemberName
+  extends IncomingCommandUtilsBase {
+  command: UtilsCommand.getEnumMemberName;
+  enumeration: unknown;
+  value: number;
+}
+export interface IncomingCommandUtilsRssiToString
+  extends IncomingCommandUtilsBase {
+  command: UtilsCommand.rssiToString;
+  rssi: RSSI;
 }
 
 export type IncomingMessageUtils =
   | IncomingCommandUtilsParseQRCodeString
   | IncomingCommandUtilsTryParseDSKFromQRCodeString
-  | IncomingCommandUtilsLookupDevice;
+  | IncomingCommandUtilsNum2hex
+  | IncomingCommandUtilsFormatId
+  | IncomingCommandUtilsBuffer2hex
+  | IncomingCommandUtilsGetEnumMemberName
+  | IncomingCommandUtilsRssiToString;

--- a/src/lib/utils/message_handler.ts
+++ b/src/lib/utils/message_handler.ts
@@ -9,7 +9,7 @@ let _ConfigManager: ConfigManager | undefined;
 
 export class UtilsMessageHandler {
   static async handle(
-    message: IncomingMessageUtils
+    message: IncomingMessageUtils,
   ): Promise<UtilsResultTypes[UtilsCommand]> {
     const { command } = message;
 
@@ -30,7 +30,7 @@ export class UtilsMessageHandler {
         const config = await _ConfigManager.lookupDevice(
           message.manufacturerId,
           message.productType,
-          message.productId
+          message.productId,
         );
         return { config };
       }

--- a/src/lib/utils/message_handler.ts
+++ b/src/lib/utils/message_handler.ts
@@ -1,8 +1,11 @@
 import { parseQRCodeString, tryParseDSKFromQRCodeString } from "@zwave-js/core";
+import { ConfigManager } from "@zwave-js/config";
 import { UnknownCommandError } from "../error";
 import { UtilsCommand } from "./command";
 import { IncomingMessageUtils } from "./incoming_message";
 import { UtilsResultTypes } from "./outgoing_message";
+
+let _ConfigManager: ConfigManager | undefined;
 
 export class UtilsMessageHandler {
   static async handle(
@@ -18,6 +21,18 @@ export class UtilsMessageHandler {
       case UtilsCommand.tryParseDSKFromQRCodeString: {
         const dsk = tryParseDSKFromQRCodeString(message.qr);
         return { dsk };
+      }
+      case UtilsCommand.lookupDevice: {
+        if (!_ConfigManager) {
+          _ConfigManager = new ConfigManager();
+          await _ConfigManager.loadDeviceIndex();
+        }
+        const config = await _ConfigManager.lookupDevice(
+          message.manufacturerId,
+          message.productType,
+          message.productId
+        )
+        return { config };
       }
       default: {
         throw new UnknownCommandError(command);

--- a/src/lib/utils/message_handler.ts
+++ b/src/lib/utils/message_handler.ts
@@ -1,14 +1,18 @@
+import {
+  buffer2hex,
+  formatId,
+  getEnumMemberName,
+  num2hex,
+  rssiToString,
+} from "zwave-js";
 import { parseQRCodeString, tryParseDSKFromQRCodeString } from "@zwave-js/core";
-import { ConfigManager } from "@zwave-js/config";
 import { UnknownCommandError } from "../error";
 import { UtilsCommand } from "./command";
 import { IncomingMessageUtils } from "./incoming_message";
 import { UtilsResultTypes } from "./outgoing_message";
 
-let _ConfigManager: ConfigManager | undefined;
-
 export class UtilsMessageHandler {
-  static async handle(
+  async handle(
     message: IncomingMessageUtils,
   ): Promise<UtilsResultTypes[UtilsCommand]> {
     const { command } = message;
@@ -22,17 +26,25 @@ export class UtilsMessageHandler {
         const dsk = tryParseDSKFromQRCodeString(message.qr);
         return { dsk };
       }
-      case UtilsCommand.lookupDevice: {
-        if (!_ConfigManager) {
-          _ConfigManager = new ConfigManager();
-          await _ConfigManager.loadDeviceIndex();
-        }
-        const config = await _ConfigManager.lookupDevice(
-          message.manufacturerId,
-          message.productType,
-          message.productId,
-        );
-        return { config };
+      case UtilsCommand.num2hex: {
+        const hex = num2hex(message.val, message.uppercase);
+        return { hex };
+      }
+      case UtilsCommand.formatId: {
+        const id = formatId(message.id);
+        return { id };
+      }
+      case UtilsCommand.buffer2hex: {
+        const hex = buffer2hex(message.buffer, message.uppercase);
+        return { hex };
+      }
+      case UtilsCommand.getEnumMemberName: {
+        const name = getEnumMemberName(message.enumeration, message.value);
+        return { name };
+      }
+      case UtilsCommand.rssiToString: {
+        const rssi = rssiToString(message.rssi);
+        return { rssi };
       }
       default: {
         throw new UnknownCommandError(command);

--- a/src/lib/utils/message_handler.ts
+++ b/src/lib/utils/message_handler.ts
@@ -9,7 +9,7 @@ let _ConfigManager: ConfigManager | undefined;
 
 export class UtilsMessageHandler {
   static async handle(
-    message: IncomingMessageUtils,
+    message: IncomingMessageUtils
   ): Promise<UtilsResultTypes[UtilsCommand]> {
     const { command } = message;
 
@@ -31,7 +31,7 @@ export class UtilsMessageHandler {
           message.manufacturerId,
           message.productType,
           message.productId
-        )
+        );
         return { config };
       }
       default: {

--- a/src/lib/utils/outgoing_message.ts
+++ b/src/lib/utils/outgoing_message.ts
@@ -9,7 +9,9 @@ export interface UtilsResultTypes {
   [UtilsCommand.tryParseDSKFromQRCodeString]: {
     dsk?: string;
   };
-  [UtilsCommand.lookupDevice]: {
-    config?: DeviceConfig;
-  };
+  [UtilsCommand.num2hex]: { hex: string };
+  [UtilsCommand.formatId]: { id: string };
+  [UtilsCommand.buffer2hex]: { hex: string };
+  [UtilsCommand.getEnumMemberName]: { name: string };
+  [UtilsCommand.rssiToString]: { rssi: string };
 }

--- a/src/lib/utils/outgoing_message.ts
+++ b/src/lib/utils/outgoing_message.ts
@@ -1,4 +1,5 @@
 import { QRProvisioningInformation } from "@zwave-js/core";
+import { DeviceConfig } from "@zwave-js/config";
 import { UtilsCommand } from "./command";
 
 export interface UtilsResultTypes {
@@ -7,5 +8,8 @@ export interface UtilsResultTypes {
   };
   [UtilsCommand.tryParseDSKFromQRCodeString]: {
     dsk?: string;
+  };
+  [UtilsCommand.lookupDevice]: {
+    config?: DeviceConfig;
   };
 }


### PR DESCRIPTION
@AlCalzone , @raman325 

This PR exposes the `lookupDevice` method of the `ConfigManager` class.

I think this should  be added, for the following reason.

Often, after scanning a QR Code, front ends might want to display the Device Information, present in the config.

 - Label
 - Manufatcure
 - Description
 
Generally, specifics about the device, not usually found in the QR its self.
I also use this method, during a Smart Start operation, to advise the user the device is unknown, as the return is either  a `DeviceConfig` or `undefined`

Example:

![Screenshot 2024-06-29 at 17 12 44](https://github.com/zwave-js/zwave-js-server/assets/55892693/893345ad-f856-40e7-9135-f51f42e93dad)


You could argue, why not include this by calling `lookupDevice` during QR Code parsing within the server?
But to allow better 1:1 mapping of the API - I didn't, feel free to suggest otherwise.

Now, I am not too familiar with this code base, so let me know if something is not right with my changes.
