### PR TITLE
chore: bump zwave-js to 15.3.0 and re-bind controller/node events after `driver ready`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "semver": "^7.5.4",
         "tsx": "^4.19.2",
         "typescript": "^5.3.3",
-        "zwave-js": "^15.1.0"
+        "zwave-js": "^15.3.0"
       },
       "engines": {
         "node": ">= 20"
@@ -1538,15 +1538,15 @@
       }
     },
     "node_modules/@zwave-js/cc": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-15.1.0.tgz",
-      "integrity": "sha512-11p7PmObOadR2yDTquVMAAPTllCPcKvImyAtn2O/t1BNexTxMhMGNRJuGp1NWiPBRMuOX/TLVr86/Rw6i6dLoA==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-15.3.0.tgz",
+      "integrity": "sha512-WWP+WLNGrRrTDr8kkFFy4nsEe0fevFntcFy85eWFIs3BewXtvLkiPqWwfwt2ZfhAdwY9PBt0Mr/WojbAQjaEaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "15.0.6",
-        "@zwave-js/host": "15.1.0",
-        "@zwave-js/shared": "15.0.4",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/host": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "reflect-metadata": "^0.2.2"
@@ -1559,14 +1559,14 @@
       }
     },
     "node_modules/@zwave-js/config": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-15.1.0.tgz",
-      "integrity": "sha512-ob9zvjfzN8rqR8oBS6/ot8X8z+3zjJG/xxpba+x5lHGAJ938kdsDeLriyXZGbYzlv/+T5fLZUw3WG/GCj6OhUA==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-15.3.0.tgz",
+      "integrity": "sha512-+BMbKJNjkjKzSixMy+6M+D3FQRi7f3MFGQo/I3SWjOettF7aDzk7yvE+roZnYKKCukH7r0ryFYSctb7YpWh19A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "15.0.6",
-        "@zwave-js/shared": "15.0.4",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "json-logic-js": "^2.0.5",
@@ -1583,14 +1583,14 @@
       }
     },
     "node_modules/@zwave-js/core": {
-      "version": "15.0.6",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-15.0.6.tgz",
-      "integrity": "sha512-wuXpVi1XCDwfmAZ879tSd1xDlE2G2w2AYFbdgEZ78PvJeEgZoY983f89RzTD4iGr7rkmffFkYgolmshWAFvb8Q==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-15.3.0.tgz",
+      "integrity": "sha512-UZuRmRtqfWgw17h76F7aBOJho+IZAxfzCfsQdT+0J0VGWmwdmEmEuCoBfXi55ReShKAz8jH50smy9GaCg6Y4KQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alcalzone/jsonl-db": "^3.1.1",
-        "@zwave-js/shared": "15.0.4",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "dayjs": "^1.11.13",
@@ -1613,15 +1613,15 @@
       }
     },
     "node_modules/@zwave-js/host": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-15.1.0.tgz",
-      "integrity": "sha512-v2U4zaEi7Wki+I1SMJadFLLLQjk5Zlwv+Yr0pqqnoDLKwf0gLVRsizfMs22jJ1AUUXLvZtfq0COYIt1VP99QfQ==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-15.3.0.tgz",
+      "integrity": "sha512-6ONrzZTyQrke1aGG2wiwrZxdBXzJ3PNQFX8iGs1A3TyYXNkFad07s08QMPTEFAVAN4OBrC6PbRmjsIleUW8jSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/config": "15.1.0",
-        "@zwave-js/core": "15.0.6",
-        "@zwave-js/shared": "15.0.4",
+        "@zwave-js/config": "15.3.0",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0"
       },
       "engines": {
@@ -1632,14 +1632,14 @@
       }
     },
     "node_modules/@zwave-js/nvmedit": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-15.1.0.tgz",
-      "integrity": "sha512-T/QhHdaXNt5YTh3B8TijaFx84HDOYSCajVO7Z1lBXwxcgAuG0KLZH2CKYwK7F4GjWFyqvVVgLokzXANNkCMyVw==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-15.3.0.tgz",
+      "integrity": "sha512-zIxsnKX4MLupkmosn278IMjjnJ+maC1w2oWEiPnsNu32sWnGPjGz9LiGUmQgHd44ZSHjwhqD3vGbFi+hPLwy+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "15.0.6",
-        "@zwave-js/shared": "15.0.4",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "reflect-metadata": "^0.2.2",
         "semver": "^7.6.3",
