### PR TITLE
Suppress logo on reconnection attempts and bump zwave-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "semver": "^7.5.4",
         "tsx": "^4.19.2",
         "typescript": "^5.3.3",
-        "zwave-js": "^15.14.0"
+        "zwave-js": "^15.15.0"
       },
       "engines": {
         "node": ">= 20"
@@ -78,7 +78,6 @@
       "resolved": "https://registry.npmjs.org/@alcalzone/jsonl-db/-/jsonl-db-3.1.1.tgz",
       "integrity": "sha512-1ezCM6Od1vW3uT+ALLkAg0vN+MZtib18k1A+JPvLTm55tb4Lj9PsF4x3o9mBI102/nRAI3FpkEzLJAeZlkXdDA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@alcalzone/proper-lockfile": "^4.1.3-0",
         "alcalzone-shared": "^4.0.8",
@@ -93,7 +92,6 @@
       "resolved": "https://registry.npmjs.org/alcalzone-shared/-/alcalzone-shared-4.0.8.tgz",
       "integrity": "sha512-Rr0efCjNL9lw7miDvU8exL87Y42ehsLU2jUGNQUphhnlvxnTMrHeApWgoOSGZvsE2PhxC3KO7Z+VpQ/IbuV3aA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -106,7 +104,6 @@
       "resolved": "https://registry.npmjs.org/@alcalzone/proper-lockfile/-/proper-lockfile-4.1.3-0.tgz",
       "integrity": "sha512-8mlX3l5Xc+pYyiK9G156NyMosNuvvukL+TtNMqw7ti2zgVpz+WqPMPb2J1WU8I03Jbm4cXF+Q0D53hWvQqLQ0Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "retry": "^0.12.0",
@@ -212,19 +209,17 @@
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
       "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
       }
     },
     "node_modules/@dabh/diagnostics": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "colorspace": "1.1.x",
+        "@so-ric/colorspace": "^1.1.6",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
       }
@@ -957,7 +952,6 @@
       "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-10.2.2.tgz",
       "integrity": "sha512-HAFzGhk9OuFMpuor7aT5G1ChPgn5qSsklTFOTUX72Rl6p0xwcSVsRtG/xaGp6bxpN7fI9D/S8THLBWbBgS6ldw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@serialport/bindings-interface": "^1.2.1",
         "debug": "^4.3.3"
@@ -972,7 +966,6 @@
       "integrity": "sha512-r25o4Bk/vaO1LyUfY/ulR6hCg/aWiN6Wo2ljVlb4Pj5bqWGcSRC4Vse4a9AcapuAu/FeBzHCbKMvRQeCuKjzIQ==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@serialport/bindings-interface": "1.2.2",
         "@serialport/parser-readline": "12.0.0",
@@ -992,7 +985,6 @@
       "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-12.0.0.tgz",
       "integrity": "sha512-gu26tVt5lQoybhorLTPsH2j2LnX3AOP2x/34+DUSTNaUTzu2fBXw+isVjQJpUBFWu6aeQRZw5bJol5X9Gxjblw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
       },
@@ -1005,7 +997,6 @@
       "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-12.0.0.tgz",
       "integrity": "sha512-O7cywCWC8PiOMvo/gglEBfAkLjp/SENEML46BXDykfKP5mTPM46XMaX1L0waWU6DXJpBgjaL7+yX6VriVPbN4w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@serialport/parser-delimiter": "12.0.0"
       },
@@ -1021,7 +1012,6 @@
       "resolved": "https://registry.npmjs.org/@serialport/bindings-interface/-/bindings-interface-1.2.2.tgz",
       "integrity": "sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.22 || ^14.13 || >=16"
       }
