### PR TITLE
fix: add Map serialization to JSON responses (Schema 45)

### DIFF
--- a/API_SCHEMA.md
+++ b/API_SCHEMA.md
@@ -105,3 +105,7 @@ Base schema.
 # Schema 44
 
 - Added another overload to the `driver.firmware_update_otw` command
+
+# Schema 45
+
+- Fixed JSON serialization of `Map` objects in responses (affects `controller.get_known_lifeline_routes` and other Map-returning commands)

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -6,7 +6,7 @@ export const version = require("../../package.json").version;
 export const minSchemaVersion = 0;
 
 // maximal/current schema version the server supports
-export const maxSchemaVersion = 44;
+export const maxSchemaVersion = 45;
 
 export const applicationName = "zwave-js-server";
 export const dnssdServiceType = applicationName;

--- a/src/util/stringify.ts
+++ b/src/util/stringify.ts
@@ -6,5 +6,9 @@ export function stringifyReplacer(key: string, value: any): any {
   if (isUint8Array(value)) {
     return Buffer.from(value).toJSON();
   }
+  // Convert Map to object for JSON serialization
+  if (value instanceof Map) {
+    return Object.fromEntries(value);
+  }
   return value;
 }


### PR DESCRIPTION
## Summary

Fixes JSON serialization of `Map` objects in API responses and bumps schema version to 45. This was probably not discovered because the commands that are impacted aren't used in Home Assistant. They may be modeled in the python library but we were using mock data and don't do end to end testing. That would be nice to be able to do but would require setting up a comprehensive mock server instance.

### Map Serialization Fix

Previously, `Map` objects were serialized as empty objects `{}` in JSON responses. This fix converts Maps to plain objects using `Object.fromEntries()` before serialization.

### Affected Commands/Properties

The following commands and state properties return `Map` objects and are affected by this fix:

| Command/Property | Returns |
|-----------------|---------|
| `controller.get_known_lifeline_routes` | `routes: Map<number, LifelineRoutes>` |
| `zniffer.supported_frequencies` | `frequencies: Map<number, string>` |
| `controller.rebuildRoutesProgress` (state) | `Map<number, RebuildRoutesStatus>` |

### Schema Version Bump

Bumps `maxSchemaVersion` from 44 to 45 in `src/lib/const.ts`.

## Checklist

- [x] Bug fix
- [x] Schema version bumped
- [x] API_SCHEMA.md updated