### PR TITLE
feat: support omitting optional data in `restoreNVM`

### DIFF
--- a/src/lib/controller/incoming_message.ts
+++ b/src/lib/controller/incoming_message.ts
@@ -8,6 +8,7 @@ import {
   InclusionGrant,
   InclusionOptions,
   KEXFailType,
+  MigrateNVMOptions,
   PlannedProvisioningEntry,
   RebuildRoutesOptions,
   ReplaceNodeOptions,
@@ -246,6 +247,7 @@ export interface IncomingCommandControllerRestoreNVM
   extends IncomingCommandControllerBase {
   command: ControllerCommand.restoreNVM;
   nvmData: string;
+  migrateOptions?: MigrateNVMOptions;
 }
 
 export interface IncomingCommandControllerSetRFRegion

--- a/src/lib/controller/message_handler.ts
+++ b/src/lib/controller/message_handler.ts
@@ -288,6 +288,7 @@ export class ControllerMessageHandler implements MessageHandler {
               }),
             );
           },
+          message.migrateOptions,
         );
         return {};
       }


### PR DESCRIPTION
Z-Wave JS 15.1.0 added support for omitting optional data while restoring an NVM, like the routing table. This can make sense when migrating between vastly different hardware.