@@ -1031,7 +1021,6 @@
       "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-13.0.0.tgz",
       "integrity": "sha512-32yvqeTAqJzAEtX5zCrN1Mej56GJ5h/cVFsCDPbF9S1ZSC9FWjOqNAgtByseHfFTSTs/4ZBQZZcZBpolt8sUng==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1044,7 +1033,6 @@
       "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-13.0.0.tgz",
       "integrity": "sha512-RErAe57g9gvnlieVYGIn1xymb1bzNXb2QtUQd14FpmbQQYlcrmuRnJwKa1BgTCujoCkhtaTtgHlbBWOxm8U2uA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1057,7 +1045,6 @@
       "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-13.0.0.tgz",
       "integrity": "sha512-Qqyb0FX1avs3XabQqNaZSivyVbl/yl0jywImp7ePvfZKLwx7jBZjvL+Hawt9wIG6tfq6zbFM24vzCCK7REMUig==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1070,7 +1057,6 @@
       "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-13.0.0.tgz",
       "integrity": "sha512-a0w0WecTW7bD2YHWrpTz1uyiWA2fDNym0kjmPeNSwZ2XCP+JbirZt31l43m2ey6qXItTYVuQBthm75sPVeHnGA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1083,7 +1069,6 @@
       "resolved": "https://registry.npmjs.org/@serialport/parser-packet-length/-/parser-packet-length-13.0.0.tgz",
       "integrity": "sha512-60ZDDIqYRi0Xs2SPZUo4Jr5LLIjtb+rvzPKMJCohrO6tAqSDponcNpcB1O4W21mKTxYjqInSz+eMrtk0LLfZIg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8.6.0"
       }
@@ -1093,7 +1078,6 @@
       "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-13.0.0.tgz",
       "integrity": "sha512-dov3zYoyf0dt1Sudd1q42VVYQ4WlliF0MYvAMA3MOyiU1IeG4hl0J6buBA2w4gl3DOCC05tGgLDN/3yIL81gsA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@serialport/parser-delimiter": "13.0.0"
       },
@@ -1109,7 +1093,6 @@
       "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-13.0.0.tgz",
       "integrity": "sha512-JNUQA+y2Rfs4bU+cGYNqOPnNMAcayhhW+XJZihSLQXOHcZsFnOa2F9YtMg9VXRWIcnHldHYtisp62Etjlw24bw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1122,7 +1105,6 @@
       "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-13.0.0.tgz",
       "integrity": "sha512-m7HpIf56G5XcuDdA3DB34Z0pJiwxNRakThEHjSa4mG05OnWYv0IG8l2oUyYfuGMowQWaVnQ+8r+brlPxGVH+eA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1135,7 +1117,6 @@
       "resolved": "https://registry.npmjs.org/@serialport/parser-slip-encoder/-/parser-slip-encoder-13.0.0.tgz",
       "integrity": "sha512-fUHZEExm6izJ7rg0A1yjXwu4sOzeBkPAjDZPfb+XQoqgtKAk+s+HfICiYn7N2QU9gyaeCO8VKgWwi+b/DowYOg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1148,7 +1129,6 @@
       "resolved": "https://registry.npmjs.org/@serialport/parser-spacepacket/-/parser-spacepacket-13.0.0.tgz",
       "integrity": "sha512-DoXJ3mFYmyD8X/8931agJvrBPxqTaYDsPoly9/cwQSeh/q4EjQND9ySXBxpWz5WcpyCU4jOuusqCSAPsbB30Eg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1161,7 +1141,6 @@
       "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-13.0.0.tgz",
       "integrity": "sha512-F7xLJKsjGo2WuEWMSEO1SimRcOA+WtWICsY13r0ahx8s2SecPQH06338g28OT7cW7uRXI7oEQAk62qh5gHJW3g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@serialport/bindings-interface": "1.2.2",
         "debug": "4.4.0"
@@ -1171,6 +1150,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "dev": true,
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
       }
     },
     "node_modules/@tsconfig/node20": {
@@ -1618,14 +1607,13 @@
       }
     },
     "node_modules/@zwave-js/cc": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-15.14.0.tgz",
-      "integrity": "sha512-P2UV2Bc0CtrN8x8ryg4usAfeG3iGfKbCiNNmENZKuBri6yX9qp/GAwkgHcLe25oBAwOoOguKFDvgixtoZjEaKw==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-15.15.0.tgz",
+      "integrity": "sha512-vvJGiQRYoGwr2SopCulu8TsImjLihDyJQTMhJjbjLZNw5lVbQxK8Tdn1MHCc4ZQbUPxgnTQsSG5CCFFMPvlrEw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "15.13.0",
-        "@zwave-js/host": "15.14.0",
+        "@zwave-js/core": "15.15.0",
+        "@zwave-js/host": "15.15.0",
         "@zwave-js/shared": "15.13.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
@@ -1639,13 +1627,12 @@
       }
     },
     "node_modules/@zwave-js/config": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-15.14.0.tgz",
