### PR TITLE
ignore cache from ZJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config.json
 .vscode/*
 .DS_Store
 *.tgz
+cache


### PR DESCRIPTION
When running ZJS, it will generate a `cache` folder. This PR ignores it from git.