### PR TITLE
fix: reuse driver's ConfigManager instance instead of creating a new one

### DIFF
--- a/src/lib/config_manager/message_handler.ts
+++ b/src/lib/config_manager/message_handler.ts
@@ -1,16 +1,12 @@
-import { ConfigManager } from "@zwave-js/config";
 import { UnknownCommandError } from "../error.js";
 import { ConfigManagerCommand } from "./command.js";
 import { IncomingMessageConfigManager } from "./incoming_message.js";
 import { ConfigManagerResultTypes } from "./outgoing_message.js";
 import { MessageHandler } from "../message_handler.js";
+import { Driver } from "zwave-js";
 
 export class ConfigManagerMessageHandler implements MessageHandler {
-  private configManager: ConfigManager = new ConfigManager();
-
-  constructor() {
-    this.configManager.loadDeviceIndex().then(() => {});
-  }
+  constructor(private driver: Driver) {}
 
   async handle(
     message: IncomingMessageConfigManager,
@@ -19,7 +15,7 @@ export class ConfigManagerMessageHandler implements MessageHandler {
 
     switch (message.command) {
       case ConfigManagerCommand.lookupDevice: {
-        const config = await this.configManager.lookupDevice(
+        const config = await this.driver.configManager.lookupDevice(
           message.manufacturerId,
           message.productType,
           message.productId,
@@ -28,50 +24,51 @@ export class ConfigManagerMessageHandler implements MessageHandler {
         return { config };
       }
       case ConfigManagerCommand.loadManufacturers: {
-        await this.configManager.loadManufacturers();
+        await this.driver.configManager.loadManufacturers();
         return {};
       }
       case ConfigManagerCommand.lookupManufacturer: {
-        const name = this.configManager.lookupManufacturer(
+        const name = this.driver.configManager.lookupManufacturer(
           message.manufacturerId,
         );
         return { name };
       }
       case ConfigManagerCommand.loadDeviceIndex: {
-        await this.configManager.loadDeviceIndex();
+        await this.driver.configManager.loadDeviceIndex();
         return {};
       }
       case ConfigManagerCommand.getIndex: {
-        const index = this.configManager.getIndex();
+        const index = this.driver.configManager.getIndex();
         return { index };
       }
       case ConfigManagerCommand.loadFulltextDeviceIndex: {
-        await this.configManager.loadFulltextDeviceIndex();
+        await this.driver.configManager.loadFulltextDeviceIndex();
         return {};
       }
       case ConfigManagerCommand.getFulltextIndex: {
-        const index = this.configManager.getFulltextIndex();
+        const index = this.driver.configManager.getFulltextIndex();
         return { index };
       }
       case ConfigManagerCommand.lookupDevicePreserveConditions: {
-        const config = await this.configManager.lookupDevicePreserveConditions(
-          message.manufacturerId,
-          message.productType,
-          message.productId,
-          message.firmwareVersion,
-        );
+        const config =
+          await this.driver.configManager.lookupDevicePreserveConditions(
+            message.manufacturerId,
+            message.productType,
+            message.productId,
+            message.firmwareVersion,
+          );
         return { config };
       }
       case ConfigManagerCommand.manufacturers: {
-        const manufacturers = this.configManager.manufacturers;
+        const manufacturers = this.driver.configManager.manufacturers;
         return { manufacturers };
       }
       case ConfigManagerCommand.loadAll: {
-        await this.configManager.loadAll();
+        await this.driver.configManager.loadAll();
         return {};
       }
       case ConfigManagerCommand.configVersion: {
-        return { configVersion: this.configManager.configVersion };
+        return { configVersion: this.driver.configManager.configVersion };
       }
       default: {
         throw new UnknownCommandError(command);

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -86,7 +86,7 @@ export class Client {
     });
     socket.on("message", (data: string) => this.receiveMessage(data));
     this.instanceHandlers = {
-      [Instance.config_manager]: new ConfigManagerMessageHandler(),
+      [Instance.config_manager]: new ConfigManagerMessageHandler(this.driver),
       [Instance.controller]: new ControllerMessageHandler(
         this.clientsController,
         this.driver,


### PR DESCRIPTION
This fixes the root cause of https://github.com/zwave-js/zwave-js-ui/issues/4216

When bundled with `pkg`, the driver is using a different filesystem abstraction. This is not available when instancing the `ConfigManager` directly, so loading the files with that instance will fail.
By reusing the driver's `ConfigManager` instance, we can avoid the issue altogether.