-      "integrity": "sha512-0cC0bbBI59ow2jKrICpsOPAGoC5WVn57pgmTS8f/LqTSZZtaoXU3GrYA3m4WvkGQWknwYNgCzDEuWFqW4aJDZQ==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-15.15.0.tgz",
+      "integrity": "sha512-uRUxu05W+4jX+uJkV3oOm/1wNObDl/BA84jpMsM2uvwLu7LRYCTnOkPwCXis+RxX3x9uRHdvQSqv/hCL2k2D0A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "15.13.0",
+        "@zwave-js/core": "15.15.0",
         "@zwave-js/shared": "15.13.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
@@ -1664,11 +1651,10 @@
       }
     },
     "node_modules/@zwave-js/core": {
-      "version": "15.13.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-15.13.0.tgz",
-      "integrity": "sha512-YJkIY9LgdXtKrUcnK04mQid8ZbOxR35iC2QxAI7w6rY/HHcAZniXYLSUVt/ZCoDD1JqPZq8Vkqv5kIA+C66SpA==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-15.15.0.tgz",
+      "integrity": "sha512-m8bhTZ9Rv5ptUvFAM176frcPXhx9+/3jaHz7XRuz16ID8pbYzD2bTKR3nANcZyByQJHSIhGLGU3pd+LPjEsQFA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@alcalzone/jsonl-db": "^3.1.1",
         "@zwave-js/shared": "15.13.0",
@@ -1694,14 +1680,13 @@
       }
     },
     "node_modules/@zwave-js/host": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-15.14.0.tgz",
-      "integrity": "sha512-gS3KwKCjxs3Ku+wIjbwisik9RjP63qOWEv7S5smiahtIhjKfMT0N+H/rF80o9ICSudkxo3jRyHQTKYgZ+UT0Dw==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-15.15.0.tgz",
+      "integrity": "sha512-toACabQg4FPrP0MC5eLfLlf8e//cv5GoV44I2cOMAk95Gkj1UzH218I/mwPGIOQb+YxxtcsKQtKymAmZznqTLA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@zwave-js/config": "15.14.0",
-        "@zwave-js/core": "15.13.0",
+        "@zwave-js/config": "15.15.0",
+        "@zwave-js/core": "15.15.0",
         "@zwave-js/shared": "15.13.0",
         "alcalzone-shared": "^5.0.0"
       },
@@ -1713,13 +1698,12 @@
       }
     },
     "node_modules/@zwave-js/nvmedit": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-15.14.0.tgz",
-      "integrity": "sha512-KfN0kIH39804ObD17uE68L0lJsXUAkf9STur+74VT+5IQEDwGqc5sVxT7rdEtE8SD/UvapIZIN0jJJ9/+iyfIQ==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-15.15.0.tgz",
+      "integrity": "sha512-Bq2Dv+A/G1jySQjXc0Y1gvvN1iUea4lA5nWj66GRDXlQR4+Vp5JZHfH4w+NLdL+c3WBs2WVXiLVSBXVwPQTTRA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "15.13.0",
+        "@zwave-js/core": "15.15.0",
         "@zwave-js/shared": "15.13.0",
         "alcalzone-shared": "^5.0.0",
         "reflect-metadata": "^0.2.2",
@@ -1741,7 +1725,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -1754,7 +1737,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -1767,7 +1749,6 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
       "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "string-width": "^7.2.0",
         "strip-ansi": "^7.1.0",
@@ -1781,15 +1762,13 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
       "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@zwave-js/nvmedit/node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^10.3.0",
         "get-east-asian-width": "^1.0.0",
@@ -1807,7 +1786,6 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -1823,7 +1801,6 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "string-width": "^7.0.0",
@@ -1841,7 +1818,6 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
       "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cliui": "^9.0.1",
         "escalade": "^3.1.1",
@@ -1859,22 +1835,20 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
       "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/@zwave-js/serial": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-15.14.0.tgz",
