### PR TITLE
chore: switch to Typescript-Go

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@types/yargs": "^17.0.24",
         "@typescript-eslint/eslint-plugin": "^8.14.0",
         "@typescript-eslint/parser": "^8.14.0",
+        "@typescript/native-preview": "^7.0.0-dev.20250617.1",
         "alcalzone-shared": "^5.0.0",
         "eslint": "^9.14.0",
         "eslint-config-prettier": "^9.1.0",
@@ -38,7 +39,6 @@
         "prettier": "^3.0.0",
         "semver": "^7.5.4",
         "tsx": "^4.19.2",
-        "typescript": "^5.3.3",
         "zwave-js": "^15.3.0"
       },
       "engines": {
@@ -1535,6 +1535,147 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript/native-preview": {
+      "version": "7.0.0-dev.20250617.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20250617.1.tgz",
+      "integrity": "sha512-ns9t0bz3JMuUnzeRbFFjPkVPJozl0gkEzPk6RTAALC/oAyCD22ZWWNT2f/4BnfaPCSv/VmS+DE+ehsBUhlLyvw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsgo": "bin/tsgo.js"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      },
+      "optionalDependencies": {
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20250617.1",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20250617.1",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20250617.1",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20250617.1",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20250617.1",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20250617.1",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20250617.1"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-arm64": {
+      "version": "7.0.0-dev.20250617.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20250617.1.tgz",
+      "integrity": "sha512-GfymQ0cnEWOoae9Yb/20VE9Mqd4gowOPRzfxJtCbmYc8Yr2XAEavKnB8eHgtE5LYxML2796GADmIRhSS2qkmeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-x64": {
+      "version": "7.0.0-dev.20250617.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20250617.1.tgz",
+      "integrity": "sha512-ZIDJvjYeB2+uHsaQCGwpFbbMdLiJQMWIdTV2ba4cFKDMEQrrj2idPL0NH618joChE8enQ1E6YBMFtJcunzaO5A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-arm": {
+      "version": "7.0.0-dev.20250617.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20250617.1.tgz",
+      "integrity": "sha512-BImtvCIl8QrJaMhAvu4cW/aguShR29ypSPqFBMzGHGttdA0A9Opqwv4KB4JP9Pa3FPIrsvQ3EnKIzXYsxR1rXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-arm64": {
+      "version": "7.0.0-dev.20250617.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20250617.1.tgz",
+      "integrity": "sha512-/OGztX0ZTvOq1xjE0m4bKC0+0ADFopE1+wG5P2x0eifgYJqWS8Z3hZGzCIZ9EntEw5ehaaepSs2x+rFYw/mozg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-x64": {
+      "version": "7.0.0-dev.20250617.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20250617.1.tgz",
+      "integrity": "sha512-YgJQ86WmTiTcm0bfV3cJr06lj4AXjnRSQ7wPn4Akie1ZnBwJ/MuBkSshcikeizEcwSNDq1wfcC1ajNTlwA6zlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-win32-arm64": {
+      "version": "7.0.0-dev.20250617.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20250617.1.tgz",
+      "integrity": "sha512-VGJL5ovkI2G4XCWeiAbQWIj2a20HIeZ5aXqxdqp6toiJ71K/w1iWa1UUFmS7Ahszr3IGUWMp54OKD8pH77+dow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-win32-x64": {
+      "version": "7.0.0-dev.20250617.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20250617.1.tgz",
+      "integrity": "sha512-w11yreVQnIP+QLF84OJUkHq7xdk5x3N6BWKnawcqYkSXLLkWBCJtzxUKr4+rT2cnITOGqWX7IVKBkWY0pJzBWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.6.0"
       }
     },
     "node_modules/@zwave-js/cc": {
@@ -4844,6 +4985,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5984,6 +6126,70 @@
           "dev": true
         }
       }
+    },
+    "@typescript/native-preview": {
+      "version": "7.0.0-dev.20250617.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20250617.1.tgz",
+      "integrity": "sha512-ns9t0bz3JMuUnzeRbFFjPkVPJozl0gkEzPk6RTAALC/oAyCD22ZWWNT2f/4BnfaPCSv/VmS+DE+ehsBUhlLyvw==",
+      "dev": true,
+      "requires": {
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20250617.1",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20250617.1",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20250617.1",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20250617.1",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20250617.1",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20250617.1",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20250617.1"
+      }
+    },
+    "@typescript/native-preview-darwin-arm64": {
+      "version": "7.0.0-dev.20250617.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20250617.1.tgz",
+      "integrity": "sha512-GfymQ0cnEWOoae9Yb/20VE9Mqd4gowOPRzfxJtCbmYc8Yr2XAEavKnB8eHgtE5LYxML2796GADmIRhSS2qkmeA==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/native-preview-darwin-x64": {
+      "version": "7.0.0-dev.20250617.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20250617.1.tgz",
+      "integrity": "sha512-ZIDJvjYeB2+uHsaQCGwpFbbMdLiJQMWIdTV2ba4cFKDMEQrrj2idPL0NH618joChE8enQ1E6YBMFtJcunzaO5A==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/native-preview-linux-arm": {
+      "version": "7.0.0-dev.20250617.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20250617.1.tgz",
+      "integrity": "sha512-BImtvCIl8QrJaMhAvu4cW/aguShR29ypSPqFBMzGHGttdA0A9Opqwv4KB4JP9Pa3FPIrsvQ3EnKIzXYsxR1rXQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/native-preview-linux-arm64": {
+      "version": "7.0.0-dev.20250617.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20250617.1.tgz",
+      "integrity": "sha512-/OGztX0ZTvOq1xjE0m4bKC0+0ADFopE1+wG5P2x0eifgYJqWS8Z3hZGzCIZ9EntEw5ehaaepSs2x+rFYw/mozg==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/native-preview-linux-x64": {
+      "version": "7.0.0-dev.20250617.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20250617.1.tgz",
+      "integrity": "sha512-YgJQ86WmTiTcm0bfV3cJr06lj4AXjnRSQ7wPn4Akie1ZnBwJ/MuBkSshcikeizEcwSNDq1wfcC1ajNTlwA6zlw==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/native-preview-win32-arm64": {
+      "version": "7.0.0-dev.20250617.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20250617.1.tgz",
+      "integrity": "sha512-VGJL5ovkI2G4XCWeiAbQWIj2a20HIeZ5aXqxdqp6toiJ71K/w1iWa1UUFmS7Ahszr3IGUWMp54OKD8pH77+dow==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/native-preview-win32-x64": {
+      "version": "7.0.0-dev.20250617.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20250617.1.tgz",
+      "integrity": "sha512-w11yreVQnIP+QLF84OJUkHq7xdk5x3N6BWKnawcqYkSXLLkWBCJtzxUKr4+rT2cnITOGqWX7IVKBkWY0pJzBWw==",
+      "dev": true,
+      "optional": true
     },
     "@zwave-js/cc": {
       "version": "15.3.0",
@@ -8156,7 +8362,8 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "undici-types": {
       "version": "6.20.0",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "scripts": {
     "lint": "eslint",
     "lint:fix": "eslint --fix && prettier -w .",
-    "test": "prettier --check src && tsc --noEmit && npm run lint && tsx src/test/integration.ts",
-    "build": "tsc -p .",
+    "test": "prettier --check src && tsgo --noEmit && npm run lint && tsx src/test/integration.ts",
+    "build": "tsgo",
     "postbuild": "esm2cjs --in dist-esm --out dist-cjs -l error -t node20",
     "prepare": "npm run build",
     "prepublishOnly": "rm -rf dist-* && npm run build"
@@ -63,6 +63,7 @@
     "@types/yargs": "^17.0.24",
     "@typescript-eslint/eslint-plugin": "^8.14.0",
     "@typescript-eslint/parser": "^8.14.0",
+    "@typescript/native-preview": "^7.0.0-dev.20250617.1",
     "alcalzone-shared": "^5.0.0",
     "eslint": "^9.14.0",
     "eslint-config-prettier": "^9.1.0",
@@ -72,7 +73,6 @@
     "prettier": "^3.0.0",
     "semver": "^7.5.4",
     "tsx": "^4.19.2",
-    "typescript": "^5.3.3",
     "zwave-js": "^15.3.0"
   },
   "engines": {

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -2,7 +2,7 @@ import { WebSocketServer, type WebSocket } from "ws";
 import {
   getResponder,
   CiaoService,
-  Protocol,
+  type Protocol,
   Responder,
 } from "@homebridge/ciao";
 import {
@@ -540,7 +540,7 @@ export class ZwavejsServer extends EventEmitter {
         name: this.driver.controller.homeId!.toString(),
         port,
         type: dnssdServiceType,
-        protocol: Protocol.TCP,
+        protocol: "tcp" as Protocol,
         txt: getVersionData(this.driver),
       });
       this.service.advertise().then(() => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "declaration": true,
     "outDir": "dist-esm",
     "rootDir": "src",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "isolatedModules": true
   }
 }


### PR DESCRIPTION
This PR serves as an experiment for using the native Go port of TypeScript for compilation. It should work as-is, with the one minor modification in `server.ts`, the output is identical to the old TypeScript compiler.

https://devblogs.microsoft.com/typescript/typescript-native-port/