### PR TITLE
feat: route User Code CC setValue calls through access control API, bump schema to 51

### DIFF
--- a/API_SCHEMA.md
+++ b/API_SCHEMA.md
@@ -407,4 +407,4 @@ Base schema.
 
 ## Schema 51
 
-- `node.set_value` calls for the User Code CC values `userCode`, `userIdStatus`, and `adminCode`/`masterCode` are now routed through the unified access control API because zwave-js removed `setValue` support for these values. Setting `userIdStatus` to `PassageMode` cannot be expressed through that API and is no longer supported. This applies to all schema versions to avoid breaking legacy clients. New clients should use the `endpoint.access_control` commands instead.
+- `node.set_value` calls for the User Code CC values `userCode`, `userIdStatus`, and `adminCode`/`masterCode` are now routed through the unified access control API because zwave-js removed `setValue` support for these values. Setting `userIdStatus` to `PassageMode` cannot be expressed through that API and continues to use the legacy `setValue` path. This applies to all schema versions to avoid breaking legacy clients. New clients should use the `endpoint.access_control` commands instead.

--- a/API_SCHEMA.md
+++ b/API_SCHEMA.md
@@ -407,4 +407,4 @@ Base schema.
 
 ## Schema 51
 
-- `node.set_value` calls that set the `userCode` property, or set `userIdStatus` to `Available`, are now routed through the unified access control API because zwave-js removed `setValue` support for these values. This applies to all schema versions to avoid breaking legacy clients. New clients should use the `endpoint.access_control` commands instead.
+- `node.set_value` calls for the User Code CC values `userCode`, `userIdStatus`, and `adminCode`/`masterCode` are now routed through the unified access control API because zwave-js removed `setValue` support for these values. Setting `userIdStatus` to `PassageMode` cannot be expressed through that API and is no longer supported. This applies to all schema versions to avoid breaking legacy clients. New clients should use the `endpoint.access_control` commands instead.

--- a/API_SCHEMA.md
+++ b/API_SCHEMA.md
@@ -404,3 +404,7 @@ Base schema.
 ## Schema 50
 
 - Added the `interview progress` node event
+
+## Schema 51
+
+- `node.set_value` calls that set the `userCode` property, or set `userIdStatus` to `Available`, are now routed through the unified access control API because zwave-js removed `setValue` support for these values. This applies to all schema versions to avoid breaking legacy clients. New clients should use the `endpoint.access_control` commands instead.

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -6,7 +6,7 @@ export const version = require("../../package.json").version;
 export const minSchemaVersion = 0;
 
 // maximal/current schema version the server supports
-export const maxSchemaVersion = 50;
+export const maxSchemaVersion = 51;
 
 export const applicationName = "zwave-js-server";
 export const dnssdServiceType = applicationName;

--- a/src/lib/node/message_handler.ts
+++ b/src/lib/node/message_handler.ts
@@ -2,7 +2,12 @@ import {
   Driver,
   LifelineHealthCheckResult,
   RouteHealthCheckResult,
+  SetCredentialResult,
+  SetValueResult,
+  SetValueStatus,
+  ZWaveNode,
 } from "zwave-js";