-      "integrity": "sha512-3bUtiVLE38feyZa8zch2T8R9Dh5SBBe8hFXAYdcJKTQsFZ59TDYGPQxinHaNMpKa2dXdztF8PJC/FKE8SqlhcA==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-15.15.0.tgz",
+      "integrity": "sha512-s9a6SGaGYolzDS1PQkGUd6VSe7Xxb2m0dZzM/sSr7xTH5uwtnD+9H9NBIg0VxOLTpjoxhf5lJIekS/38/ItUPQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@serialport/stream": "^13.0.0",
-        "@zwave-js/cc": "15.14.0",
-        "@zwave-js/core": "15.13.0",
-        "@zwave-js/host": "15.14.0",
+        "@zwave-js/cc": "15.15.0",
+        "@zwave-js/core": "15.15.0",
+        "@zwave-js/host": "15.15.0",
         "@zwave-js/shared": "15.13.0",
         "alcalzone-shared": "^5.0.0",
         "serialport": "^13.0.0",
@@ -1892,7 +1866,6 @@
       "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-15.13.0.tgz",
       "integrity": "sha512-9GYxVomlaaTfBV/bfpfDu0WcN1T5VFMWhqK7/iVfekheJWQ2uePRyOCdp7wJ7zLwjwFtXGOHrOyt4nXUT0AWmQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "alcalzone-shared": "^5.0.0",
         "pathe": "^2.0.3"
@@ -1905,15 +1878,14 @@
       }
     },
     "node_modules/@zwave-js/testing": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-15.14.0.tgz",
-      "integrity": "sha512-0iXbWA9G9/4lelSO9CdUWUBN/KhWAZVcqrIRii7R85REa//ZYDergnXsZcFvIIQ10Asbn5vhsEMMUjKn89Yihg==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-15.15.0.tgz",
+      "integrity": "sha512-7I5ZxiZUhe77xg0Bct00xcqTmdlmDcpzs3SPVYg83SGusGA3jHvwQ2opLWdPOK4xULlJooEB+0ebskyD03OItg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@zwave-js/core": "15.13.0",
-        "@zwave-js/host": "15.14.0",
-        "@zwave-js/serial": "15.14.0",
+        "@zwave-js/core": "15.15.0",
+        "@zwave-js/host": "15.15.0",
+        "@zwave-js/serial": "15.15.0",
         "@zwave-js/shared": "15.13.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3"
@@ -1988,7 +1960,6 @@
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
       "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2042,8 +2013,7 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2206,14 +2176,16 @@
       }
     },
     "node_modules/color": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.2.tgz",
+      "integrity": "sha512-e2hz5BzbUPcYlIRHo8ieAhYgoajrJr+hWoceg6E345TPsATMUKqDgzt8fSXZJJbxfpiPzkWyphz8yn8At7q3fA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
+        "color-convert": "^3.0.1",
+        "color-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/color-convert": {
@@ -2235,49 +2207,52 @@
       "dev": true
     },
     "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.2.tgz",
+      "integrity": "sha512-RxmjYxbWemV9gKu4zPgiZagUxbH3RQpEIO77XoSSX0ivgABDZ+h8Zuash/EMFLTI4N9QgFPOJ6JQpPZKFxa+dA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.2.tgz",
+      "integrity": "sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/color/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.2.tgz",
+      "integrity": "sha512-UNqkvCDXstVck3kdowtOTWROIJQwafjOfXSmddoDrXo4cewMKmusCeF22Q24zvjR8nwWib/3S/dfyzPItPEiJg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "color-name": "1.1.3"
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
       }
     },
     "node_modules/color/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.2.tgz",
+      "integrity": "sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==",
       "dev": true,
-      "license": "MIT"
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
-    },
-    "node_modules/colorspace": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color": "^3.1.3",
-        "text-hex": "1.0.x"
-      }
     },
     "node_modules/commander": {
       "version": "12.1.0",
@@ -2334,8 +2309,7 @@
       "version": "1.11.18",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
       "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -2391,8 +2365,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -2741,15 +2714,13 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -2768,7 +2739,6 @@
       "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz",
       "integrity": "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "moment": "^2.29.1"
       }
@@ -2839,8 +2809,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -3035,8 +3004,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -3089,7 +3057,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -3131,8 +3098,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/json-logic-js/-/json-logic-js-2.0.5.tgz",
       "integrity": "sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -3157,7 +3123,6 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -3191,8 +3156,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/ky": {
       "version": "1.8.2",
@@ -3691,7 +3655,6 @@
       "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
       "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@colors/colors": "1.6.0",
         "@types/triple-beam": "^1.3.2",
@@ -3779,7 +3742,6 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -3801,7 +3763,6 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.0.tgz",
       "integrity": "sha512-8VOpLHFrOQlAH+qA0ZzuGRlALRA6/LVh8QJldbrC4DY0hXoMP0l4Acq8TzFC018HztWiRqyCEj2aTWY2UvnJUg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
       }
