### PR TITLE
chore: bump Z-Wave JS Server to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zwave-js/server",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zwave-js/server",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/ciao": "^1.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/server",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Full access to zwave-js driver through Websockets",
   "homepage": "https://github.com/zwave-js/zwave-js-server#readme",
   "repository": {


### PR DESCRIPTION
Apparently, version 2.0.0 was published on npm before.