@@ -1656,17 +1656,17 @@
       }
     },
     "node_modules/@zwave-js/serial": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-15.1.0.tgz",
-      "integrity": "sha512-i/WrlK7IVo22jHavmGgpLQf/hqm6UBlsiWt1uwxHsiilA9mCrWXWMwtERLDasOSuT5GSJNbXKHVpIPK5ISEY7g==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-15.3.0.tgz",
+      "integrity": "sha512-Wf9cBcle0l2QA58MEKnBbpOnBRqLQS559e6+R/vXeppkbmQ6A/SWWbjApQQLgRe9AEKstvd+pXQOYuqqAsqGgA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@serialport/stream": "^13.0.0",
-        "@zwave-js/cc": "15.1.0",
-        "@zwave-js/core": "15.0.6",
-        "@zwave-js/host": "15.1.0",
-        "@zwave-js/shared": "15.0.4",
+        "@zwave-js/cc": "15.3.0",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/host": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "serialport": "^13.0.0",
         "winston": "^3.17.0"
@@ -1679,9 +1679,9 @@
       }
     },
     "node_modules/@zwave-js/shared": {
-      "version": "15.0.4",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-15.0.4.tgz",
-      "integrity": "sha512-0u8lTtZe1jMQLUWoYD5LDokWqas2qWREn1YGgZNKJuyHprWBpxJOa7alnSHd6j/Qkhb+ofJFcup/PNxLNasGSg==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-15.3.0.tgz",
+      "integrity": "sha512-9r/laLelOc65sE2UX1YtKkZy7OPMmG4oiPBIcw7K7xgW8eRxYxmfafNWIFYi788VjYIEOi9VtCe1Ry8DBTYlnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1696,16 +1696,16 @@
       }
     },
     "node_modules/@zwave-js/testing": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-15.1.0.tgz",
-      "integrity": "sha512-oApjRc3ia46YKl9vNXiJSOnkNvWa7/MiIjpvN/iGURSqZSZ7r4hm0WNj4JlPnY82XgRktroI51Ke04UVvtUVgg==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-15.3.0.tgz",
+      "integrity": "sha512-rtKwG7QrXeAIRqvk03rODRBBlmvrEZerkUIShIREF+JToOcfE9xHyoj5W9dTdhZ3S1I0bTq0bxsOOhil1Qha5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "15.0.6",
-        "@zwave-js/host": "15.1.0",
-        "@zwave-js/serial": "15.1.0",
-        "@zwave-js/shared": "15.0.4",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/host": "15.3.0",
+        "@zwave-js/serial": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3"
       },
@@ -5062,23 +5062,23 @@
       }
     },
     "node_modules/zwave-js": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-15.1.0.tgz",
-      "integrity": "sha512-xQPn4M+S+PjRLQqTBaDpzkpPsPbAqL/EatSfXTuMgh6ipZIyVe7mTfdmu5eY+yqBjVUlebHTE1aUa3eN0tjCBw==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-15.3.0.tgz",
+      "integrity": "sha512-sQymF2I+Lda4V/kaIKjR6me9xh29E1ZEjy17naonHoZ2XLBDnEtteb6E2KjSpolydu4oGgmV7IUjzrUMvxkPAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alcalzone/jsonl-db": "^3.1.1",
         "@andrewbranch/untar.js": "^1.0.3",
         "@homebridge/ciao": "^1.3.1",
-        "@zwave-js/cc": "15.1.0",
-        "@zwave-js/config": "15.1.0",
-        "@zwave-js/core": "15.0.6",
-        "@zwave-js/host": "15.1.0",
-        "@zwave-js/nvmedit": "15.1.0",
-        "@zwave-js/serial": "15.1.0",
-        "@zwave-js/shared": "15.0.4",
-        "@zwave-js/testing": "15.1.0",
+        "@zwave-js/cc": "15.3.0",
+        "@zwave-js/config": "15.3.0",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/host": "15.3.0",
+        "@zwave-js/nvmedit": "15.3.0",
+        "@zwave-js/serial": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
+        "@zwave-js/testing": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "ky": "^1.7.2",
@@ -5986,27 +5986,27 @@
       }
     },
     "@zwave-js/cc": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-15.1.0.tgz",