@@ -3811,7 +3772,6 @@
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -3823,7 +3783,6 @@
       "resolved": "https://registry.npmjs.org/nrf-intel-hex/-/nrf-intel-hex-1.4.0.tgz",
       "integrity": "sha512-q3+GGRIpe0VvCjUP1zaqW5rk6IpCZzhD0lu7Sguo1bgWwFcA9kZRjsaKUb0jBQMnefyOl5o0BBGAxvqMqYx8Sg==",
       "dev": true,
-      "license": "BSD",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -3833,7 +3792,6 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
@@ -3843,7 +3801,6 @@
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
       "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fn.name": "1.x.x"
       }
@@ -3995,8 +3952,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -4102,7 +4058,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -4116,8 +4071,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "dev": true,
-      "license": "Apache-2.0"
+      "dev": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -4196,7 +4150,6 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -4260,15 +4213,13 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -4308,7 +4259,6 @@
       "resolved": "https://registry.npmjs.org/serialport/-/serialport-13.0.0.tgz",
       "integrity": "sha512-PHpnTd8isMGPfFTZNCzOZp9m4mAJSNWle9Jxu6BPTcWq7YXl5qN7tp8Sgn0h+WIGcD6JFz5QDgixC2s4VW7vzg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@serialport/binding-mock": "10.2.2",
         "@serialport/bindings-cpp": "13.0.0",
@@ -4357,25 +4307,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
-      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
-      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -4448,7 +4380,6 @@
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -4458,7 +4389,6 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -4527,8 +4457,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/tiny-glob": {
       "version": "0.2.9",
@@ -4558,7 +4487,6 @@
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
       "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
@@ -5080,8 +5008,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -5105,14 +5032,13 @@
       "dev": true
     },
     "node_modules/winston": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
-      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.18.3.tgz",
+      "integrity": "sha512-NoBZauFNNWENgsnC9YpgyYwOVrl2m58PpQ8lNHjV3kosGs7KJ7Npk9pCUE+WJlawVSe8mykWDKWFSVfs3QO9ww==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",
-        "@dabh/diagnostics": "^2.0.2",
+        "@dabh/diagnostics": "^2.0.8",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
         "logform": "^2.7.0",
@@ -5132,7 +5058,6 @@
       "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-5.0.0.tgz",
       "integrity": "sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "file-stream-rotator": "^0.6.1",
         "object-hash": "^3.0.0",
@@ -5151,7 +5076,6 @@
       "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
       "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "logform": "^2.7.0",
         "readable-stream": "^3.6.2",
@@ -5261,23 +5185,22 @@
       }
     },
     "node_modules/zwave-js": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-15.14.0.tgz",
-      "integrity": "sha512-EuS181i/AsRWRZTvPF0GcNhgb5WaTp9EsKDzAnf0dexTukSzrYWkO5FokAG5bn8bj5OvBtDedDEwEu3uM+L2Ww==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-15.15.0.tgz",
+      "integrity": "sha512-0GeFIOyGl2GhjN1xJJymTJqVpddk9nYGtTCQgc0kO+Zx3UlI4EWf2STREgFhLBolYI6tD3Kh3sFN89Gahux6gg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@alcalzone/jsonl-db": "^3.1.1",
         "@andrewbranch/untar.js": "^1.0.3",
         "@homebridge/ciao": "^1.3.4",
-        "@zwave-js/cc": "15.14.0",
-        "@zwave-js/config": "15.14.0",
-        "@zwave-js/core": "15.13.0",
-        "@zwave-js/host": "15.14.0",
-        "@zwave-js/nvmedit": "15.14.0",
-        "@zwave-js/serial": "15.14.0",
+        "@zwave-js/cc": "15.15.0",
+        "@zwave-js/config": "15.15.0",
+        "@zwave-js/core": "15.15.0",
+        "@zwave-js/host": "15.15.0",
+        "@zwave-js/nvmedit": "15.15.0",
+        "@zwave-js/serial": "15.15.0",
         "@zwave-js/shared": "15.13.0",
