### PR TITLE
docs: add AI contribution policy

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,41 @@
+# AI Policy
+
+We support using AI tools, including large language models, when contributing to Z-Wave JS projects. However, you are responsible for any contributions you submit, and the maintainers are responsible for any contributions they merge and release. We hold a high bar for all contributions to our projects.
+
+Our maintainers dedicate their time and expertise to reviewing contributions. Submitting AI-generated content that you have not personally reviewed and understood wastes that time and will not be accepted.
+
+## Autonomous agents
+
+**We do not allow autonomous agents to contribute to our projects.** We will close any pull requests or issues that we believe were created autonomously, and we may mark automated comments as spam. This includes contributions that bypass the provided issue or pull request templates.
+
+## Communication on issues, pull requests, and code reviews
+
+You may use AI tools to help you write. However, do not have tools post unreviewed content on your behalf. Keep responses to the minimum needed to communicate your intent. We may hide any comments that we believe are unreviewed AI output.
+
+If you open a pull request, we expect you to explain the proposed changes in your own words. This includes the pull request description and responses to questions. If you use AI to help generate the pull request summary, you must review it for technical accuracy.
+
+**Do not use AI to generate answers to questions from maintainers.** You must understand and be able to explain your own work. Using AI to improve grammar or clarity is fine, but the substance of your responses must be your own.
+
+If you include context from an interaction with AI in your comments, put it in a quote block using `>` and disclose its source. Add your own commentary to explain its relevance and implications. Do not share long excerpts.
+
+## Non-native English speakers
+
+We understand that AI is useful when communicating in a language that is not your first language. You may use AI to improve the grammar or clarity of text you wrote yourself. If you use AI to translate your comments, ensure the translation accurately reflects your intent. Including your original text in a details block shows the effort behind your contribution, helps maintainers verify the translation if needed, and keeps the conversation readable.
+
+## Code and documentation contributions
+
+AI can be a helpful tool for writing code and documentation. However, Z-Wave JS projects require a human in the loop who understands the work produced by AI.
+
+You must review and understand every contribution before submitting it. You must be able to explain every code and documentation change in a pull request you submit. We will close pull requests that appear to contain unreviewed AI output without review.
+
+## Our use of AI
+
+Some Z-Wave JS projects use AI tools to assist with code reviews, issue triage, reporting, and other project management tasks. These tools may leave comments on pull requests or issues. Like any automated tooling, these tools can be wrong.
+
+Treat a comment from an AI tool like any other review comment. If you believe it is incorrect, say so. A brief explanation is sufficient. Maintainers always have the final say. Ask a maintainer if you are unsure.
+
+## Enforcement
+
+We will close contributions that do not follow this policy. Repeated violations may result in contributors being blocked from Z-Wave JS projects. If you believe we closed your contribution in error, contact a maintainer to discuss it.
+
+This policy is adapted from the [Home Assistant and Open Home Foundation AI policy](https://developers.home-assistant.io/docs/ai_policy).

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 Small server wrapper around Z-Wave JS to access it via a WebSocket.
 
-## Contributing
-
-AI assistance is welcome when contributors personally review, understand, and can explain every change. Autonomous contributions and unreviewed AI-generated communication are prohibited. Read the full [Z-Wave JS AI policy](./AI_POLICY.md) before contributing.
-
 ## Trying it out
 
 These instructions are for development only. These CLIs will be available as `zwave-server` and `zwave-client` after installing the [NPM package](https://www.npmjs.com/package/@zwave-js/server).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Small server wrapper around Z-Wave JS to access it via a WebSocket.
 
+## Contributing
+
+AI assistance is welcome when contributors personally review, understand, and can explain every change. Autonomous contributions and unreviewed AI-generated communication are prohibited. Read the full [Z-Wave JS AI policy](./AI_POLICY.md) before contributing.
+
 ## Trying it out
 
 These instructions are for development only. These CLIs will be available as `zwave-server` and `zwave-client` after installing the [NPM package](https://www.npmjs.com/package/@zwave-js/server).


### PR DESCRIPTION
## Summary

- adapt the Home Assistant and Open Home Foundation AI policy for Z-Wave JS
- document the requirements for human review, understanding, communication, and enforcement
- link the policy from the README contributor section
- credit the source policy