### PR TITLE
ci: test across Node 22 and 24 in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [22, 24]
+
     steps:
       - uses: actions/checkout@v7
-      - name: Use Node.js 24
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ matrix.node-version }}
           cache: "npm"
       - run: npm ci
       - run: npm test


### PR DESCRIPTION
## Summary
- `ci.yml` claimed to test "across different versions of node" but only ran a single pinned Node 24 job. Expanded it to a `[22, 24]` matrix so it matches that claim and drops Node 20 (EOL April 2026) from consideration.
- `npmpublish.yml` was reviewed but left untouched — it already uses `actions/checkout@v7`, `actions/setup-node@v6`, Node 24, OIDC trusted publishing, and dist-tag detection via `actions/github-script`, so there was nothing outdated to change. Its `release: published` trigger (drafted by release-drafter, then manually published) is intentionally kept as-is.
- `release-drafter.yml` was left untouched per instructions.

This aligns `ci.yml` with the Node-version matrix pattern already rolled out in AlCalzone/jsonl-db, zwave-js/waddle and AlCalzone/node-coap-client.