-        "@zwave-js/testing": "15.14.0",
+        "@zwave-js/testing": "15.15.0",
         "@zwave-js/waddle": "^1.2.1",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
@@ -5445,12 +5368,12 @@
       "dev": true
     },
     "@dabh/diagnostics": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
       "dev": true,
       "requires": {
-        "colorspace": "1.1.x",
+        "@so-ric/colorspace": "^1.1.6",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
       }
@@ -5938,6 +5861,16 @@
         "debug": "4.4.0"
       }
     },
+    "@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "dev": true,
+      "requires": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
     "@tsconfig/node20": {
       "version": "20.1.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.4.tgz",
@@ -6225,13 +6158,13 @@
       }
     },
     "@zwave-js/cc": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-15.14.0.tgz",
-      "integrity": "sha512-P2UV2Bc0CtrN8x8ryg4usAfeG3iGfKbCiNNmENZKuBri6yX9qp/GAwkgHcLe25oBAwOoOguKFDvgixtoZjEaKw==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/cc/-/cc-15.15.0.tgz",
+      "integrity": "sha512-vvJGiQRYoGwr2SopCulu8TsImjLihDyJQTMhJjbjLZNw5lVbQxK8Tdn1MHCc4ZQbUPxgnTQsSG5CCFFMPvlrEw==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "15.13.0",
-        "@zwave-js/host": "15.14.0",
+        "@zwave-js/core": "15.15.0",
+        "@zwave-js/host": "15.15.0",
         "@zwave-js/shared": "15.13.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
@@ -6239,12 +6172,12 @@
       }
     },
     "@zwave-js/config": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-15.14.0.tgz",
-      "integrity": "sha512-0cC0bbBI59ow2jKrICpsOPAGoC5WVn57pgmTS8f/LqTSZZtaoXU3GrYA3m4WvkGQWknwYNgCzDEuWFqW4aJDZQ==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-15.15.0.tgz",
+      "integrity": "sha512-uRUxu05W+4jX+uJkV3oOm/1wNObDl/BA84jpMsM2uvwLu7LRYCTnOkPwCXis+RxX3x9uRHdvQSqv/hCL2k2D0A==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "15.13.0",
+        "@zwave-js/core": "15.15.0",
         "@zwave-js/shared": "15.13.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",
@@ -6257,9 +6190,9 @@
       }
     },
     "@zwave-js/core": {
-      "version": "15.13.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-15.13.0.tgz",
-      "integrity": "sha512-YJkIY9LgdXtKrUcnK04mQid8ZbOxR35iC2QxAI7w6rY/HHcAZniXYLSUVt/ZCoDD1JqPZq8Vkqv5kIA+C66SpA==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-15.15.0.tgz",
+      "integrity": "sha512-m8bhTZ9Rv5ptUvFAM176frcPXhx9+/3jaHz7XRuz16ID8pbYzD2bTKR3nANcZyByQJHSIhGLGU3pd+LPjEsQFA==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^3.1.1",
@@ -6280,24 +6213,24 @@
       }
     },
     "@zwave-js/host": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-15.14.0.tgz",
-      "integrity": "sha512-gS3KwKCjxs3Ku+wIjbwisik9RjP63qOWEv7S5smiahtIhjKfMT0N+H/rF80o9ICSudkxo3jRyHQTKYgZ+UT0Dw==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/host/-/host-15.15.0.tgz",
+      "integrity": "sha512-toACabQg4FPrP0MC5eLfLlf8e//cv5GoV44I2cOMAk95Gkj1UzH218I/mwPGIOQb+YxxtcsKQtKymAmZznqTLA==",
       "dev": true,
       "requires": {
-        "@zwave-js/config": "15.14.0",
-        "@zwave-js/core": "15.13.0",
+        "@zwave-js/config": "15.15.0",
+        "@zwave-js/core": "15.15.0",
         "@zwave-js/shared": "15.13.0",
         "alcalzone-shared": "^5.0.0"
       }
     },
     "@zwave-js/nvmedit": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-15.14.0.tgz",
