### PR TITLE
docs: fix README documentation for existing API features

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,63 @@ interface {
 }
 ```
 
+#### [Firmware Update OTW (Over The Wire)](https://zwave-js.github.io/node-zwave-js/#/api/driver?id=firmwareupdateotw)
+
+[compatible with schema version: 41+]
+
+This command performs a controller firmware update using firmware obtained over the wire (e.g., downloaded from the internet). The firmware update can be provided in two ways:
+
+**Option 1**: Provide the raw firmware file (schema 41+):
+
+```ts
+interface {
+  messageId: string;
+  command: "driver.firmware_update_otw";
+  filename: string;
+  file: string; // use base64 encoding for the file
+  fileFormat?: FirmwareFileFormat;
+}
+```
+
+**Option 2**: Provide the update info from Z-Wave JS update service (schema 44+):
+
+```ts
+interface {
+  messageId: string;
+  command: "driver.firmware_update_otw";
+  updateInfo: FirmwareUpdateInfo;
+}
+```
+
+If `fileFormat` is not provided in Option 1, the format will be guessed based on the filename and file payload.
+
+Returns:
+
+```ts
+interface {
+  result: OTWFirmwareUpdateResult;
+}
+```
+
+#### [Is OTW Firmware Update In Progress](https://zwave-js.github.io/node-zwave-js/#/api/driver?id=isotwfirmwareupdateinprogress)
+
+[compatible with schema version: 41+]
+
+```ts
+interface {
+  messageId: string;
+  command: "driver.is_otw_firmware_update_in_progress";
+}
+```
+
+Returns:
+
+```ts
+interface {
+  progress: boolean;
+}
+```
+
 ### Controller level commands
 
 `zwave-js-server` supports all of the controller methods listed in the [Z-Wave JS documentation](https://zwave-js.github.io/node-zwave-js/#/api/controller?id=controller-methods). `zwave-js-server` uses [snake casing](https://en.wikipedia.org/wiki/Snake_case) for commands and prefixes every controller command with `controller.`, so `beginInclusion` is called using the `controller.begin_inclusion` command.
@@ -545,9 +602,11 @@ interface {
 }
 ```
 
-#### [Update Firmware](https://zwave-js.github.io/node-zwave-js/#/api/node?id=updatefirmware)
+#### [Begin Firmware Update](https://zwave-js.github.io/node-zwave-js/#/api/node?id=updatefirmware)
 
-[compatible with schema version: 24+]
+[compatible with schema version: 0-23]
+
+> **Note**: For schema versions 24 and higher, use `node.update_firmware` instead.
 
 If `firmwareFileFormat` is not provided, the format will be guessed based on the filename and file payload.
 
@@ -556,10 +615,31 @@ interface {
   messageId: string;
   command: "node.begin_firmware_update";
   nodeId: number;
+  firmwareFilename: string;
+  firmwareFile: string; // use base64 encoding for the file
+  firmwareFileFormat?: FirmwareFileFormat;
+  target?: number;
+}
+```
+
+#### [Update Firmware](https://zwave-js.github.io/node-zwave-js/#/api/node?id=updatefirmware)
+
+[compatible with schema version: 24+]
+
+This command supports updating multiple firmware files in a single operation.
+
+If `fileFormat` is not provided, the format will be guessed based on the filename and file payload.
+
+```ts
+interface {
+  messageId: string;
+  command: "node.update_firmware";
+  nodeId: number;
   updates: {
     filename: string;
     file: string; // use base64 encoding for the file
-    fileFormat?: FileFormat;
+    fileFormat?: FirmwareFileFormat;
+    firmwareTarget?: number;
   }[];
 }
 ```
@@ -795,11 +875,33 @@ interface {
 
 [compatible with schema version: 21+]
 
+> **Note**: The command `node.get_firmware_update_progress` is an alias for this command and can be used interchangeably.
+
 ```ts
 interface {
   messageId: string;
   nodeId: number;
   command: "node.is_firmware_update_in_progress";
+}
+```
+
+Returns:
+
+```ts
+interface {
+  progress: boolean;
+}
+```
+
+#### [Get Firmware Update Progress](https://zwave-js.github.io/node-zwave-js/#/api/node?id=getfirmwareupdateprogress)
+
+[compatible with schema version: 21+]
+
+```ts
+interface {
+  messageId: string;
+  command: "node.get_firmware_update_progress";
+  nodeId: number;
 }
 ```
 


### PR DESCRIPTION
## Summary

Fixes and improves README documentation to accurately reflect existing API behavior.

### Typo and Grammar Fixes
- Fix typo: "specificed" → "specified"
- Fix doc: "Gets the current frequency" (was "Gets list of...")

### API Documentation Corrections
- Add `minSchemaVersion` and `maxSchemaVersion` to version message interface
- Change `homeId` type to `number | undefined` to reflect actual API
- Add `driver` property to `start_listening` state structure (as `DriverState`)
- Add `"zniffer"` to event source union type (schema 38+)
- Fix event names: `nvm convert progress` and `nvm restore progress`
- Fix multicast command: `supports_cc_api` (was incorrectly `get_cc_version`)

### Error Codes Table
- Add all missing error codes from `ErrorCode` enum: `endpoint_not_found`, `virtual_endpoint_not_found`, `inclusion_phase_not_in_progress`, `inclusion_already_in_progress`, `invalid_params_passed_to_command`, `no_longer_supported`
- Fix `zwave_error` JSON example formatting (add code block)

### Firmware Update Documentation
- Add `driver.firmware_update_otw` docs (schema 41+) with Option 1/Option 2
- Add `driver.is_otw_firmware_update_in_progress` docs (schema 41+)
- Split node firmware update into `node.begin_firmware_update` (schema 0-23) and `node.update_firmware` (schema 24+)
- Add return type and alias note to `node.is_firmware_update_in_progress`
- Add `node.get_firmware_update_progress` alias documentation (schema 21+)

### Duplicate Removal
- Remove duplicate `driver.shutdown` and `driver.update_options` entries (keeping schema 36+ versions with correct links)
- Remove incomplete `node.set_raw_config_parameter_value` entry (keeping complete schema 33+ version)

## Checklist

- [x] Updated documentation
- [x] No breaking changes