-      "integrity": "sha512-11p7PmObOadR2yDTquVMAAPTllCPcKvImyAtn2O/t1BNexTxMhMGNRJuGp1NWiPBRMuOX/TLVr86/Rw6i6dLoA==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-15.3.0.tgz",
+      "integrity": "sha512-WWP+WLNGrRrTDr8kkFFy4nsEe0fevFntcFy85eWFIs3BewXtvLkiPqWwfwt2ZfhAdwY9PBt0Mr/WojbAQjaEaQ==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "15.0.6",
-        "@zwave-js/host": "15.1.0",
-        "@zwave-js/shared": "15.0.4",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/host": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "reflect-metadata": "^0.2.2"
       }
     },
     "@zwave-js/config": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-15.1.0.tgz",
-      "integrity": "sha512-ob9zvjfzN8rqR8oBS6/ot8X8z+3zjJG/xxpba+x5lHGAJ938kdsDeLriyXZGbYzlv/+T5fLZUw3WG/GCj6OhUA==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-15.3.0.tgz",
+      "integrity": "sha512-+BMbKJNjkjKzSixMy+6M+D3FQRi7f3MFGQo/I3SWjOettF7aDzk7yvE+roZnYKKCukH7r0ryFYSctb7YpWh19A==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "15.0.6",
-        "@zwave-js/shared": "15.0.4",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "json-logic-js": "^2.0.5",
@@ -6017,13 +6017,13 @@
       }
     },
     "@zwave-js/core": {
-      "version": "15.0.6",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-15.0.6.tgz",
-      "integrity": "sha512-wuXpVi1XCDwfmAZ879tSd1xDlE2G2w2AYFbdgEZ78PvJeEgZoY983f89RzTD4iGr7rkmffFkYgolmshWAFvb8Q==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-15.3.0.tgz",
+      "integrity": "sha512-UZuRmRtqfWgw17h76F7aBOJho+IZAxfzCfsQdT+0J0VGWmwdmEmEuCoBfXi55ReShKAz8jH50smy9GaCg6Y4KQ==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^3.1.1",
-        "@zwave-js/shared": "15.0.4",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "dayjs": "^1.11.13",
@@ -6040,25 +6040,25 @@
       }
     },
     "@zwave-js/host": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-15.1.0.tgz",
-      "integrity": "sha512-v2U4zaEi7Wki+I1SMJadFLLLQjk5Zlwv+Yr0pqqnoDLKwf0gLVRsizfMs22jJ1AUUXLvZtfq0COYIt1VP99QfQ==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-15.3.0.tgz",
+      "integrity": "sha512-6ONrzZTyQrke1aGG2wiwrZxdBXzJ3PNQFX8iGs1A3TyYXNkFad07s08QMPTEFAVAN4OBrC6PbRmjsIleUW8jSw==",
       "dev": true,
       "requires": {
-        "@zwave-js/config": "15.1.0",
-        "@zwave-js/core": "15.0.6",
-        "@zwave-js/shared": "15.0.4",
+        "@zwave-js/config": "15.3.0",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0"
       }
     },
     "@zwave-js/nvmedit": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-15.1.0.tgz",
-      "integrity": "sha512-T/QhHdaXNt5YTh3B8TijaFx84HDOYSCajVO7Z1lBXwxcgAuG0KLZH2CKYwK7F4GjWFyqvVVgLokzXANNkCMyVw==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-15.3.0.tgz",
+      "integrity": "sha512-zIxsnKX4MLupkmosn278IMjjnJ+maC1w2oWEiPnsNu32sWnGPjGz9LiGUmQgHd44ZSHjwhqD3vGbFi+hPLwy+A==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "15.0.6",
-        "@zwave-js/shared": "15.0.4",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "reflect-metadata": "^0.2.2",
         "semver": "^7.6.3",