-      "integrity": "sha512-KfN0kIH39804ObD17uE68L0lJsXUAkf9STur+74VT+5IQEDwGqc5sVxT7rdEtE8SD/UvapIZIN0jJJ9/+iyfIQ==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/nvmedit/-/nvmedit-15.15.0.tgz",
+      "integrity": "sha512-Bq2Dv+A/G1jySQjXc0Y1gvvN1iUea4lA5nWj66GRDXlQR4+Vp5JZHfH4w+NLdL+c3WBs2WVXiLVSBXVwPQTTRA==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "15.13.0",
+        "@zwave-js/core": "15.15.0",
         "@zwave-js/shared": "15.13.0",
         "alcalzone-shared": "^5.0.0",
         "reflect-metadata": "^0.2.2",
@@ -6388,15 +6321,15 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-15.14.0.tgz",
-      "integrity": "sha512-3bUtiVLE38feyZa8zch2T8R9Dh5SBBe8hFXAYdcJKTQsFZ59TDYGPQxinHaNMpKa2dXdztF8PJC/FKE8SqlhcA==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-15.15.0.tgz",
+      "integrity": "sha512-s9a6SGaGYolzDS1PQkGUd6VSe7Xxb2m0dZzM/sSr7xTH5uwtnD+9H9NBIg0VxOLTpjoxhf5lJIekS/38/ItUPQ==",
       "dev": true,
       "requires": {
         "@serialport/stream": "^13.0.0",
-        "@zwave-js/cc": "15.14.0",
-        "@zwave-js/core": "15.13.0",
-        "@zwave-js/host": "15.14.0",
+        "@zwave-js/cc": "15.15.0",
+        "@zwave-js/core": "15.15.0",
+        "@zwave-js/host": "15.15.0",
         "@zwave-js/shared": "15.13.0",
         "alcalzone-shared": "^5.0.0",
         "serialport": "^13.0.0",
@@ -6414,14 +6347,14 @@
       }
     },
     "@zwave-js/testing": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-15.14.0.tgz",
-      "integrity": "sha512-0iXbWA9G9/4lelSO9CdUWUBN/KhWAZVcqrIRii7R85REa//ZYDergnXsZcFvIIQ10Asbn5vhsEMMUjKn89Yihg==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/testing/-/testing-15.15.0.tgz",
+      "integrity": "sha512-7I5ZxiZUhe77xg0Bct00xcqTmdlmDcpzs3SPVYg83SGusGA3jHvwQ2opLWdPOK4xULlJooEB+0ebskyD03OItg==",
       "dev": true,
       "requires": {
-        "@zwave-js/core": "15.13.0",
-        "@zwave-js/host": "15.14.0",
-        "@zwave-js/serial": "15.14.0",
+        "@zwave-js/core": "15.15.0",
+        "@zwave-js/host": "15.15.0",
+        "@zwave-js/serial": "15.15.0",
         "@zwave-js/shared": "15.13.0",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3"
@@ -6626,28 +6559,28 @@
       }
     },
     "color": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.2.tgz",
+      "integrity": "sha512-e2hz5BzbUPcYlIRHo8ieAhYgoajrJr+hWoceg6E345TPsATMUKqDgzt8fSXZJJbxfpiPzkWyphz8yn8At7q3fA==",
       "dev": true,
       "requires": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
+        "color-convert": "^3.0.1",
+        "color-string": "^2.0.0"
       },
       "dependencies": {
         "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.2.tgz",
+          "integrity": "sha512-UNqkvCDXstVck3kdowtOTWROIJQwafjOfXSmddoDrXo4cewMKmusCeF22Q24zvjR8nwWib/3S/dfyzPItPEiJg==",
           "dev": true,
           "requires": {
-            "color-name": "1.1.3"
+            "color-name": "^2.0.0"
           }
         },
         "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.2.tgz",
+          "integrity": "sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==",
           "dev": true
         }
       }
@@ -6668,13 +6601,20 @@
       "dev": true
     },
     "color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.2.tgz",
+      "integrity": "sha512-RxmjYxbWemV9gKu4zPgiZagUxbH3RQpEIO77XoSSX0ivgABDZ+h8Zuash/EMFLTI4N9QgFPOJ6JQpPZKFxa+dA==",
       "dev": true,
       "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