+import { UserCredentialType, UserIDStatus } from "@zwave-js/cc";
 import {
   CommandClasses,
   ConfigurationMetadata,
@@ -12,7 +17,10 @@ import { NodeNotFoundError, UnknownCommandError } from "../error.js";
 import { Client } from "../server.js";
 import { dumpConfigurationMetadata, dumpMetadata, dumpNode } from "../state.js";
 import { NodeCommand } from "./command.js";
-import { IncomingMessageNode } from "./incoming_message.js";
+import {
+  IncomingCommandNodeSetValue,
+  IncomingMessageNode,
+} from "./incoming_message.js";
 import { NodeResultTypes } from "./outgoing_message.js";
 import {
   firmwareUpdateOutgoingMessage,
@@ -42,11 +50,20 @@ export class NodeMessageHandler implements MessageHandler {
 
     switch (message.command) {
       case NodeCommand.setValue: {
-        const result = await node.setValue(
-          message.valueId,
-          message.value,
-          message.options,
-        );
+        // zwave-js removed `setValue` support for User Code CC user codes,
+        // so route them through the access control API to keep legacy
+        // clients working
+        let result =
+          message.valueId.commandClass === CommandClasses["User Code"]
+            ? await trySetUserCodeValue(node, message)
+            : undefined;
+        if (result === undefined) {
+          result = await node.setValue(
+            message.valueId,
+            message.value,
+            message.options,
+          );
+        }
         return setValueOutgoingMessage(result, this.client.schemaVersion);
       }
       case NodeCommand.refreshInfo: {
@@ -368,5 +385,95 @@ export class NodeMessageHandler implements MessageHandler {
         throw new UnknownCommandError(command);
       }
     }
+  }
+}
+
+/**
+ * Handles a legacy User Code CC `setValue` call via the unified access
+ * control API on a best-effort basis. Returns `undefined` when the value
+ * cannot be routed, in which case the caller should fall back to
+ * `node.setValue`.
+ */
+async function trySetUserCodeValue(
+  node: ZWaveNode,
+  message: IncomingCommandNodeSetValue,
+): Promise<SetValueResult | undefined> {
+  const { endpoint: endpointIndex, property, propertyKey } = message.valueId;
+  const isClear =
+    property === "userIdStatus" && message.value === UserIDStatus.Available;
+  const isSet = property === "userCode" && typeof message.value === "string";
+  if ((!isClear && !isSet) || typeof propertyKey !== "number") {
+    return undefined;
+  }
+
+  const accessControl = node.getEndpoint(endpointIndex ?? 0)?.accessControl;
+  if (accessControl === undefined) {
+    return undefined;
+  }
+
+  // User Code CC devices support exactly one credential type: Password
+  // instead of PINCode when the device allows non-PIN characters
+  const { supportedCredentialTypes } =
+    accessControl.getCredentialCapabilitiesCached();
+  const credentialType = [
+    UserCredentialType.PINCode,
+    UserCredentialType.Password,
+  ].find((type) => supportedCredentialTypes.has(type));
+  if (credentialType === undefined) {
+    return undefined;
+  }
+
+  // For User Code CC devices the credential slot mirrors the user ID
+  return convertSetCredentialResultToSetValueResult(
+    isClear
+      ? await accessControl.deleteCredential(credentialType, propertyKey)
+      : await accessControl.setCredential(
+          propertyKey,
+          credentialType,
+          propertyKey,
+          message.value as string,
+        ),
+  );
+}
+
+function convertSetCredentialResultToSetValueResult(
+  result: SetCredentialResult,
+): SetValueResult {
+  switch (result) {
+    case SetCredentialResult.OK:
+      return { status: SetValueStatus.Success };
+    case SetCredentialResult.Error_AddRejectedLocationOccupied:
+      return {
+        status: SetValueStatus.InvalidValue,
+        message: "The credential slot is already occupied",
+      };
+    case SetCredentialResult.Error_ModifyRejectedLocationEmpty:
+      return {
+        status: SetValueStatus.InvalidValue,
+        message: "The credential slot is empty",
+      };
+    case SetCredentialResult.Error_DuplicateCredential:
+      return {
+        status: SetValueStatus.InvalidValue,
+        message: "A credential with this value already exists",
+      };
+    case SetCredentialResult.Error_ManufacturerSecurityRules:
+      return {
+        status: SetValueStatus.InvalidValue,
+        message: "The credential violates manufacturer security rules",
+      };
+    case SetCredentialResult.Error_DuplicateAdminPINCode:
+      return {
+        status: SetValueStatus.InvalidValue,
+        message: "The credential duplicates the admin PIN code",
+      };
+    case SetCredentialResult.Error_WrongUserUniqueIdentifier:
+      return {
+        status: SetValueStatus.InvalidValue,
+        message: "The user unique identifier is invalid",
+      };
+    case SetCredentialResult.Error_Unknown:
+    default:
+      return { status: SetValueStatus.Fail };
   }
 }

--- a/src/lib/node/message_handler.ts
+++ b/src/lib/node/message_handler.ts
@@ -489,6 +489,18 @@ async function trySetUserCodeValue(
   if (typeof value !== "string" && !(value instanceof Uint8Array)) {
     return undefined;
   }
+  // Setting a code on an unoccupied slot must create the user together with
+  // the credential
+  if (accessControl.getUserCached(propertyKey) === undefined) {
+    const result = await accessControl.addUser(
+      propertyKey,
+      {},
+      { type: credentialType, slot: propertyKey, data: value },
+    );
+    return result.credential !== undefined
+      ? convertSetCredentialResultToSetValueResult(result.credential)
+      : convertSetUserResultToSetValueResult(result.user);
+  }
   return convertSetCredentialResultToSetValueResult(
     await accessControl.setCredential(
       propertyKey,

--- a/src/lib/node/message_handler.ts
+++ b/src/lib/node/message_handler.ts
@@ -3,11 +3,17 @@ import {
   LifelineHealthCheckResult,
   RouteHealthCheckResult,
   SetCredentialResult,
+  SetUserResult,
   SetValueResult,
   SetValueStatus,
+  supervisionResultToSetValueResult,
   ZWaveNode,
 } from "zwave-js";
-import { UserCredentialType, UserIDStatus } from "@zwave-js/cc";
+import {
+  UserCredentialType,
+  UserCredentialUserType,
+  UserIDStatus,
+} from "@zwave-js/cc";
 import {
   CommandClasses,
   ConfigurationMetadata,
@@ -399,15 +405,56 @@ async function trySetUserCodeValue(
   message: IncomingCommandNodeSetValue,
 ): Promise<SetValueResult | undefined> {
   const { endpoint: endpointIndex, property, propertyKey } = message.valueId;
-  const isClear =
-    property === "userIdStatus" && message.value === UserIDStatus.Available;
-  const isSet = property === "userCode" && typeof message.value === "string";
-  if ((!isClear && !isSet) || typeof propertyKey !== "number") {
+  const { value } = message;
+  const accessControl = node.getEndpoint(endpointIndex ?? 0)?.accessControl;
+  if (accessControl === undefined) {
     return undefined;
   }
 
-  const accessControl = node.getEndpoint(endpointIndex ?? 0)?.accessControl;
-  if (accessControl === undefined) {
+  // Support devices that were interviewed before the rename to adminCode
+  if (property === "adminCode" || property === "masterCode") {
+    if (typeof value !== "string") {
+      return undefined;
+    }
+    return supervisionResultToSetValueResult(
+      await accessControl.setAdminCode(value),
+    );
+  }
+
+  if (
+    (property !== "userIdStatus" && property !== "userCode") ||
+    typeof propertyKey !== "number"
+  ) {
+    return undefined;
+  }
+
+  if (property === "userIdStatus" && value !== UserIDStatus.Available) {
+    switch (value) {
+      case UserIDStatus.Enabled:
+        return convertSetUserResultToSetValueResult(
+          await accessControl.setUser(propertyKey, { active: true }),
+        );
+      case UserIDStatus.Disabled:
+        return convertSetUserResultToSetValueResult(
+          await accessControl.setUser(propertyKey, { active: false }),
+        );
+      case UserIDStatus.Messaging:
+        return convertSetUserResultToSetValueResult(
+          await accessControl.setUser(propertyKey, {
+            active: true,
+            userType: UserCredentialUserType.NonAccess,
+          }),
+        );
+      default:
+        // Other statuses (e.g. PassageMode) have no access control equivalent
+        return undefined;
+    }
+  }
+
+  // Setting a user code or clearing one (userIdStatus = Available) maps to
+  // the user's single credential
+  const isClear = property === "userIdStatus";
+  if (!isClear && typeof value !== "string") {
     return undefined;
   }
 
@@ -431,9 +478,31 @@ async function trySetUserCodeValue(
           propertyKey,
           credentialType,
           propertyKey,
-          message.value as string,
+          value as string,
         ),
   );
+}
+
+function convertSetUserResultToSetValueResult(
+  result: SetUserResult,
+): SetValueResult {
+  switch (result) {
+    case SetUserResult.OK:
+      return { status: SetValueStatus.Success };
+    case SetUserResult.Error_AddRejectedLocationOccupied:
+      return {
+        status: SetValueStatus.InvalidValue,
+        message: "The user slot is already occupied",
+      };
+    case SetUserResult.Error_ModifyRejectedLocationEmpty:
+      return {
+        status: SetValueStatus.InvalidValue,
+        message: "The user slot is empty",
+      };
+    case SetUserResult.Error_Unknown:
+    default:
+      return { status: SetValueStatus.Fail };
+  }
 }
 
 function convertSetCredentialResultToSetValueResult(

--- a/src/lib/node/message_handler.ts
+++ b/src/lib/node/message_handler.ts
@@ -18,6 +18,8 @@ import {
   CommandClasses,
   ConfigurationMetadata,
   Firmware,
+  ZWaveError,
+  ZWaveErrorCodes,
 } from "@zwave-js/core";
 import { NodeNotFoundError, UnknownCommandError } from "../error.js";
 import { Client } from "../server.js";
@@ -429,35 +431,43 @@ async function trySetUserCodeValue(
   }
 
   if (property === "userIdStatus" && value !== UserIDStatus.Available) {
-    switch (value) {
-      case UserIDStatus.Enabled:
-        return convertSetUserResultToSetValueResult(
-          await accessControl.setUser(propertyKey, { active: true }),
-        );
-      case UserIDStatus.Disabled:
-        return convertSetUserResultToSetValueResult(
-          await accessControl.setUser(propertyKey, { active: false }),
-        );
-      case UserIDStatus.Messaging:
-        return convertSetUserResultToSetValueResult(
-          await accessControl.setUser(propertyKey, {
-            active: true,
-            userType: UserCredentialUserType.NonAccess,
-          }),
-        );
-      default:
-        // Other statuses (e.g. PassageMode) have no access control equivalent
-        return undefined;
+    try {
+      switch (value) {
+        case UserIDStatus.Enabled:
+          return convertSetUserResultToSetValueResult(
+            await accessControl.setUser(propertyKey, { active: true }),
+          );
+        case UserIDStatus.Disabled:
+          return convertSetUserResultToSetValueResult(
+            await accessControl.setUser(propertyKey, { active: false }),
+          );
+        case UserIDStatus.Messaging:
+          return convertSetUserResultToSetValueResult(
+            await accessControl.setUser(propertyKey, {
+              active: true,
+              userType: UserCredentialUserType.NonAccess,
+            }),
+          );
+        default:
+          // Other statuses (e.g. PassageMode) have no access control equivalent
+          return undefined;
+      }
+    } catch (error) {
+      // User Code CC devices reject status changes on empty slots because
+      // users and codes must be stored together. Legacy clients expect a
+      // SetValueResult rather than an error response.
+      if (
+        error instanceof ZWaveError &&
+        error.code === ZWaveErrorCodes.Argument_Invalid
+      ) {
+        return { status: SetValueStatus.InvalidValue, message: error.message };
+      }
+      throw error;
     }
   }
 
   // Setting a user code or clearing one (userIdStatus = Available) maps to
-  // the user's single credential
-  const isClear = property === "userIdStatus";
-  if (!isClear && typeof value !== "string") {
-    return undefined;
-  }
-
+  // the user's single credential.
   // User Code CC devices support exactly one credential type: Password
   // instead of PINCode when the device allows non-PIN characters
   const { supportedCredentialTypes } =
@@ -471,15 +481,21 @@ async function trySetUserCodeValue(
   }
 
   // For User Code CC devices the credential slot mirrors the user ID
+  if (property === "userIdStatus") {
+    return convertSetCredentialResultToSetValueResult(
+      await accessControl.deleteCredential(credentialType, propertyKey),
+    );
+  }
+  if (typeof value !== "string" && !(value instanceof Uint8Array)) {
+    return undefined;
+  }
   return convertSetCredentialResultToSetValueResult(
-    isClear
-      ? await accessControl.deleteCredential(credentialType, propertyKey)
-      : await accessControl.setCredential(
-          propertyKey,
-          credentialType,
-          propertyKey,
-          value as string,
-        ),
+    await accessControl.setCredential(
+      propertyKey,
+      credentialType,
+      propertyKey,
+      value,
+    ),
   );
 }
 


### PR DESCRIPTION
## Summary

zwave-js ([zwave-js/zwave-js#8930](https://github.com/zwave-js/zwave-js/pull/8930), targeting `next`) made the unified Access Control API the source of truth for User Code CC: the `userCode`/`userIdStatus`/`adminCode` values became internal and their `setValue`/`pollValue` support was removed. Clients that manage user codes via the `node.set_value` path (e.g. existing Home Assistant installs) would silently break once the server ships a driver containing that change.

This PR routes those legacy `setValue` calls through the access control API on a best-effort basis, covering every path the old `UserCodeCC` SET_VALUE implementation supported:

| Legacy `setValue` call | Routed to |
| --- | --- |
| `userCode` (string) | `accessControl.setCredential(...)` |
| `userIdStatus` = `Available` | `accessControl.deleteCredential(...)` |
| `userIdStatus` = `Enabled` | `accessControl.setUser(userId, { active: true })` |
| `userIdStatus` = `Disabled` | `accessControl.setUser(userId, { active: false })` |
| `userIdStatus` = `Messaging` | `accessControl.setUser(userId, { active: true, userType: NonAccess })` |
| `adminCode` / `masterCode` (string) | `accessControl.setAdminCode(...)` |

Not routed: `keypadMode` still works through `setValue` upstream, and `userIdStatus` = `PassageMode` has no access control equivalent (documented as no longer supported).

Implementation notes:

- The credential type is derived from `getCredentialCapabilitiesCached()` (PIN code, or Password for locks that allow non-PIN characters) rather than hardcoded
- The endpoint is resolved from `valueId.endpoint`, and anything unroutable (other properties/values, non-numeric propertyKey, unsupported endpoint/type) falls back to `node.setValue` unchanged
- Results are converted back to `SetValueResult` (`SetCredentialResult`/`SetUserResult` via local converters, `setAdminCode`'s supervision result via `supervisionResultToSetValueResult`) so the response shape is unchanged for callers

The routing intentionally applies to **all** schema versions: the clients that need it are the ones that have not adopted the access control API, and the legacy behavior it would otherwise preserve no longer exists in zwave-js. Schema 51 documents the behavior change; clients targeting schema 51+ should use the `endpoint.access_control` commands directly.

## Changes

- `src/lib/node/message_handler.ts`: `trySetUserCodeValue()` shim + result converters
- `src/lib/const.ts`: `maxSchemaVersion` 50 → 51
- `API_SCHEMA.md`: Schema 51 entry

## Testing

- `prettier --check`, `tsc --noEmit`, and `eslint` pass
- `tsx src/test/integration.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)