### PR TITLE
Refuse new clients while the driver is not ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ All these options can be combined.
 
 ## API
 
-When a client connects, the server will send the version.
+When a client connects, the server will send the version. While the driver is not ready, for example
+because the controller is being re-interviewed after a hard reset, an NVM restore or a firmware
+update, the server instead closes the connection with code `1013` (Try Again Later), and the client
+should retry.
 
 ```ts
 interface {

--- a/README.md
+++ b/README.md
@@ -64,10 +64,7 @@ All these options can be combined.
 
 ## API
 
-When a client connects, the server will send the version. While the driver is not ready, for example
-because the controller is being re-interviewed after a hard reset, an NVM restore or a firmware
-update, the server instead closes the connection with code `1013` (Try Again Later), and the client
-should retry.
+When a client connects, the server will send the version. While the driver is not ready, the server instead closes the connection with code `1013` (Try Again Later), and the client should retry.
 
 ```ts
 interface {

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -374,6 +374,23 @@ export class ClientsController extends EventEmitter {
   }
 
   addSocket(socket: WebSocket) {
+    // Attach this first so that closing the socket below can never emit an
+    // unhandled error event.
+    socket.on("error", (error) => {
+      this.logger.error("Client socket error", error);
+    });
+
+    if (!this.driver.ready) {
+      // The controller is destroyed and re-interviewed in place around e.g. a
+      // hard reset, an NVM restore and a firmware update. Until that completes
+      // the driver cannot serve this client, and sendVersion() below would
+      // either omit the home ID or throw, because driver.controller throws
+      // while the controller is gone. Refuse it, like start() already does.
+      this.logger.info("Rejecting new client, driver is not ready");
+      socket.close(1013, "Driver is not ready");
+      return;
+    }
+
     this.logger.debug("New client");
     const client = new Client(
       socket,
@@ -382,9 +399,6 @@ export class ClientsController extends EventEmitter {
       this.logger,
       this.remoteController,
     );
-    socket.on("error", (error) => {
-      this.logger.error("Client socket error", error);
-    });
     socket.on("close", (code, reason) => {
       this.logger.info("Client disconnected");
       this.logger.debug(`Code ${code}: ${reason}`);

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -381,11 +381,9 @@ export class ClientsController extends EventEmitter {
     });
 
     if (!this.driver.ready) {
-      // The controller is destroyed and re-interviewed in place around e.g. a
-      // hard reset, an NVM restore and a firmware update. Until that completes
-      // the driver cannot serve this client, and sendVersion() below would
-      // either omit the home ID or throw, because driver.controller throws
-      // while the controller is gone. Refuse it, like start() already does.
+      // sendVersion() below reads driver.controller, which omits the home ID
+      // or throws while the controller is gone. start() gates on driver.ready
+      // too, but only once, at startup.
       this.logger.info("Rejecting new client, driver is not ready");
       socket.close(1013, "Driver is not ready");
       return;

--- a/src/test/integration.ts
+++ b/src/test/integration.ts
@@ -216,6 +216,31 @@ const runTest = async () => {
 
     assert.deepEqual(driver.getLogConfig().transports, [customTransport]);
 
+    // A client that connects while the driver is not ready is refused, because
+    // the version message we send on connect needs the home ID.
+    const mockDriver = driver as unknown as { ready: boolean };
+    mockDriver.ready = false;
+    const rejectedSocket = new ws(`ws://localhost:${PORT}`);
+    try {
+      const rejectedMessages: unknown[] = [];
+      rejectedSocket.on("message", (data: string) =>
+        rejectedMessages.push(JSON.parse(data)),
+      );
+      const closeCode = await new Promise<number>((resolve, reject) => {
+        rejectedSocket.once("close", resolve);
+        rejectedSocket.once("error", reject);
+        setTimeout(
+          () => reject(new Error("Client was not refused within 5 seconds")),
+          5000,
+        ).unref();
+      });
+      assert.equal(closeCode, 1013);
+      assert.deepEqual(rejectedMessages, []);
+    } finally {
+      rejectedSocket.close();
+      mockDriver.ready = true;
+    }
+
     console.log("Integration tests passed :)");
   } finally {
     if (socket) {


### PR DESCRIPTION
## Proposed change

Follow-up to the discussion in home-assistant/core#179525: refuse new clients while the driver is not ready, as suggested.

### Detailed information

A client that connects while the driver is not ready can get a broken response, and in part of that window it takes the server down with it. `addSocket()` calls `client.sendVersion()` synchronously for every new socket, and the version message is built by `getVersionData()` from `driver.controller.homeId`. The driver destroys and re-creates its controller in place around a hard reset, a `softResetAndRestart()` (which an NVM restore and a 500 series OTW firmware update both go through) and a bootloader entry/exit, giving two failure modes:

- While `_controller` is `undefined`, the `driver.controller` getter **throws** `The controller is not yet ready!`. `sendVersion()` runs inside the ws `connection` handler, so that throw is an uncaught exception and the server process exits.
- Once `initializeControllerAndNodes()` has assigned the new `ZWaveController` but `identify()` has not populated `_homeId` yet, `homeId` is `undefined`, the `!` does not hold, and `JSON.stringify` drops the key, so the client gets a version message with no `homeId`.

`start()` already refuses to run before the driver is ready. This applies the same gate when a client connects and closes the socket with `1013 Try Again Later`, which a client should treat as "retry". The error listener is attached before the gate, so closing the socket cannot emit an unhandled `'error'` event on a listenerless socket.

This deliberately gates on `driver.ready` alone. The known hole is the unexpected bootloader reboot, which currently drops the controller without `driver.ready` becoming false — being fixed driver-side in node-zwave-js instead, per the issue discussion.

<details><summary>Notes on scope and docs</summary>
<p>

The gate is slightly wider than the broken responses: `identify()` populates the home ID part-way through `initializeControllerAndNodes()`, while `_controllerInterviewed` is only set at the end, so clients are also refused in the tail of a re-interview where the version message would already be complete. The controller is still being interviewed there, so refusing seems like the right side to err on, and it keeps the gate identical to `start()`. And since `homeId` is declared optional (`homeId?: number` and the README's `number | undefined`), an omitted home ID is formally contract-legal today — the refusal just spares clients from having to handle it in practice.

The README now documents the refusal, since it previously promised only that a connecting client gets a version message. No `API_SCHEMA.md` entry seemed warranted, since no message shape changes — happy to add one if you disagree.

</p>
</details>

Downstream, home-assistant/core#179525 hit the missing-key half of this as `KeyError: 'homeId'` out of `zwave-js-server-python` while setting up the Z-Wave integration; a companion PR against that library makes it fail cleanly instead of with a bare `KeyError`.

## Testing

`src/test/integration.ts` gained a case that flips the mock driver to not ready, connects, and asserts the client is closed with 1013 having received no message first. Against the unpatched server it fails on its 5 second bound.