@@ -6066,25 +6066,25 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-15.1.0.tgz",
-      "integrity": "sha512-i/WrlK7IVo22jHavmGgpLQf/hqm6UBlsiWt1uwxHsiilA9mCrWXWMwtERLDasOSuT5GSJNbXKHVpIPK5ISEY7g==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-15.3.0.tgz",
+      "integrity": "sha512-Wf9cBcle0l2QA58MEKnBbpOnBRqLQS559e6+R/vXeppkbmQ6A/SWWbjApQQLgRe9AEKstvd+pXQOYuqqAsqGgA==",
       "dev": true,
       "requires": {
         "@serialport/stream": "^13.0.0",
-        "@zwave-js/cc": "15.1.0",
-        "@zwave-js/core": "15.0.6",
-        "@zwave-js/host": "15.1.0",
-        "@zwave-js/shared": "15.0.4",
+        "@zwave-js/cc": "15.3.0",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/host": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "serialport": "^13.0.0",
         "winston": "^3.17.0"
       }
     },
     "@zwave-js/shared": {
-      "version": "15.0.4",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-15.0.4.tgz",
-      "integrity": "sha512-0u8lTtZe1jMQLUWoYD5LDokWqas2qWREn1YGgZNKJuyHprWBpxJOa7alnSHd6j/Qkhb+ofJFcup/PNxLNasGSg==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-15.3.0.tgz",
+      "integrity": "sha512-9r/laLelOc65sE2UX1YtKkZy7OPMmG4oiPBIcw7K7xgW8eRxYxmfafNWIFYi788VjYIEOi9VtCe1Ry8DBTYlnw==",
       "dev": true,
       "requires": {
         "alcalzone-shared": "^5.0.0",
@@ -6092,15 +6092,15 @@
       }
     },
     "@zwave-js/testing": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-15.1.0.tgz",
-      "integrity": "sha512-oApjRc3ia46YKl9vNXiJSOnkNvWa7/MiIjpvN/iGURSqZSZ7r4hm0WNj4JlPnY82XgRktroI51Ke04UVvtUVgg==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-15.3.0.tgz",
+      "integrity": "sha512-rtKwG7QrXeAIRqvk03rODRBBlmvrEZerkUIShIREF+JToOcfE9xHyoj5W9dTdhZ3S1I0bTq0bxsOOhil1Qha5w==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "15.0.6",
-        "@zwave-js/host": "15.1.0",
-        "@zwave-js/serial": "15.1.0",
-        "@zwave-js/shared": "15.0.4",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/host": "15.3.0",
+        "@zwave-js/serial": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3"
       }
@@ -8299,22 +8299,22 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-15.1.0.tgz",
-      "integrity": "sha512-xQPn4M+S+PjRLQqTBaDpzkpPsPbAqL/EatSfXTuMgh6ipZIyVe7mTfdmu5eY+yqBjVUlebHTE1aUa3eN0tjCBw==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-15.3.0.tgz",
+      "integrity": "sha512-sQymF2I+Lda4V/kaIKjR6me9xh29E1ZEjy17naonHoZ2XLBDnEtteb6E2KjSpolydu4oGgmV7IUjzrUMvxkPAA==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^3.1.1",
         "@andrewbranch/untar.js": "^1.0.3",
         "@homebridge/ciao": "^1.3.1",
-        "@zwave-js/cc": "15.1.0",
-        "@zwave-js/config": "15.1.0",
-        "@zwave-js/core": "15.0.6",
-        "@zwave-js/host": "15.1.0",
-        "@zwave-js/nvmedit": "15.1.0",
-        "@zwave-js/serial": "15.1.0",
-        "@zwave-js/shared": "15.0.4",
-        "@zwave-js/testing": "15.1.0",
+        "@zwave-js/cc": "15.3.0",
+        "@zwave-js/config": "15.3.0",
+        "@zwave-js/core": "15.3.0",
+        "@zwave-js/host": "15.3.0",
+        "@zwave-js/nvmedit": "15.3.0",
+        "@zwave-js/serial": "15.3.0",
+        "@zwave-js/shared": "15.3.0",
+        "@zwave-js/testing": "15.3.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
         "ky": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ws": "^8.18.0"
   },
   "peerDependencies": {
-    "zwave-js": "^15.1.0"
+    "zwave-js": "^15.3.0"
   },
   "devDependencies": {
     "@alcalzone/esm2cjs": "^1.4.0",
@@ -73,7 +73,7 @@
     "semver": "^7.5.4",
     "tsx": "^4.19.2",
     "typescript": "^5.3.3",
-    "zwave-js": "^15.1.0"
+    "zwave-js": "^15.3.0"
   },
   "engines": {
     "node": ">= 20"


### PR DESCRIPTION
As of Z-Wave JS 15.3.0, receiving the `driver ready` event always means that the old controller and node instances are no longer valid, and that their event handlers will no longer be called. This PR makes sure that we handle this case correctly, which happens after NVM restore, and OTW upgrades.