+        "color-name": "^2.0.0"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.2.tgz",
+          "integrity": "sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==",
+          "dev": true
+        }
       }
     },
     "colorette": {
@@ -6682,16 +6622,6 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
-    },
-    "colorspace": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-      "dev": true,
-      "requires": {
-        "color": "^3.1.3",
-        "text-hex": "1.0.x"
-      }
     },
     "commander": {
       "version": "12.1.0",
@@ -8098,23 +8028,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
-    "simple-swizzle": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
-      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "^0.3.1"
-      },
-      "dependencies": {
-        "is-arrayish": {
-          "version": "0.3.4",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
-          "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
-          "dev": true
-        }
-      }
-    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -8531,13 +8444,13 @@
       "dev": true
     },
     "winston": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
-      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.18.3.tgz",
+      "integrity": "sha512-NoBZauFNNWENgsnC9YpgyYwOVrl2m58PpQ8lNHjV3kosGs7KJ7Npk9pCUE+WJlawVSe8mykWDKWFSVfs3QO9ww==",
       "dev": true,
       "requires": {
         "@colors/colors": "^1.6.0",
-        "@dabh/diagnostics": "^2.0.2",
+        "@dabh/diagnostics": "^2.0.8",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
         "logform": "^2.7.0",
@@ -8629,22 +8542,22 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-15.14.0.tgz",
-      "integrity": "sha512-EuS181i/AsRWRZTvPF0GcNhgb5WaTp9EsKDzAnf0dexTukSzrYWkO5FokAG5bn8bj5OvBtDedDEwEu3uM+L2Ww==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-15.15.0.tgz",
+      "integrity": "sha512-0GeFIOyGl2GhjN1xJJymTJqVpddk9nYGtTCQgc0kO+Zx3UlI4EWf2STREgFhLBolYI6tD3Kh3sFN89Gahux6gg==",
       "dev": true,
       "requires": {
         "@alcalzone/jsonl-db": "^3.1.1",
         "@andrewbranch/untar.js": "^1.0.3",
         "@homebridge/ciao": "^1.3.4",
-        "@zwave-js/cc": "15.14.0",
-        "@zwave-js/config": "15.14.0",
-        "@zwave-js/core": "15.13.0",
-        "@zwave-js/host": "15.14.0",
-        "@zwave-js/nvmedit": "15.14.0",
-        "@zwave-js/serial": "15.14.0",
+        "@zwave-js/cc": "15.15.0",
+        "@zwave-js/config": "15.15.0",
+        "@zwave-js/core": "15.15.0",
+        "@zwave-js/host": "15.15.0",
+        "@zwave-js/nvmedit": "15.15.0",
+        "@zwave-js/serial": "15.15.0",
         "@zwave-js/shared": "15.13.0",
-        "@zwave-js/testing": "15.14.0",
+        "@zwave-js/testing": "15.15.0",
         "@zwave-js/waddle": "^1.2.1",
         "alcalzone-shared": "^5.0.0",
         "ansi-colors": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "semver": "^7.5.4",
     "tsx": "^4.19.2",
     "typescript": "^5.3.3",
-    "zwave-js": "^15.14.0"
+    "zwave-js": "^15.15.0"
   },
   "engines": {
     "node": ">= 20"

--- a/src/bin/server.ts
+++ b/src/bin/server.ts
@@ -211,6 +211,20 @@ const logger: Logger = {
   const getRetryDelay = () => Math.min(Math.pow(2, retryCount) * 1000, 60000);
 
   const startDriverWithRetry = async (): Promise<void> => {
+    // We only want to show the logo the very first connection attempt.
+    if (
+      retryCount > 0 &&
+      (!params!.options.logConfig || params.options.logConfig.showLogo)
+    ) {
+      if (!params.options.logConfig) {
+        params.options.logConfig = {
+          showLogo: false,
+        };
+      } else {
+        params.options.logConfig.showLogo = false;
+      }
+    }
+
     if (retryTimer) {
       clearTimeout(retryTimer);
       retryTimer = undefined;


### PR DESCRIPTION
When the driver reconnects after a failure, suppress the zwave-js logo by setting logConfig.showLogo to false for retry attempts. This prevents repeated logo displays in the logs.

Updates zwave-js dependency to ^15.15.0 to get this new feature.

<img width="1524" height="906" alt="CleanShot 2025-10-03 at 10 06 18@2x" src="https://github.com/user-attachments/assets/30bacda3-4b83-4185-9f1b-0f3e64845976" />
