### PR TITLE
feat: add `sdkVersion` to `NodeState`, bump schema to 42

### DIFF
--- a/API_SCHEMA.md
+++ b/API_SCHEMA.md
@@ -93,3 +93,7 @@ Base schema.
 - Changed `source` of the `firmware update progress` and `firmware update finished` events from `controller` to `driver`
 - Added `driver.firmware_update_otw` and `driver.is_otw_firmware_update_in_progress` commands
 - Added `node.get_supported_notification_events` command
+
+# Schema 42
+
+- Added `sdkVersion` property to `NodeState`

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -6,7 +6,7 @@ export const version = require("../../package.json").version;
 export const minSchemaVersion = 0;
 
 // maximal/current schema version the server supports
-export const maxSchemaVersion = 41;
+export const maxSchemaVersion = 42;
 
 export const applicationName = "zwave-js-server";
 export const dnssdServiceType = applicationName;

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -365,6 +365,10 @@ export interface NodeStateSchema35 extends NodeStateSchema31 {
   protocol: Protocols;
 }
 
+export interface NodeStateSchema42 extends NodeStateSchema35 {
+  sdkVersion?: string;
+}
+
 export type NodeState =
   | NodeStateSchema0
   | NodeStateSchema1
@@ -377,7 +381,8 @@ export type NodeState =
   | NodeStateSchema29
   | NodeStateSchema30
   | NodeStateSchema31
-  | NodeStateSchema35;
+  | NodeStateSchema35
+  | NodeStateSchema42;
 
 export interface FoundNodeStateSchema19 {
   nodeId: number;
@@ -712,7 +717,14 @@ export const dumpNode = (node: ZWaveNode, schemaVersion: number): NodeState => {
 
   const node35 = node31 as NodeStateSchema35;
   node35.protocol = node.protocol;
-  return node35;
+
+  if (schemaVersion <= 41) {
+    return node35;
+  }
+
+  const node42 = node35 as NodeStateSchema42;
+  node42.sdkVersion = node.sdkVersion;
+  return node42;
 };
 
 export const dumpFoundNode = (


### PR DESCRIPTION
We noticed that the node dump did not include this field, although the driver makes it available.